### PR TITLE
compile: make --type optional, raise the timeout default, and document what actually loads your code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- `compile --type` is now **optional**. NinjaTrader's compiler always builds the whole tree (the
+  AddOn never read `typeName`), so requiring the flag forced every caller — especially scripted and
+  agent-driven ones — to invent a meaningless argument, and a bare `compile` exited 2. Still
+  accepted, and documented as ignored.
+- `compile --timeout` default raised **30s → 120s**. A real tree compiles slower than 30s, so the
+  old default reported `{"status":"timeout"}` for a perfectly healthy compile that NinjaTrader was
+  still running.
+- A `compile` timeout now carries a `hint` distinguishing "NinjaTrader is still compiling" from
+  "the AddOn isn't loaded", instead of leaving the caller to guess which failure it hit.
+
+### Documentation
+
+- New README section **"What actually loads your code"**: `compile` validates only
+  (`checkCompileOnly=true` ⇒ `assemblyReloaded` is always `false`), but writing a `.cs` into
+  `bin\Custom` while NinjaTrader is running makes NinjaTrader recompile and **hot-reload the
+  assembly on its own** — so `deploy` is not an inert file copy (measured: DLL rebuilt ~19s after
+  the write, on 8.1.7.2). Documents the two consequences: the reload happens underneath whatever is
+  running, and it does **not** close already-open AddOn windows — the old window keeps executing the
+  old assembly while the new assembly's statics start empty, so an AddOn that auto-opens a window
+  can stack a second instance on a live one. Neither statics nor `Type` identity can detect that;
+  the interlock has to live in an artifact that crosses the reload boundary. Bars types are the
+  exception (sticky instance — still need F5 + a chart reload).
+
 ## [1.1.1] - 2026-07-19
 
 ### Fixed / Added

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ With the AddOn loaded (above) and NinjaTrader running:
 ```bash
 python -m nt8bridge doctor                         # preconditions OK?
 python -m nt8bridge deploy --strategy MyStrategy.cs # copy your strategy into bin/Custom
-python -m nt8bridge compile --type MyStrategy       # compile INSIDE NT8 -> real errors as JSON
+python -m nt8bridge compile                         # compile INSIDE NT8 -> real errors as JSON
 # ...fix any errors, redeploy, recompile until clean...
 python -m nt8bridge backtest --config config/config.json --pdf report.pdf
 ```
@@ -120,6 +120,21 @@ Triggers a compile inside NinjaTrader via the AddOn and returns NinjaTrader's ow
 ```json
 { "ok": false, "errors": [ { "file": "MyStrategy.cs", "line": 42, "code": "CS0103", "message": "…" } ] }
 ```
+
+`--type` is accepted but ignored — NinjaTrader's compiler always builds the **whole tree**, exactly as F5 does, so there is nothing to scope. `compile` on its own is enough.
+
+**`compile` validates; it does not load.** The AddOn calls NinjaTrader's compiler with `checkCompileOnly=true`, so `assemblyReloaded` is always `false` — your code is *proved correct*, but the running NinjaTrader is still executing the previously loaded assembly. See below for what does load it.
+
+### What actually loads your code
+
+Writing a `.cs` into `bin\Custom` **while NinjaTrader is running** makes NinjaTrader recompile and hot-reload the assembly by itself — no F5, nobody at the GUI. Measured on NinjaTrader 8.1.7.2: `NinjaTrader.Custom.dll` was rebuilt ~19 s after the file landed, and the new code was live. (Measured for an overwrite in place; `deploy` writes a temp file and renames it over the destination, which is expected to behave the same but was not separately verified.)
+
+That is useful — it is the missing "load" step, and it works headlessly — but it has two teeth worth knowing before you script it:
+
+- **It reloads the assembly underneath whatever is running.** A code sync during a live session restarts strategies and indicators mid-flight. Deploy deliberately, not casually.
+- **The reload does *not* close already-open AddOn windows.** A `NTWindow` you opened survives, still executing the *old* assembly's code, while the new assembly's statics start empty. So an AddOn that opens a window on load can stack a second instance on top of a live one, and neither statics nor `Type` identity can detect it (both reset across the reload). If your AddOn auto-opens anything, interlock it on an artifact that crosses the reload boundary — a file, or a timestamped line in your own log — and test the interlock by deploying while the window is open.
+
+A **bars type** is the exception: its instance is sticky on a chart, so new bars-type code needs an Editor F5 *and* a chart reload.
 
 ### backtest
 
@@ -245,7 +260,7 @@ The AddOn writes a heartbeat from NinjaTrader's main UI thread each second. The 
 
 ```bash
 python -m nt8bridge deploy --strategy MyStrategy.cs
-python -m nt8bridge compile --type MyStrategy              # fix errors until: {"ok": true, "errors": []}
+python -m nt8bridge compile                               # fix errors until: {"ok": true, "errors": []}
 python -m nt8bridge configure --config config/config.json  # set instrument/dates/bar-type on the SA tab
 python -m nt8bridge backtest  --config config/config.json --pdf report.pdf
 python -m nt8bridge peek                                   # re-read the result + confirm params injected

--- a/nt8bridge/cli.py
+++ b/nt8bridge/cli.py
@@ -41,7 +41,7 @@ Commands:
   python -m nt8bridge doctor                 check preconditions
   python -m nt8bridge precheck --strategy X.cs   offline compile (no NT8)
   python -m nt8bridge deploy   --strategy X.cs   atomic cp into bin/Custom
-  python -m nt8bridge compile  --type MyStrategy in-process compile (needs AddOn)
+  python -m nt8bridge compile                    in-process compile (needs AddOn)
   python -m nt8bridge backtest --config c.json   auto backtest in NT8 (--pdf for report)
   python -m nt8bridge batch    --batch b.json    run N param-sets -> combined report (--pdf)
   python -m nt8bridge sweep    --config c.json --instruments 'MNQ 09-26,MES 09-26' --bars 'Minute:1,Minute:5'  backtest matrix (--pdf)
@@ -132,7 +132,19 @@ def _compile(type_name: str, timeout: float) -> int:
     except TimeoutError as e:
         print(
             json.dumps(
-                {"command": "compile", "status": "timeout", "ok": False, "message": str(e)},
+                {
+                    "command": "compile",
+                    "status": "timeout",
+                    "ok": False,
+                    "message": str(e),
+                    # A timeout is NOT proof of a broken bridge: NinjaTrader may still be
+                    # compiling. Say so, so a caller does not read it as a failed compile.
+                    "hint": (
+                        "no result within the timeout -- NinjaTrader may still be compiling "
+                        "a large tree. Run `doctor` to tell 'AddOn not loaded' apart from "
+                        "'slow compile', or retry with a longer --timeout."
+                    ),
+                },
                 indent=2,
             )
         )
@@ -513,8 +525,16 @@ def main(argv: list[str]) -> int:
     p_dep.add_argument("--strategy", required=True)
     p_dep.add_argument("--kind", default="strategy")
     p_com = sub.add_parser("compile")
-    p_com.add_argument("--type", required=True)
-    p_com.add_argument("--timeout", type=float, default=30.0)
+    # NT's compiler always builds the WHOLE tree (same as F5), so there is nothing
+    # for --type to scope; the AddOn never reads it. Kept accepted for back-compat.
+    p_com.add_argument(
+        "--type",
+        default="",
+        help="accepted for back-compat and ignored — NT compiles the whole tree",
+    )
+    # A real tree can take well over 30s to compile; the old default turned a healthy
+    # compile into a spurious "timeout".
+    p_com.add_argument("--timeout", type=float, default=120.0)
     p_bt = sub.add_parser("backtest")
     p_bt.add_argument("--config", required=True)
     p_bt.add_argument("--timeout", type=float, default=120.0)

--- a/nt8bridge/compile.py
+++ b/nt8bridge/compile.py
@@ -37,11 +37,15 @@ def parse_compile_response(payload: dict) -> CompileResult:
     )
 
 
-def run_compile(type_name: str, timeout: float = 30.0) -> CompileResult:
+def run_compile(type_name: str = "", timeout: float = 120.0) -> CompileResult:
     """Drop a compile request for the in-NT8 AddOn and wait for its result.
 
+    `type_name` is accepted for back-compat and ignored: NinjaTrader's compiler
+    always builds the whole tree (exactly as F5 does), so there is nothing to scope.
+
     Raises TimeoutError if the AddOn does not respond within `timeout` (NT8 not
-    running, AddOn not compiled, or NT8 hung).
+    running, AddOn not compiled, NT8 hung -- or simply a tree that compiles slower
+    than the timeout, in which case NT is still working and a retry will succeed).
     """
     trigger, result = ntio.ensure_bridge_dirs()
     request_id = new_request_id()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,8 +96,28 @@ def test_compile_subcommand_ok(monkeypatch, capsys):
     assert payload["ok"] is True
 
 
+def test_compile_subcommand_without_type(monkeypatch, capsys):
+    """NT compiles the whole tree, so --type is optional (and ignored)."""
+    from nt8bridge.compile import CompileResult
+
+    seen = {}
+
+    def fake(type_name, timeout=120.0):
+        seen["type_name"] = type_name
+        seen["timeout"] = timeout
+        return CompileResult(ok=True)
+
+    monkeypatch.setattr(cli.ntcompile, "run_compile", fake)
+    rc = cli.main(["compile"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["ok"] is True
+    assert seen["type_name"] == ""
+    assert seen["timeout"] == 120.0  # a real tree needs more than the old 30s
+
+
 def test_compile_subcommand_timeout(monkeypatch, capsys):
-    def boom(t, timeout=30.0):
+    def boom(t, timeout=120.0):
         raise TimeoutError("no result from AddOn")
 
     monkeypatch.setattr(cli.ntcompile, "run_compile", boom)
@@ -105,6 +125,7 @@ def test_compile_subcommand_timeout(monkeypatch, capsys):
     payload = json.loads(capsys.readouterr().out)
     assert rc == 1
     assert payload["status"] == "timeout"
+    assert "hint" in payload  # a timeout must not read as "your code is broken"
 
 
 def test_batch_subcommand_ok(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
Two small contributions out of about a week of driving the bridge headlessly against a large NinjaScript tree (~600 files, NinjaTrader 8.1.7.2, Python 3.12). Both came from using it rather than reading it. Happy to split into separate PRs if you'd rather review them apart.

### 1. `compile --type` is required but never read

`typeName` does not appear anywhere in `NT8BridgeServer.cs` — `RunCompile(id)` never receives it, and calls `Compiler.Compile(checkCompileOnly: true, false, [], [])`, which builds the whole tree exactly as F5 does. So the flag is mandatory but inert: every scripted or agent-driven caller has to invent a type name to satisfy it, and a bare `compile` exits 2.

This makes it optional. Still accepted, now documented as ignored. No change to the AddOn or the wire contract.

### 2. `compile --timeout` default 30s → 120s

A real tree compiles slower than 30s. Same box, same code: `{"status": "timeout"}` at 30s, `{"ok": true}` at 120s, with NinjaTrader compiling happily throughout.

A timeout now also carries a `hint`, because "NinjaTrader is still compiling" and "the AddOn isn't loaded" are very different problems, and the old message let the first one read as a failed compile.

### 3. Docs — what actually loads your code

`compile` runs with `checkCompileOnly = true`, so `assemblyReloaded` is always `false`: it validates, it does not load. What *does* load is currently undocumented — writing a `.cs` into `bin\Custom` while NinjaTrader is running makes NinjaTrader recompile and hot-reload the assembly by itself. Measured on 8.1.7.2, twice: `NinjaTrader.Custom.dll` rebuilt ~19s after the file landed, new code live, no F5 and nobody at the GUI.

**One scope caveat, stated because I did not test it:** I measured an **overwrite in place** (`scp` over the existing path). `deploy` writes a temp file and `os.replace()`s it, so the watcher sees a rename rather than a change. I would expect NinjaTrader to react identically, but I have not verified that path, and you are better placed than I am to say. The README wording I added describes the write generally; if you want it narrowed to what is proven, or `deploy` confirmed first, say so and I will adjust.

Two consequences are documented because both cost us real debugging time:

- **The reload happens underneath whatever is running.** A code sync restarted a live replay session mid-job for us.
- **The reload does not close already-open AddOn windows.** The old window keeps executing the *old* assembly while the new assembly's statics start empty — so an AddOn that auto-opens a window can stack a second instance on top of a live one, with two of them driving the same subsystem. Neither statics nor `Type` identity can detect that across the reload. We hit this exactly, and the interlock that works has to live in an artifact that survives the reload (we used a heartbeat line in our own log, plus a process-start check so a dead process's heartbeat cannot false-block a legitimate startup).

Bars types are called out as the exception — the chart's instance is sticky, so those still need an Editor F5 plus a chart reload.

If the reload behaviour reads differently on 8.1.6.x, say the word and I will scope the wording to 8.1.7.x rather than stating it generally.

### Verification

- `pytest`: **169 passed, 5 skipped** (Python 3.12, Windows Server).
- New tests: a bare `compile` succeeds and forwards `type_name=""` / `timeout=120.0`; a timeout response carries `hint`.
- Live: `python -m nt8bridge compile` with no arguments → `{"ok": true, "errors": []}` against a running NinjaTrader 8.1.7.2.

Thanks for building this. It replaced an ugly `_verify.csproj` workaround on our side and is now the compile path for a fairly large private suite.
