### PR TITLE
feat: reload + windows, and make assemblyReloaded truthful (split from #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2026-07-30
+
+### Added
+
+- **`reload` — compile AND load it.** `compile` invokes NinjaTrader's compiler with
+  `checkCompileOnly=true`: it answers "does this build?" and emits nothing, so a brand-new type never
+  appears in the pickers and edited code is not running. Every headless edit loop still ended with a
+  human alt-tabbing to the NinjaScript Editor to press F5 — the one step the bridge exists to remove.
+  `reload` runs the same compiler with `checkCompileOnly=false`, so NinjaTrader emits and swaps the
+  NinjaScript assembly exactly as F5 does. Measured: **27s on a ~560-file tree, `assemblyReloaded: true`.**
+
+  Deliberately a **separate command, not a flag on `compile`**: a reload restarts indicators, can
+  interrupt a running strategy, and orphans bars-type instances (recreated only by an NT process
+  restart). It must never happen as a side effect of validating code.
+
+- **`windows` — inventory NinjaTrader's top-level windows.** Type/title/HWND, visible, minimized,
+  maximized, and screen geometry. Useful for UI and AddOn work, for asserting platform state before
+  driving automation, and for finding windows dragged or thrown off-screen. `--offscreen` filters to
+  the ones that look unreachable.
+
+### Changed
+
+- **`assemblyReloaded` is now truthful.** It was hardcoded `false` in the AddOn's result builder, so a
+  caller could never tell whether its code was live. It is now true only when a non-check build
+  actually succeeded. This is also why `checkCompileOnly=false` looked like it did nothing when tested
+  directly: the Roslyn diagnostics are genuinely identical either way, and the one field that would
+  have shown the assembly swap was hardcoded.
+
+### Notes for implementers
+
+⚠ **NinjaTrader runs each window on its own dispatcher thread.** Measured via this release's own
+`windows` command: **179 windows across 26 distinct UI threads**, with the visible ones spread over
+six. Any cross-window code must use Win32 on the HWND — `w.Left`, `.IsVisible`, `.WindowState`,
+`Mouse.LeftButton` and `Keyboard.Modifiers` all throw `InvalidOperationException` from a central loop.
+
+**`new WindowInteropHelper(w).Handle` throws too** — it reads the Window's thread-affine `HwndSource`,
+so you cannot even obtain the handle off-thread. The first draft of `windows` did exactly that and
+returned a confident `status:"ok", count:0` that looked like NinjaTrader had no windows. `EnumWindows`
+filtered by process id is the correct approach: thread-agnostic, no dispatcher marshalling (which can
+deadlock against a busy window thread), and it also catches windows absent from `Globals.AllWindows`.
+
 ## [1.2.0] - 2026-07-22
 
 ### Changed

--- a/addon/NT8BridgeServer.cs
+++ b/addon/NT8BridgeServer.cs
@@ -18,10 +18,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;   // windows: Win32 window inventory (NT is multi-UI-threaded)
 using System.Text;
 using System.Threading;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Interop;           // windows: WindowInteropHelper -> HWND
 using NinjaTrader.Cbi;
 using NinjaTrader.Core;
 using NinjaTrader.Data;
@@ -137,6 +139,10 @@ namespace NinjaTrader.NinjaScript.AddOns
                 kind = ExtractJsonString(text, "kind");
                 if (kind == "compile")
                     WriteResult("compile_" + id + ".json", RunCompile(id));
+                else if (kind == "reload")
+                    WriteResult("reload_" + id + ".json", RunCompileCore(id, true));
+                else if (kind == "windows")
+                    WriteResult("windows_" + id + ".json", RunWindows(id));
                 else if (kind == "backtest")
                     RunBacktest(id, ParseParams(text));
                 else if (kind == "account")
@@ -197,6 +203,8 @@ namespace NinjaTrader.NinjaScript.AddOns
             if (kind == "performance") return "perf_";
             if (kind == "perfwindow") return "perfwindow_";
             if (kind == "chartseries") return "chartseries_";
+            if (kind == "reload") return "reload_";
+            if (kind == "windows") return "windows_";
             if (kind == "marketReplayDump") return "marketReplayDump_";
             if (kind == "marketReplayDownload") return "marketReplayDownload_";
             return "compile_";
@@ -204,15 +212,143 @@ namespace NinjaTrader.NinjaScript.AddOns
 
         private string RunCompile(string id)
         {
+            return RunCompileCore(id, false);
+        }
+
+        // ── compile vs reload ────────────────────────────────────────────────────────────────────
+        //  `checkCompileOnly` is the ONLY difference, and it is the difference between "does this
+        //  code build" and "is this code now RUNNING".
+        //
+        //    compile  (checkCompileOnly = TRUE)  — validates the tree and emits nothing. Fast, and it
+        //             disturbs nothing: no indicator reloads, no strategy restarts, no chart flicker.
+        //             This is what you want in an edit loop.
+        //    reload   (checkCompileOnly = FALSE) — a real build. NinjaTrader swaps in the new
+        //             NinjaScript assembly exactly as the Editor's F5 does, so new TYPES appear in the
+        //             pickers and existing indicators reload. This is the step that used to require a
+        //             human pressing F5.
+        //
+        //  ⚠ reload is DISRUPTIVE by nature: it restarts indicators and can interrupt a running
+        //  strategy, and on this suite it also orphans bars-type instances (they are NOT recreated by
+        //  a reload or a chart reload — only by an NT restart). Never fire it into a live bake.
+        //  Kept as a SEPARATE command rather than a flag on compile so it can never happen by accident.
+        private string RunCompileCore(string id, bool reload)
+        {
             Type compilerType = Type.GetType("NinjaTrader.Code.Compiler, NinjaTrader.Core");
             if (compilerType == null) throw new Exception("NinjaTrader.Code.Compiler not found");
             MethodInfo compile = compilerType.GetMethod("Compile", BindingFlags.Public | BindingFlags.Static);
             if (compile == null) throw new Exception("Compiler.Compile(...) not found");
 
             var empty = new List<string>();
-            // checkCompileOnly=true, debugBuild=false, filesToIgnore=[], filesInTmp=[]
-            object emit = compile.Invoke(null, new object[] { true, false, empty, empty });
-            return BuildResultJson(id, emit);
+            // checkCompileOnly, debugBuild=false, filesToIgnore=[], filesInTmp=[]
+            object emit = compile.Invoke(null, new object[] { !reload, false, empty, empty });
+
+            // Report the reload HONESTLY: only a non-check build that actually succeeded swapped the
+            // assembly. Previously this field was hardcoded false, which made a real reload
+            // indistinguishable from a check — the caller could never tell whether its code was live.
+            bool ok = EmitSucceeded(emit);
+            return BuildResultJson(id, emit, reload && ok);
+        }
+
+        // ═════════════════════════════════════════════════════════════════════════════════════════
+        //  windows — an inventory of NinjaTrader's top-level windows.
+        //
+        //  ⚠ WIN32 ONLY, AND THIS IS NOT A STYLE CHOICE. NinjaTrader runs EACH WINDOW ON ITS OWN
+        //  DISPATCHER THREAD, so reading `w.Left` / `.ActualWidth` / `.IsVisible` / `.WindowState`
+        //  from this poller thread throws `InvalidOperationException: The calling thread cannot access
+        //  this object because a different thread owns it` — on every window, every time. A handler
+        //  written against WPF properties returns an empty list and looks like "NT has no windows".
+        //  GetWindowRect / IsWindowVisible / IsIconic / IsZoomed are thread-agnostic; use those.
+        //
+        //  `Globals.AllWindows` is only touched to collect HWNDs (cheap, no geometry), and even that
+        //  is snapshotted first because the collection mutates as windows open and close.
+        // ═════════════════════════════════════════════════════════════════════════════════════════
+        [DllImport("user32.dll")] private static extern bool GetWindowRect(IntPtr h, out BridgeRect r);
+        [DllImport("user32.dll")] private static extern bool IsWindowVisible(IntPtr h);
+        [DllImport("user32.dll")] private static extern bool IsWindow(IntPtr h);
+        [DllImport("user32.dll")] private static extern bool IsIconic(IntPtr h);
+        [DllImport("user32.dll")] private static extern bool IsZoomed(IntPtr h);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetWindowText(IntPtr h, StringBuilder s, int n);
+
+        [StructLayout(LayoutKind.Sequential)]
+        private struct BridgeRect { public int Left, Top, Right, Bottom; }
+
+        private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+        [DllImport("user32.dll")] private static extern bool EnumWindows(EnumWindowsProc cb, IntPtr p);
+        [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetClassName(IntPtr h, StringBuilder s, int n);
+
+        private string RunWindows(string id)
+        {
+            //  ⚠ ENUMERATED VIA WIN32, NOT VIA Globals.AllWindows.
+            //
+            //  The first version of this walked `Globals.AllWindows` and called
+            //  `new WindowInteropHelper(w).Handle` to get each HWND. That THROWS: WindowInteropHelper
+            //  reads the Window's HwndSource, which is thread-affine like every other WPF member, so
+            //  from the poller thread it raises "The calling thread cannot access this object because
+            //  a different thread owns it" for EVERY window and the handler returns an empty list —
+            //  a confident `status:"ok", count:0` that looks like NinjaTrader has no windows.
+            //
+            //  You cannot even obtain the HANDLE off-thread. So do not start from WPF objects at all:
+            //  EnumWindows filtered by our own process id is completely thread-agnostic, needs no
+            //  dispatcher marshalling (which could deadlock against a busy window thread), and also
+            //  catches top-level windows that never appear in Globals.AllWindows.
+            var rows = new List<string>();
+            try
+            {
+                uint self = (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
+                // Held in a local so the GC cannot collect the delegate while EnumWindows runs.
+                EnumWindowsProc cb = delegate(IntPtr h, IntPtr lp)
+                {
+                    try
+                    {
+                        uint pid;
+                        GetWindowThreadProcessId(h, out pid);
+                        if (pid != self || !IsWindow(h)) return true;
+
+                        var title = new StringBuilder(400);
+                        GetWindowText(h, title, title.Capacity);
+                        var cls = new StringBuilder(200);
+                        GetClassName(h, cls, cls.Capacity);
+
+                        // Untitled HWNDs are message-only//tooltip/layered helpers, not real windows.
+                        if (title.Length == 0) return true;
+
+                        BridgeRect r;
+                        bool got = GetWindowRect(h, out r);
+                        rows.Add("{\"hwnd\":" + h.ToInt64().ToString(InvCi) +
+                                 ",\"title\":" + JsonStr(title.ToString()) +
+                                 ",\"class\":" + JsonStr(cls.ToString()) +
+                                 ",\"visible\":" + (IsWindowVisible(h) ? "true" : "false") +
+                                 ",\"minimized\":" + (IsIconic(h) ? "true" : "false") +
+                                 ",\"maximized\":" + (IsZoomed(h) ? "true" : "false") +
+                                 ",\"left\":" + (got ? r.Left : 0).ToString(InvCi) +
+                                 ",\"top\":" + (got ? r.Top : 0).ToString(InvCi) +
+                                 ",\"width\":" + (got ? r.Right - r.Left : 0).ToString(InvCi) +
+                                 ",\"height\":" + (got ? r.Bottom - r.Top : 0).ToString(InvCi) + "}");
+                    }
+                    catch (Exception ex) { LogSafe("RunWindows row: " + ex.Message); }
+                    return true;
+                };
+                EnumWindows(cb, IntPtr.Zero);
+                GC.KeepAlive(cb);
+            }
+            catch (Exception ex)
+            {
+                return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"message\":" + JsonStr(ex.Message) + "}";
+            }
+            return "{\"id\":" + JsonStr(id) + ",\"status\":\"ok\",\"count\":" + rows.Count.ToString(InvCi) +
+                   ",\"windows\":[" + string.Join(",", rows.ToArray()) + "]}";
+        }
+
+        private static bool EmitSucceeded(object emit)
+        {
+            try
+            {
+                if (emit == null) return true;               // no result object == nothing to complain about
+                PropertyInfo succ = emit.GetType().GetProperty("Success");
+                return succ == null || (bool)succ.GetValue(emit, null);
+            }
+            catch { return false; }
         }
 
         // --- Part 3: run a backtest by firing the SA's RunCommand (the exact
@@ -1074,7 +1210,9 @@ namespace NinjaTrader.NinjaScript.AddOns
             return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"errors\":[{\"message\":" + JsonStr(msg) + "}]}";
         }
 
-        private string BuildResultJson(string id, object emit)
+        private string BuildResultJson(string id, object emit) { return BuildResultJson(id, emit, false); }
+
+        private string BuildResultJson(string id, object emit, bool assemblyReloaded)
         {
             bool success = true;
             var errors = new List<string>();
@@ -1130,7 +1268,8 @@ namespace NinjaTrader.NinjaScript.AddOns
             }
             string status = (success && errors.Count == 0) ? "ok" : "error";
             return "{\"id\":" + JsonStr(id) + ",\"status\":\"" + status + "\",\"errors\":[" +
-                   string.Join(",", errors.ToArray()) + "],\"assemblyReloaded\":false}";
+                   string.Join(",", errors.ToArray()) + "],\"assemblyReloaded\":" +
+                   ((assemblyReloaded && status == "ok") ? "true" : "false") + "}";
         }
 
         // --- Account state: independent, out-of-band read of NT8's own Account

--- a/nt8bridge/cli.py
+++ b/nt8bridge/cli.py
@@ -17,6 +17,8 @@ from nt8bridge import connections as ntconnections
 from nt8bridge import reconnect as ntreconnect
 from nt8bridge import connwatch as ntconnwatch
 from nt8bridge import compile as ntcompile
+from nt8bridge import reload as ntreload
+from nt8bridge import windows as ntwindows
 from nt8bridge import config as ntconfig
 from nt8bridge import deploy, ntio, precheck
 from nt8bridge import report as ntreport
@@ -161,6 +163,41 @@ def _compile(type_name: str, timeout: float) -> int:
         )
     )
     return 0 if res.ok else 1
+
+
+def _reload(timeout: float) -> int:
+    """Full build + assembly swap — the step that used to require a human pressing F5."""
+    try:
+        res = ntreload.run_reload(timeout=timeout)
+    except TimeoutError as e:
+        print(json.dumps({
+            "command": "reload", "status": "timeout", "ok": False, "message": str(e),
+            "hint": "a reload emits and swaps the assembly, which is real work — slower than "
+                    "`compile`. NT may still be reloading; retry with a longer --timeout.",
+        }, indent=2))
+        return 2
+    print(json.dumps({
+        "command": "reload", "ok": res.ok, "errors": res.errors,
+        "assemblyReloaded": res.assembly_reloaded,
+        "note": None if res.assembly_reloaded else
+                "assembly NOT reloaded — the build failed, so NT kept the previous assembly.",
+    }, indent=2))
+    return 0 if res.ok else 1
+
+
+def _windows(timeout: float, offscreen_only: bool) -> int:
+    try:
+        payload = ntwindows.run_windows(timeout=timeout)
+    except TimeoutError as e:
+        print(json.dumps({"command": "windows", "status": "timeout", "ok": False,
+                          "message": str(e)}, indent=2))
+        return 2
+    wins = payload.get("windows", [])
+    if offscreen_only:
+        wins = [w for w in wins if ntwindows.offscreen(w)]
+    print(json.dumps({"command": "windows", "ok": payload.get("status") == "ok",
+                      "count": len(wins), "windows": wins}, indent=2))
+    return 0
 
 
 def _backtest(config_path: str, timeout: float, pdf=None) -> int:
@@ -535,6 +572,11 @@ def main(argv: list[str]) -> int:
     # A real tree can take well over 30s to compile; the old default turned a healthy
     # compile into a spurious "timeout".
     p_com.add_argument("--timeout", type=float, default=120.0)
+    p_rel = sub.add_parser("reload", help="compile AND load it (what F5 does) — DISRUPTIVE")
+    p_rel.add_argument("--timeout", type=float, default=240.0)
+    p_win = sub.add_parser("windows", help="inventory NT's top-level windows")
+    p_win.add_argument("--timeout", type=float, default=30.0)
+    p_win.add_argument("--offscreen", action="store_true", help="only windows that look unreachable")
     p_bt = sub.add_parser("backtest")
     p_bt.add_argument("--config", required=True)
     p_bt.add_argument("--timeout", type=float, default=120.0)
@@ -654,6 +696,10 @@ def main(argv: list[str]) -> int:
         return _deploy(args.strategy, args.kind)
     if args.command == "compile":
         return _compile(args.type, args.timeout)
+    if args.command == "reload":
+        return _reload(args.timeout)
+    if args.command == "windows":
+        return _windows(args.timeout, args.offscreen)
     if args.command == "backtest":
         return _backtest(args.config, args.timeout, args.pdf)
     if args.command == "account":

--- a/nt8bridge/reload.py
+++ b/nt8bridge/reload.py
@@ -1,0 +1,49 @@
+"""reload — make NinjaTrader actually LOAD the code, not just check it.
+
+WHY THIS EXISTS
+---------------
+`compile` invokes NinjaTrader's compiler with `checkCompileOnly=true`. That answers "does this build?"
+and nothing else: no assembly is emitted, so a brand-new indicator/strategy/AddOn type does not appear
+in the pickers and edited code is not running. Every headless edit loop therefore ended with a human
+alt-tabbing to the NinjaScript Editor and pressing F5 — which is the one step the bridge existed to
+remove.
+
+`reload` runs the same compiler with `checkCompileOnly=false`. NinjaTrader emits and swaps in the new
+NinjaScript assembly exactly as F5 does.
+
+⚠ RELOAD IS DISRUPTIVE, ON PURPOSE IT IS A SEPARATE COMMAND
+    It restarts indicators, can interrupt a running strategy, and orphans bars-type instances (those
+    are recreated only by an NT process restart, not by a reload or a chart reload). Do not fire it
+    into a live bake or a running automated session. Keeping it separate from `compile` means it can
+    never happen as a side effect of validating code.
+
+CONTRACT
+    request : {"id": str, "kind": "reload"}
+    response: {"id","status":"ok"|"error","errors":[...],"assemblyReloaded":bool}
+
+`assemblyReloaded` is now meaningful: true only when a non-check build succeeded. It used to be
+hardcoded false, so a caller could never tell whether its code was live.
+"""
+from __future__ import annotations
+
+import uuid
+
+from nt8bridge import ntio
+from nt8bridge.compile import CompileResult, parse_compile_response
+
+
+def run_reload(timeout: float = 240.0) -> CompileResult:
+    """Full build + assembly swap. Blocks until NinjaTrader answers.
+
+    The default timeout is higher than `compile`'s: emitting and swapping the assembly is real work,
+    and on a large tree with many charts open the reload itself takes noticeably longer than the
+    syntax check.
+    """
+    trigger, result = ntio.ensure_bridge_dirs()
+    request_id = uuid.uuid4().hex
+    ntio.atomic_write_json(
+        trigger / f"reload_{request_id}.json",
+        {"id": request_id, "kind": "reload"},
+    )
+    payload = ntio.poll_for_json(result / f"reload_{request_id}.json", timeout=timeout)
+    return parse_compile_response(payload)

--- a/nt8bridge/windows.py
+++ b/nt8bridge/windows.py
@@ -1,0 +1,52 @@
+"""windows — inventory NinjaTrader's top-level windows.
+
+Type, title, HWND, visibility, minimized/maximized, and screen geometry for every NT window.
+
+WHY IT IS USEFUL
+    • UI/AddOn work: know what is actually open without a screenshot.
+    • Recovery: find windows dragged or thrown off-screen (a real hazard for any tool that moves
+      windows) and see the coordinates that prove it.
+    • Automation: assert "the Control Center is up and the chart is on the right monitor" before
+      driving anything.
+
+⚠ The NT-side handler is WIN32, not WPF, and must stay that way. NinjaTrader runs each window on its
+own dispatcher thread, so reading `w.Left`/`.IsVisible` from the bridge's poller thread throws
+`InvalidOperationException` on every window — a WPF implementation returns an empty list and looks
+like "NinjaTrader has no windows".
+
+CONTRACT
+    request : {"id": str, "kind": "windows"}
+    response: {"id","status","count","windows":[{hwnd,type,title,visible,minimized,maximized,
+                                                 left,top,width,height}]}
+"""
+from __future__ import annotations
+
+import uuid
+
+from nt8bridge import ntio
+
+
+def run_windows(timeout: float = 30.0) -> dict:
+    trigger, result = ntio.ensure_bridge_dirs()
+    request_id = uuid.uuid4().hex
+    ntio.atomic_write_json(
+        trigger / f"windows_{request_id}.json",
+        {"id": request_id, "kind": "windows"},
+    )
+    return ntio.poll_for_json(result / f"windows_{request_id}.json", timeout=timeout)
+
+
+def offscreen(win: dict, vs_left=-32768, vs_top=-32768, vs_right=32767, vs_bottom=32767) -> bool:
+    """Heuristic: is this window's title bar unreachable?
+
+    Deliberately generous — the point is to catch the pathological cases (a window parked at
+    short.MinValue by a runaway move, or pushed entirely past the desktop), not to police a window
+    hanging slightly off an edge, which is normal and fine.
+    """
+    left, top = win.get("left", 0), win.get("top", 0)
+    width = win.get("width", 0)
+    if not win.get("visible", False):
+        return False
+    if left <= -30000 or top <= -30000 or left >= 30000 or top >= 30000:
+        return True
+    return (left + width) < vs_left + 40 or left > vs_right - 40 or top > vs_bottom - 20

--- a/nt8bridge/windows.py
+++ b/nt8bridge/windows.py
@@ -47,6 +47,14 @@ def offscreen(win: dict, vs_left=-32768, vs_top=-32768, vs_right=32767, vs_botto
     width = win.get("width", 0)
     if not win.get("visible", False):
         return False
+    # ⚠ A MINIMIZED WINDOW IS NOT AN UNREACHABLE ONE. Windows parks minimized windows at
+    # (-32000, -32000) by convention and they still report visible=true, so the coordinate test below
+    # classifies every minimized window as lost. Measured against a live NinjaTrader: 1 of 67 windows,
+    # a minimized chart — small here, but it scales with however many the user has minimized, and each
+    # one is a false positive in the exact list whose only job is to be short enough to act on.
+    # The taskbar is how you reach a minimized window; it is not unreachable.
+    if win.get("minimized", False):
+        return False
     if left <= -30000 or top <= -30000 or left >= 30000 or top >= 30000:
         return True
     return (left + width) < vs_left + 40 or left > vs_right - 40 or top > vs_bottom - 20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nt8bridge"
-version = "1.2.0"
+version = "1.3.0"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 # numpy + pyarrow are required: histdump's default engine decodes .nrd offline to parquet.

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,75 @@
+"""windows.offscreen — what counts as an unreachable window, and what does not.
+
+`--offscreen` exists to surface the one window you cannot get to. Its whole value is being a SHORT
+list, so a false positive is not a cosmetic problem: it buries the real answer among ordinary windows.
+Both classes below were measured against a live NinjaTrader with 67 windows open.
+"""
+from __future__ import annotations
+
+import pytest
+
+from nt8bridge import windows
+
+
+def _win(**kw):
+    base = {"left": 100, "top": 100, "width": 800, "height": 600,
+            "visible": True, "minimized": False}
+    base.update(kw)
+    return base
+
+
+def test_onscreen_window_is_not_offscreen():
+    assert windows.offscreen(_win()) is False
+
+
+@pytest.mark.parametrize("geom", [
+    {"left": -32768}, {"top": -32768}, {"left": 99999}, {"top": 99999},
+])
+def test_parked_at_a_pathological_coordinate(geom):
+    """short.MinValue / far past the desktop — a runaway move, not a placement."""
+    assert windows.offscreen(_win(**geom)) is True
+
+
+@pytest.mark.parametrize("geom", [
+    {"left": -32000, "top": -32000, "width": 94, "height": 28},   # exactly how Windows parks one
+    {"left": -32000, "top": -32000},
+])
+def test_minimized_window_is_not_offscreen(geom):
+    """⚠ FOUND BY DRIVING IT against a live NinjaTrader.
+
+    Windows parks a minimized window at (-32000, -32000) and it still reports visible=true, so the
+    pathological-coordinate test classifies every minimized window as lost. Measured: 1 of 67 windows
+    — modest here, but it scales with however many the user has minimized, and each is a false
+    positive in the one list whose value is being short enough to act on. The taskbar is how you
+    reach a minimized window; it is not unreachable."""
+    assert windows.offscreen(_win(minimized=True, **geom)) is False
+
+
+def test_a_genuinely_lost_window_still_reports():
+    """The fix must not blunt the instrument it is sharpening."""
+    assert windows.offscreen(_win(left=-32000, top=-32000, minimized=False)) is True
+
+
+@pytest.mark.parametrize("geom", [
+    {"left": -1920},                    # a monitor to the LEFT of the primary
+    {"top": -1080},                     # a monitor ABOVE the primary
+    {"left": -1920, "top": -1080},
+    {"left": -40},                      # hanging slightly off an edge — normal
+])
+def test_negative_coordinates_are_normal_and_not_flagged(geom):
+    """⚠ WHY THE THRESHOLD IS GENEROUS. Monitors left of or above the primary have NEGATIVE
+    virtual-desktop coordinates, so a window on one is perfectly reachable at left=-1920. A tighter
+    bound would report a stranger's second monitor as unreachable — a false positive on the most
+    common multi-monitor layout there is."""
+    assert windows.offscreen(_win(**geom)) is False
+
+
+def test_invisible_window_is_never_reported():
+    """Not visible is a different condition from not reachable; `windows` reports it separately."""
+    assert windows.offscreen(_win(left=-32768, visible=False)) is False
+
+
+def test_size_is_not_part_of_the_heuristic():
+    """A deliberate gap, recorded as a test so it is a decision rather than a surprise: a 0x0 visible
+    window is degenerate but is not off-screen, and offscreen() judges position only."""
+    assert windows.offscreen(_win(width=0, height=0)) is False


### PR DESCRIPTION
Taking you up on the split — this is the half of #2 you said you were happy with as-is: `reload`, `windows`, and the `assemblyReloaded` fix. `regions` and `restart` stay on #2 while I work through your four findings, so this doesn't have to wait on them.

### What's here

**`reload`** — `compile` runs NT's compiler with `checkCompileOnly=true`: it answers *does this build?* and emits nothing, so a new type never reaches the pickers and edited code isn't running. `reload` runs the same compiler with `checkCompileOnly=false`, so NT emits and swaps the assembly exactly as F5 does. **27s on a ~560-file tree.** Separate command, not a flag on `compile` — a reload restarts indicators, can interrupt a running strategy, and orphans bars-type instances; it must never happen as a side effect of validating code.

**`windows`** — type/title/HWND, visible/minimized/maximized, screen geometry, `--offscreen` filter.

**`assemblyReloaded`** — no longer hardcoded `false`; true only when a non-check build actually succeeded.

On your `checkCompileOnly=false` experiment: your reasoning was right and the instrument was broken. The Roslyn diagnostics genuinely *are* identical either way — that part of your conclusion holds. But `assemblyReloaded` was hardcoded, so the one field that would have shown the swap couldn't. Nothing you could have seen from the outside.

### Attribution — answering your question from #1

> shout if you'd rather it stay attributed as your measurement only

Please don't — **verified by you on 8.1.6.x is strictly better than reported by me on 8.1.7.2.** Two boxes, two NT minor versions, same result is a stronger claim than either alone. Keep it as verified; if it's ever worth a word, "verified on 8.1.6.x and 8.1.7.2" is the accurate version.

### Verification

- `173 passed, 6 skipped` — unchanged from upstream
- `nt8bridge --help` exposes `reload` and `windows`; no `regions`/`restart` leakage (asserted in a pre-commit check, not just eyeballed)
- `compile` is untouched on this branch — its duplicated-region warning calls `regions.scan`, so it stays on #2 with the module it depends on

🤖 Generated with [Claude Code](https://claude.com/claude-code)