### PR TITLE
feat: read-only state commands — playback, ntstatus, workspace, screenshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-08-04
+
+Four **read-only** commands that answer questions which previously required an RDP session. Each one
+exists because of a specific failure that cost real time; none of them mutate NinjaTrader state.
+
+Numbered 1.5.0 to stay clear of the in-flight 1.4.0 (`regions` + `restart`). This release does not
+depend on it and can merge in either order — say the word and it renumbers.
+
+### Added
+
+- **`playback` — replay transport state.** Connection, replay clock, speed, and per-`.nrd` coverage
+  via NinjaTrader's own `GetReplayMinMaxDates`. **The clock is sampled twice, a real gap apart**, and
+  the delta is reported as `movingSec`: a single reading cannot distinguish a parked transport from a
+  running one, and that distinction blocked a replay-equivalence gate for a day — the same seek landed
+  on a parked clock and silently no-opped on a moving one. `--require-ready` turns the report into an
+  assertion (exit 2) for bake scripts; reporting stays the default, because a box with no Playback
+  configured is not a failure of this command.
+
+  Coverage is read from the `.nrd` reader, **not the Playback slider** — the slider's bounds are the
+  connection range you typed, not the indexed data, and reading it as proof that data was loaded cost
+  hours on the same day.
+
+- **`ntstatus` — is NinjaTrader running the code on disk?** Process start time vs the built assembly's
+  timestamp, and it **exits 2 when the DLL is newer than the process**. This is the stale-DLL
+  condition that once ran a 33-minute cell against code the operator believed had been replaced: the
+  source on disk said one version, the running assembly was another, and every downstream conclusion
+  was drawn from the wrong build. On a timeout it degrades rather than fails — a wedged or signed-out
+  NinjaTrader is exactly when this matters, and the filesystem half of the answer is still available.
+
+- **`workspace` — charts, indicators, strategies, and their `State`.** Toggling Playback silently
+  disables chart strategies, and two runs were lost to a cell that replayed for half an hour with
+  nothing armed. Marshals to **each chart window's own dispatcher** with a bounded wait, and reports
+  `null` — never `[]` — when a member does not resolve: an unreadable chart and an empty chart are
+  different claims and must not share a representation.
+
+- **`screenshot` — capture a window (or the screen) as PNG.** A fleet of headless workers cannot be
+  operated through a human describing a window; during one incident the Playback window and a panel
+  were displaying two different clock values the whole time and nobody noticed, because nobody could
+  look at both at once. Matches by HWND or case-insensitive substring of the title.
+
+  ⚠ **It must run inside NinjaTrader.** SSH lands in session 0, which owns no desktop, and a session-0
+  capture returns **black — which looks like an answer** rather than an error. GDI `PrintWindow` with
+  `PW_RENDERFULLCONTENT`, encoded through WPF's `PngBitmapEncoder`, so no `System.Drawing` reference
+  is needed and no dispatcher is required (NinjaTrader is multi-UI-threaded; Win32 is thread-agnostic).
+
+### Notes for implementers
+
+**`PlaybackAdapter` members are bound by reflection, not directly.** NinjaTrader compiles every `.cs`
+under `bin\Custom` into one assembly, so a hard binding to an internal API turns any NinjaTrader
+change into a whole-tree compile break — which takes down every unrelated tool in the same tree.
+
+### Tests
+
+- **+17 tests**, `204 passed, 6 skipped` (1.3.0 baseline: 187). Two of them exist because driving
+  these against a live NinjaTrader within the hour found two defects in them:
+  - `playback` reported **ready** for a transport reading `2099-12-01` with nothing loaded. It was
+    stationary, so it passed the moving/not-moving test — a false green of exactly the kind this
+    command exists to eliminate.
+  - `workspace` matched strategies on `name` only. Tools that blank their own `Name` at `DataLoaded`
+    (the on-chart label *is* the `Name` property) were therefore invisible, and it found nothing on a
+    real chart. It now matches on name **or** type.
+
 ## [1.3.0] - 2026-07-30
 
 ### Added

--- a/addon/NT8BridgeServer.cs
+++ b/addon/NT8BridgeServer.cs
@@ -153,6 +153,14 @@ namespace NinjaTrader.NinjaScript.AddOns
                     WriteResult("connections_" + id + ".json", RunConnections(id));
                 else if (kind == "reconnect")
                     WriteResult("reconnect_" + id + ".json", RunReconnect(id, ExtractJsonString(text, "connection")));
+                else if (kind == "playback")
+                    WriteResult("playback_" + id + ".json", RunPlayback(id, ExtractJsonString(text, "instrument")));
+                else if (kind == "ntstatus")
+                    WriteResult("ntstatus_" + id + ".json", RunNtStatus(id));
+                else if (kind == "workspace")
+                    WriteResult("workspace_" + id + ".json", RunWorkspace(id));
+                else if (kind == "screenshot")
+                    WriteResult("screenshot_" + id + ".json", RunScreenshot(id, text));
                 else if (kind == "peek")
                     WriteResult("peek_" + id + ".json", RunPeek(id));
                 else if (kind == "probe")
@@ -196,6 +204,10 @@ namespace NinjaTrader.NinjaScript.AddOns
             if (kind == "backtest") return "backtest_";
             if (kind == "connections") return "connections_";
             if (kind == "reconnect") return "reconnect_";
+            if (kind == "playback") return "playback_";
+            if (kind == "ntstatus") return "ntstatus_";
+            if (kind == "workspace") return "workspace_";
+            if (kind == "screenshot") return "screenshot_";
             if (kind == "peek") return "peek_";
             if (kind == "probe") return "probe_";
             if (kind == "configure") return "configure_";
@@ -208,6 +220,591 @@ namespace NinjaTrader.NinjaScript.AddOns
             if (kind == "marketReplayDump") return "marketReplayDump_";
             if (kind == "marketReplayDownload") return "marketReplayDownload_";
             return "compile_";
+        }
+
+        // ═══════════════════════════════════════════════════════════════════════════════════════════════
+        //  READ-ONLY STATE COMMANDS  (playback · ntstatus · workspace)
+        //
+        //  WHY THESE EXIST — 2026-08-02, and each one is tied to a failure that actually cost a day.
+        //    A Gate 3 equivalence run compared two boxes proven byte-identical in every input we had made
+        //    hashable: code (muster), replay .nrd, historical bars, and the chart+strategy blob. It still
+        //    diverged. The cause was in none of them — it was the transport state inside a running NT:
+        //    one box's replay clock was parked at the range start, the other's was 27 h in and moving, so
+        //    the same Reset() call seeked on one and no-opped on the other.
+        //
+        //    ⭐ THE PATTERN: every input we could verify was a FILE. Everything still diverging lives only
+        //    in a running NinjaTrader — no file, no hash, no read-back — and so was set by hand, per box,
+        //    at different moments. We were verifying what was easy to verify. These three commands give
+        //    that state a read-back, which is the whole prerequisite for ever trusting it.
+        //
+        //    ⭐ THE SCALING ARGUMENT: the Watch is SIX replay workers. Any input that needs a GUI click per
+        //    box cannot be held equal across a matrix, and any check that needs an eye on a screen cannot
+        //    be run across one either. Read-only first — these three answer questions, they change nothing.
+        //
+        //  Each maps to a specific incident:
+        //    playback   — the divergence above, and the Playback range silently reverting across restarts
+        //    ntstatus   — a STALE DLL ran an entire 33-minute cell while the source on disk said otherwise
+        //    workspace  — two runs where the strategy was silently disabled (toggling Playback disables it)
+        // ═══════════════════════════════════════════════════════════════════════════════════════════════
+
+        private const BindingFlags BFStatic = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        // Long enough that a real replay clock provably moves (400 ms at 100x is 40 replay-seconds), short
+        // enough that a status call stays snappy. Same constant, same reasoning, as the Conductor pre-flight.
+        private const int PlaybackSampleMs = 400;
+        private static string NtCoreVersion()
+        {
+            try { return typeof(Connection).Assembly.GetName().Version.ToString(); } catch { return ""; }
+        }
+
+        // ── playback ────────────────────────────────────────────────────────────────────────────────────
+        //  Connection state + the replay clock + speed + what the .nrd files on disk actually cover.
+        //
+        //  ⚠ Reflection, not a direct reference — the same reasoning as SentinelConductor: PlaybackAdapter's
+        //  members are internal-ish, and NinjaTrader compiles every .cs under bin\Custom into ONE assembly,
+        //  so a hard binding would turn any NT API change into a whole-suite compile break. Reflection
+        //  degrades to nulls in the JSON instead.
+        //
+        //  ⭐ `movingSec` is the field this was written for. A single clock reading cannot distinguish a
+        //  parked transport from a running one, and that distinction is exactly what broke Gate 3. Two
+        //  samples a real gap apart can. REPORT THE OUTCOME, NOT THE INTENT.
+        private string RunPlayback(string id, string instrument)
+        {
+            var sb = new StringBuilder();
+            try
+            {
+                Type pb = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                PropertyInfo piSpeed = pb != null ? pb.GetProperty("PlaybackSpeed", BFStatic) : null;
+                PropertyInfo piNowEst = pb != null ? pb.GetProperty("NowEst", BFStatic) : null;
+                FieldInfo fiMaxSpeed = pb != null ? pb.GetField("MaxSpeedValue", BFStatic) : null;
+                MethodInfo miMinMax = pb != null
+                    ? pb.GetMethod("GetReplayMinMaxDates", BFStatic, null,
+                        new[] { typeof(string), typeof(DateTime).MakeByRefType(), typeof(DateTime).MakeByRefType() }, null)
+                    : null;
+                PropertyInfo piConn = typeof(Connection).GetProperty("PlaybackConnection", BFStatic);
+
+                object speed = null, maxSpeed = null;
+                try { if (piSpeed != null) speed = piSpeed.GetValue(null); } catch (Exception ex) { LogSafe("playback speed: " + ex.Message); }
+                try { if (fiMaxSpeed != null) maxSpeed = fiMaxSpeed.GetValue(null); } catch (Exception ex) { LogSafe("playback maxspeed: " + ex.Message); }
+
+                // Two clock samples, a real gap apart — parked vs running (see above).
+                DateTime? c1 = ReadClock(piNowEst);
+                Thread.Sleep(PlaybackSampleMs);
+                DateTime? c2 = ReadClock(piNowEst);
+                double movingSec = (c1.HasValue && c2.HasValue) ? (c2.Value - c1.Value).TotalSeconds : 0.0;
+
+                string connStatus = "none";
+                bool connected = false;
+                try
+                {
+                    var c = piConn != null ? piConn.GetValue(null) as Connection : null;
+                    if (c != null) { connStatus = c.Status.ToString(); connected = c.Status == ConnectionStatus.Connected; }
+                }
+                catch (Exception ex) { LogSafe("playback conn: " + ex.Message); }
+
+                sb.Append("{\"id\":").Append(JsonStr(id))
+                  .Append(",\"status\":\"ok\",\"ts\":").Append(JsonStr(DateTime.UtcNow.ToString("o")))
+                  .Append(",\"transportResolved\":").Append(pb != null ? "true" : "false")
+                  .Append(",\"connection\":{\"status\":").Append(JsonStr(connStatus))
+                  .Append(",\"connected\":").Append(connected ? "true" : "false").Append("}")
+                  .Append(",\"clockEst\":").Append(c2.HasValue ? JsonStr(c2.Value.ToString("o")) : "null")
+                  .Append(",\"clockEstFirst\":").Append(c1.HasValue ? JsonStr(c1.Value.ToString("o")) : "null")
+                  .Append(",\"sampleMs\":").Append(PlaybackSampleMs.ToString(InvCi))
+                  .Append(",\"movingSec\":").Append(movingSec.ToString("0.###", InvCi))
+                  .Append(",\"moving\":").Append(movingSec > 2.0 ? "true" : "false")
+                  .Append(",\"speed\":").Append(speed is int ? ((int)speed).ToString(InvCi) : "null")
+                  .Append(",\"maxSpeedValue\":").Append(maxSpeed is int ? ((int)maxSpeed).ToString(InvCi) : "null");
+
+                // Coverage — what the .nrd files actually contain, from NT's own reader. The Playback
+                // slider is NOT this: its bounds are the CONNECTION range you typed, not indexed data,
+                // and misreading it as proof of loaded data cost hours on 2026-08-02.
+                sb.Append(",\"coverage\":");
+                AppendCoverage(sb, miMinMax, instrument);
+                sb.Append("}");
+                return sb.ToString();
+            }
+            catch (Exception ex)
+            {
+                return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"errors\":[{\"code\":\"BRIDGE\",\"message\":"
+                     + JsonStr(ex.GetType().Name + ": " + ex.Message) + "}]}";
+            }
+        }
+
+        private static DateTime? ReadClock(PropertyInfo piNowEst)
+        {
+            try { if (piNowEst != null) return (DateTime)piNowEst.GetValue(null); } catch { }
+            return null;
+        }
+
+        // Per-instrument .nrd spans. `instrument` null/empty => every instrument folder under db\replay.
+        private void AppendCoverage(StringBuilder sb, MethodInfo miMinMax, string instrument)
+        {
+            sb.Append("[");
+            if (miMinMax == null) { sb.Append("]"); return; }
+            bool firstInstr = true;
+            try
+            {
+                string root = Path.Combine(Globals.UserDataDir, "db", "replay");
+                if (!Directory.Exists(root)) { sb.Append("]"); return; }
+                string[] dirs = string.IsNullOrEmpty(instrument)
+                    ? Directory.GetDirectories(root)
+                    : new[] { Path.Combine(root, instrument) };
+                foreach (string dir in dirs)
+                {
+                    if (!Directory.Exists(dir)) continue;
+                    string[] files = Directory.GetFiles(dir, "*.nrd");
+                    Array.Sort(files);
+                    DateTime lo = DateTime.MaxValue, hi = DateTime.MinValue;
+                    int ok = 0, bad = 0;
+                    var days = new StringBuilder();
+                    foreach (string f in files)
+                    {
+                        DateTime a = DateTime.MinValue, b = DateTime.MinValue;
+                        bool read = false;
+                        try
+                        {
+                            object[] args = new object[] { f, DateTime.MinValue, DateTime.MinValue };
+                            miMinMax.Invoke(null, args);
+                            a = (DateTime)args[1]; b = (DateTime)args[2];
+                            read = true;
+                        }
+                        catch { }
+                        if (days.Length > 0) days.Append(",");
+                        days.Append("{\"file\":").Append(JsonStr(Path.GetFileNameWithoutExtension(f)))
+                            .Append(",\"readable\":").Append(read ? "true" : "false")
+                            .Append(",\"from\":").Append(read ? JsonStr(a.ToString("o")) : "null")
+                            .Append(",\"to\":").Append(read ? JsonStr(b.ToString("o")) : "null")
+                            .Append(",\"bytes\":").Append(SafeLen(f).ToString(InvCi)).Append("}");
+                        if (read) { ok++; if (a < lo) lo = a; if (b > hi) hi = b; } else bad++;
+                    }
+                    if (!firstInstr) sb.Append(",");
+                    firstInstr = false;
+                    sb.Append("{\"instrument\":").Append(JsonStr(Path.GetFileName(dir)))
+                      .Append(",\"files\":").Append(files.Length.ToString(InvCi))
+                      .Append(",\"readable\":").Append(ok.ToString(InvCi))
+                      .Append(",\"unreadable\":").Append(bad.ToString(InvCi))
+                      .Append(",\"from\":").Append(ok > 0 ? JsonStr(lo.ToString("o")) : "null")
+                      .Append(",\"to\":").Append(ok > 0 ? JsonStr(hi.ToString("o")) : "null")
+                      .Append(",\"days\":[").Append(days).Append("]}");
+                }
+            }
+            catch (Exception ex) { LogSafe("AppendCoverage: " + ex.Message); }
+            sb.Append("]");
+        }
+
+        private static long SafeLen(string f)
+        {
+            try { return new FileInfo(f).Length; } catch { return -1; }
+        }
+
+        // ── ntstatus ────────────────────────────────────────────────────────────────────────────────────
+        //  "Is the code NinjaTrader is RUNNING the code that is on disk?"
+        //
+        //  ⭐ WHY: on 2026-08-02 a box ran Conductor v0.1.0 for 33 minutes while the source on disk said
+        //  v0.2.0b — the deploy had copied source without compiling, and every downstream conclusion from
+        //  that cell was worthless. The version chip was on screen the whole time and went unread.
+        //  A comparison of PROCESS START vs ASSEMBLY BUILD makes the same mistake impossible to miss, and
+        //  unlike the chip it can be read across six boxes in one command.
+        //
+        //  Answered from INSIDE NT deliberately: only this process knows which assembly it actually loaded.
+        //  The Python side additionally stats the DLL on disk, so the two can disagree — and that
+        //  disagreement IS the finding.
+        private string RunNtStatus(string id)
+        {
+            try
+            {
+                var proc = System.Diagnostics.Process.GetCurrentProcess();
+                DateTime procStart = proc.StartTime.ToUniversalTime();
+
+                string loadedPath = null, loadedVer = null;
+                DateTime? loadedBuilt = null;
+                try
+                {
+                    Assembly custom = null;
+                    foreach (Assembly a in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        string n = a.GetName().Name;
+                        if (string.Equals(n, "NinjaTrader.Custom", StringComparison.OrdinalIgnoreCase)) { custom = a; break; }
+                    }
+                    if (custom != null)
+                    {
+                        loadedVer = custom.GetName().Version != null ? custom.GetName().Version.ToString() : null;
+                        try { loadedPath = custom.Location; } catch { }
+                        // An in-memory (byte[]-loaded) assembly has no Location — NT swaps NinjaScript in
+                        // that way on a reload, so an empty Location is INFORMATION, not an error.
+                        if (!string.IsNullOrEmpty(loadedPath) && File.Exists(loadedPath))
+                            loadedBuilt = File.GetLastWriteTimeUtc(loadedPath);
+                    }
+                }
+                catch (Exception ex) { LogSafe("ntstatus assembly: " + ex.Message); }
+
+                string dllOnDisk = Path.Combine(Globals.UserDataDir, "bin", "Custom", "NinjaTrader.Custom.dll");
+                DateTime? diskBuilt = File.Exists(dllOnDisk) ? (DateTime?)File.GetLastWriteTimeUtc(dllOnDisk) : null;
+
+                // The finding, stated rather than left for the reader to compute.
+                bool stale = diskBuilt.HasValue && diskBuilt.Value > procStart;
+
+                var sb = new StringBuilder();
+                sb.Append("{\"id\":").Append(JsonStr(id))
+                  .Append(",\"status\":\"ok\",\"ts\":").Append(JsonStr(DateTime.UtcNow.ToString("o")))
+                  .Append(",\"pid\":").Append(proc.Id.ToString(InvCi))
+                  .Append(",\"processStartUtc\":").Append(JsonStr(procStart.ToString("o")))
+                  .Append(",\"ntVersion\":").Append(JsonStr(NtCoreVersion()))
+                  .Append(",\"userDataDir\":").Append(JsonStr(Globals.UserDataDir))
+                  .Append(",\"loadedAssembly\":{\"version\":").Append(JsonStr(loadedVer))
+                  .Append(",\"location\":").Append(JsonStr(loadedPath))
+                  .Append(",\"inMemory\":").Append(string.IsNullOrEmpty(loadedPath) ? "true" : "false")
+                  .Append(",\"builtUtc\":").Append(loadedBuilt.HasValue ? JsonStr(loadedBuilt.Value.ToString("o")) : "null").Append("}")
+                  .Append(",\"dllOnDisk\":{\"path\":").Append(JsonStr(dllOnDisk))
+                  .Append(",\"builtUtc\":").Append(diskBuilt.HasValue ? JsonStr(diskBuilt.Value.ToString("o")) : "null").Append("}")
+                  .Append(",\"assemblyOlderThanDisk\":").Append(stale ? "true" : "false")
+                  .Append("}");
+                return sb.ToString();
+            }
+            catch (Exception ex)
+            {
+                return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"errors\":[{\"code\":\"BRIDGE\",\"message\":"
+                     + JsonStr(ex.GetType().Name + ": " + ex.Message) + "}]}";
+            }
+        }
+
+        // ── screenshot ──────────────────────────────────────────────────────────────────────────────────
+        //  LET THE OPERATOR SEE THE SCREEN.
+        //
+        //  ⭐ WHY: 2026-08-02, and this one is a process failure rather than a code failure. A replay would
+        //  not seek on one node. Every diagnosis was made by asking the user what was on their screen and
+        //  reasoning about the answer — and the reasoning was wrong repeatedly, because a relayed screen is
+        //  a lossy channel: the Playback window and the Conductor panel were displaying two DIFFERENT clock
+        //  values the whole time and nobody noticed, because nobody was looking at both at once.
+        //
+        //  A fleet of six headless replay workers cannot be operated through a human describing a window.
+        //  ⇒ Capture the pixels and ship them back. This is the read-only sibling of `windows`: that command
+        //  says a window EXISTS, this one says what it SAYS.
+        //
+        //  ⚠ MUST run inside NinjaTrader, not over SSH. SSH lands in session 0, which owns no desktop — a
+        //  capture from there returns black, and black is worse than an error because it looks like an answer.
+        //  Running in the AddOn means running in the interactive session where the pixels actually are.
+        //
+        //  ⚠ GDI, not WPF rendering. RenderTargetBitmap would need each window's own dispatcher (NT is
+        //  multi-UI-threaded) and would miss child HWNDs and the DWM composition. PrintWindow with
+        //  PW_RENDERFULLCONTENT captures what is genuinely on screen, and Win32 is thread-agnostic — the
+        //  same reason `windows` enumerates via EnumWindows rather than Globals.AllWindows.
+        private const uint PW_RENDERFULLCONTENT = 0x00000002;
+        private const int SRCCOPY = 0x00CC0020;
+
+        private string RunScreenshot(string id, string triggerJson)
+        {
+            string title = ExtractJsonString(triggerJson, "title");
+            string hwndStr = ExtractJsonString(triggerJson, "hwnd");
+            string outPath = ExtractJsonString(triggerJson, "out");
+
+            try { SetProcessDPIAware(); } catch { }
+
+            IntPtr target = IntPtr.Zero;
+            string matched = null;
+            long parsed;
+            if (!string.IsNullOrEmpty(hwndStr) && long.TryParse(hwndStr, out parsed))
+            {
+                target = new IntPtr(parsed);
+                var tb = new StringBuilder(400);
+                GetWindowText(target, tb, tb.Capacity);
+                matched = tb.ToString();
+            }
+            else if (!string.IsNullOrEmpty(title))
+            {
+                // Substring, case-insensitive — a caller should not have to know a window's exact caption,
+                // and NT retitles windows as their content changes.
+                var found = new List<KeyValuePair<IntPtr, string>>();
+                uint self = (uint)System.Diagnostics.Process.GetCurrentProcess().Id;
+                EnumWindowsProc cb = delegate(IntPtr h, IntPtr lp)
+                {
+                    try
+                    {
+                        uint pid; GetWindowThreadProcessId(h, out pid);
+                        if (pid != self || !IsWindow(h) || !IsWindowVisible(h)) return true;
+                        var tb2 = new StringBuilder(400);
+                        GetWindowText(h, tb2, tb2.Capacity);
+                        string t = tb2.ToString();
+                        if (t.Length > 0 && t.IndexOf(title, StringComparison.OrdinalIgnoreCase) >= 0)
+                            found.Add(new KeyValuePair<IntPtr, string>(h, t));
+                    }
+                    catch { }
+                    return true;
+                };
+                EnumWindows(cb, IntPtr.Zero);
+                GC.KeepAlive(cb);
+                if (found.Count == 0)
+                    return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"errors\":[{\"code\":\"BRIDGE\",\"message\":"
+                         + JsonStr("no visible window matching '" + title + "'") + "}]}";
+                target = found[0].Key;
+                matched = found[0].Value;
+            }
+
+            int x = 0, y = 0, w, h2;
+            bool fullScreen = target == IntPtr.Zero;
+            if (fullScreen)
+            {
+                // Virtual screen: every monitor, including negative-origin ones.
+                x = GetSystemMetrics(76); y = GetSystemMetrics(77);
+                w = GetSystemMetrics(78); h2 = GetSystemMetrics(79);
+                matched = "(virtual screen)";
+            }
+            else
+            {
+                BridgeRect r;
+                if (!GetWindowRect(target, out r))
+                    return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"errors\":[{\"code\":\"BRIDGE\",\"message\":\"GetWindowRect failed\"}]}";
+                w = r.Right - r.Left; h2 = r.Bottom - r.Top; x = r.Left; y = r.Top;
+                // A minimized window has a real HWND and nonsense geometry. Say so rather than return an
+                // 8x8 sliver that looks like a failed render.
+                if (IsIconic(target) || w <= 0 || h2 <= 0)
+                    return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"errors\":[{\"code\":\"BRIDGE\",\"message\":"
+                         + JsonStr("window is minimized or has no area (" + w + "x" + h2 + ") — restore it first") + "}]}";
+            }
+
+            if (string.IsNullOrEmpty(outPath))
+                outPath = Path.Combine(Globals.UserDataDir, "NT8Bridge", "result", "shot_" + id + ".png");
+
+            IntPtr srcDc = IntPtr.Zero, memDc = IntPtr.Zero, bmp = IntPtr.Zero, old = IntPtr.Zero;
+            try
+            {
+                srcDc = fullScreen ? GetDC(IntPtr.Zero) : GetWindowDC(target);
+                if (srcDc == IntPtr.Zero) throw new Exception("could not get a device context");
+                memDc = CreateCompatibleDC(srcDc);
+                bmp = CreateCompatibleBitmap(srcDc, w, h2);
+                old = SelectObject(memDc, bmp);
+
+                bool ok = false;
+                if (!fullScreen)
+                    ok = PrintWindow(target, memDc, PW_RENDERFULLCONTENT);
+                if (!ok)
+                    // Fallback: blit from the screen DC. Captures whatever is actually visible, so an
+                    // occluded window comes back occluded — which is the truth, not a defect.
+                    ok = BitBlt(memDc, 0, 0, w, h2, fullScreen ? srcDc : GetDC(IntPtr.Zero), x, y, SRCCOPY);
+                if (!ok) throw new Exception("both PrintWindow and BitBlt failed");
+
+                var src = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+                    bmp, IntPtr.Zero, System.Windows.Int32Rect.Empty,
+                    System.Windows.Media.Imaging.BitmapSizeOptions.FromEmptyOptions());
+                var enc = new System.Windows.Media.Imaging.PngBitmapEncoder();
+                enc.Frames.Add(System.Windows.Media.Imaging.BitmapFrame.Create(src));
+
+                string dir = Path.GetDirectoryName(outPath);
+                if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir)) Directory.CreateDirectory(dir);
+                using (var fs = new FileStream(outPath, FileMode.Create, FileAccess.Write))
+                    enc.Save(fs);
+
+                return "{\"id\":" + JsonStr(id) + ",\"status\":\"ok\",\"ts\":" + JsonStr(DateTime.UtcNow.ToString("o"))
+                     + ",\"path\":" + JsonStr(outPath)
+                     + ",\"window\":" + JsonStr(matched)
+                     + ",\"hwnd\":" + target.ToInt64().ToString(InvCi)
+                     + ",\"width\":" + w.ToString(InvCi) + ",\"height\":" + h2.ToString(InvCi)
+                     + ",\"bytes\":" + SafeLen(outPath).ToString(InvCi) + "}";
+            }
+            catch (Exception ex)
+            {
+                return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"errors\":[{\"code\":\"BRIDGE\",\"message\":"
+                     + JsonStr(ex.GetType().Name + ": " + ex.Message) + "}]}";
+            }
+            finally
+            {
+                try { if (old != IntPtr.Zero) SelectObject(memDc, old); } catch { }
+                try { if (bmp != IntPtr.Zero) DeleteObject(bmp); } catch { }
+                try { if (memDc != IntPtr.Zero) DeleteDC(memDc); } catch { }
+                try { if (srcDc != IntPtr.Zero) ReleaseDC(fullScreen ? IntPtr.Zero : target, srcDc); } catch { }
+            }
+        }
+
+        // ── workspace ───────────────────────────────────────────────────────────────────────────────────
+        //  What is actually ON each chart: instrument, bar type, indicators, strategies + their State.
+        //
+        //  ⭐ WHY: two Gate 3 runs were lost to a strategy that was silently DISABLED — toggling the
+        //  Playback connection disables chart strategies, and on an unattended boot a workspace can restore
+        //  with the strategy off. That looks identical to a healthy run until the corpus comes back empty.
+        //  "Is my strategy enabled on both boxes?" should be one command, not an RDP session per box.
+        //
+        //  ⚠ NT IS MULTI-UI-THREADED — every window owns its own dispatcher, and reading a WPF member from
+        //  the poller thread throws "the calling thread cannot access this object" for EVERY window. So:
+        //  snapshot Globals.AllWindows (a plain collection — safe), then marshal to EACH window's OWN
+        //  dispatcher to read it. A short timeout per window so one busy chart cannot wedge the bridge.
+        //
+        //  ⚠ Read by REFLECTION with the resolved member recorded. NT's chart object model is not part of
+        //  the documented NinjaScript surface, so a hard binding is both a compile risk and a silent-wrong
+        //  risk across versions. When a member does not resolve the JSON says so rather than reporting an
+        //  empty chart — an absent reading and a zero reading are not the same claim.
+        private string RunWorkspace(string id)
+        {
+            var charts = new List<string>();
+            var notes = new List<string>();
+            try
+            {
+                var snap = new List<Window>();
+                try
+                {
+                    var all = Globals.AllWindows;
+                    if (all != null) for (int i = 0; i < all.Count; i++) snap.Add(all[i]);
+                }
+                catch (Exception ex) { notes.Add("AllWindows snapshot: " + ex.Message); }
+
+                foreach (Window w in snap)
+                {
+                    if (w == null) continue;
+                    string tn;
+                    try { tn = w.GetType().FullName; } catch { continue; }
+                    if (tn == null || tn.IndexOf("Chart", StringComparison.Ordinal) < 0) continue;
+                    if (tn.IndexOf("ChartTrader", StringComparison.Ordinal) >= 0) continue;
+
+                    Window win = w;
+                    string row = null;
+                    try
+                    {
+                        var op = win.Dispatcher.BeginInvoke(new Func<string>(delegate { return DescribeChart(win); }));
+                        // Bounded wait: a chart mid-render must not hold the poller. Silence is reported,
+                        // not swallowed — a window we could not read is a fact worth returning.
+                        if (op.Wait(TimeSpan.FromSeconds(5)) == System.Windows.Threading.DispatcherOperationStatus.Completed)
+                            row = op.Result as string;
+                        else
+                            notes.Add("chart window did not answer within 5s: " + tn);
+                    }
+                    catch (Exception ex) { notes.Add("chart read (" + tn + "): " + ex.Message); }
+                    if (row != null) charts.Add(row);
+                }
+            }
+            catch (Exception ex)
+            {
+                return "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"charts\":[],\"errors\":[{\"code\":\"BRIDGE\",\"message\":"
+                     + JsonStr(ex.GetType().Name + ": " + ex.Message) + "}]}";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append("{\"id\":").Append(JsonStr(id))
+              .Append(",\"status\":\"ok\",\"ts\":").Append(JsonStr(DateTime.UtcNow.ToString("o")))
+              .Append(",\"workspace\":").Append(JsonStr(CurrentWorkspaceName()))
+              .Append(",\"chartCount\":").Append(charts.Count.ToString(InvCi))
+              .Append(",\"charts\":[").Append(string.Join(",", charts.ToArray())).Append("]")
+              .Append(",\"notes\":[");
+            for (int i = 0; i < notes.Count; i++) { if (i > 0) sb.Append(","); sb.Append(JsonStr(notes[i])); }
+            sb.Append("]}");
+            return sb.ToString();
+        }
+
+        // Reflected, not bound: the member has moved across NT builds and is not worth a compile break.
+        private static string CurrentWorkspaceName()
+        {
+            string[] names = { "CurrentWorkspace", "Workspace", "WorkspaceName" };
+            foreach (string n in names)
+            {
+                try
+                {
+                    PropertyInfo pi = typeof(Globals).GetProperty(n, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                    if (pi != null)
+                    {
+                        object v = pi.GetValue(null, null);
+                        if (v != null) return Convert.ToString(v);
+                    }
+                }
+                catch { }
+            }
+            return null;
+        }
+
+        // MUST be called on the chart window's OWN dispatcher (see RunWorkspace).
+        private string DescribeChart(Window win)
+        {
+            var sb = new StringBuilder();
+            string title = null;
+            try { title = win.Title; } catch { }
+            sb.Append("{\"title\":").Append(JsonStr(title))
+              .Append(",\"type\":").Append(JsonStr(SafeTypeName(win)));
+
+            object cc = FirstMember(win, new[] { "ActiveChartControl", "ChartControl" });
+            if (cc == null)
+            {
+                sb.Append(",\"chartControlResolved\":false,\"instrument\":null,\"barsPeriod\":null")
+                  .Append(",\"indicators\":null,\"strategies\":null}");
+                return sb.ToString();
+            }
+            sb.Append(",\"chartControlResolved\":true");
+
+            object instr = FirstMember(cc, new[] { "Instrument" });
+            object bp = FirstMember(cc, new[] { "BarsPeriod" });
+            sb.Append(",\"instrument\":").Append(JsonStr(instr != null ? Convert.ToString(instr) : null))
+              .Append(",\"barsPeriod\":").Append(JsonStr(bp != null ? Convert.ToString(bp) : null));
+
+            sb.Append(",\"indicators\":");
+            AppendNsList(sb, FirstMember(cc, new[] { "Indicators" }));
+            sb.Append(",\"strategies\":");
+            AppendNsList(sb, FirstMember(cc, new[] { "Strategies" }));
+
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        // NinjaScript objects (indicators/strategies) as {name, state, enabled}. `state` is NT's own State
+        // enum verbatim — Active/Realtime/Historical/Terminated — because the raw value is the evidence and
+        // any collapsing of it into a boolean is a claim we would then have to defend.
+        private void AppendNsList(StringBuilder sb, object list)
+        {
+            if (list == null) { sb.Append("null"); return; }
+            sb.Append("[");
+            try
+            {
+                var en = list as IEnumerable;
+                if (en != null)
+                {
+                    bool first = true;
+                    foreach (object o in en)
+                    {
+                        if (o == null) continue;
+                        string nm = null, st = null;
+                        // ⚠ A Sentinel tool BLANKS its own Name at DataLoaded (that is how the on-chart label
+                        // is hidden — the label IS the Name property), so `Name` is legitimately "" for most
+                        // of this suite. Fall back to the type name, or every row reads as anonymous and any
+                        // caller matching on name matches nothing. Found by running this against sentry-2.
+                        try { object v = FirstMember(o, new[] { "Name" }); nm = Convert.ToString(v); } catch { }
+                        if (string.IsNullOrEmpty(nm)) nm = SafeTypeName(o);
+                        try { object v = FirstMember(o, new[] { "State" }); st = v != null ? Convert.ToString(v) : null; } catch { }
+                        if (!first) sb.Append(",");
+                        first = false;
+                        sb.Append("{\"name\":").Append(JsonStr(nm))
+                          .Append(",\"type\":").Append(JsonStr(SafeTypeName(o)))
+                          .Append(",\"state\":").Append(JsonStr(st))
+                          .Append(",\"enabled\":").Append(st == "Active" || st == "Realtime" || st == "Historical" ? "true" : "false")
+                          .Append("}");
+                    }
+                }
+            }
+            catch (Exception ex) { LogSafe("AppendNsList: " + ex.Message); }
+            sb.Append("]");
+        }
+
+        private static string SafeTypeName(object o)
+        {
+            try { return o != null ? o.GetType().Name : null; } catch { return null; }
+        }
+
+        // First of the candidate property/field names that resolves on this object, else null.
+        private static object FirstMember(object target, string[] names)
+        {
+            if (target == null) return null;
+            Type t;
+            try { t = target.GetType(); } catch { return null; }
+            const BindingFlags bf = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+            foreach (string n in names)
+            {
+                try
+                {
+                    PropertyInfo pi = t.GetProperty(n, bf);
+                    if (pi != null && pi.CanRead) { object v = pi.GetValue(target, null); if (v != null) return v; }
+                }
+                catch { }
+                try
+                {
+                    FieldInfo fi = t.GetField(n, bf);
+                    if (fi != null) { object v = fi.GetValue(target); if (v != null) return v; }
+                }
+                catch { }
+            }
+            return null;
         }
 
         private string RunCompile(string id)
@@ -276,6 +873,23 @@ namespace NinjaTrader.NinjaScript.AddOns
         [DllImport("user32.dll")] private static extern bool EnumWindows(EnumWindowsProc cb, IntPtr p);
         [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr h, out uint pid);
         [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetClassName(IntPtr h, StringBuilder s, int n);
+
+        // ── screenshot P/Invoke ─────────────────────────────────────────────────────────────────────────
+        //  GDI, not System.Drawing: the encode goes through WPF's PngBitmapEncoder (PresentationCore, which
+        //  this suite already depends on everywhere) so nothing new has to be referenced to build.
+        [DllImport("user32.dll")] private static extern IntPtr GetDC(IntPtr h);
+        [DllImport("user32.dll")] private static extern IntPtr GetWindowDC(IntPtr h);
+        [DllImport("user32.dll")] private static extern int ReleaseDC(IntPtr h, IntPtr dc);
+        [DllImport("user32.dll")] private static extern bool PrintWindow(IntPtr h, IntPtr dc, uint flags);
+        [DllImport("user32.dll")] private static extern int GetSystemMetrics(int i);
+        [DllImport("user32.dll")] private static extern bool SetProcessDPIAware();
+        [DllImport("gdi32.dll")] private static extern IntPtr CreateCompatibleDC(IntPtr dc);
+        [DllImport("gdi32.dll")] private static extern IntPtr CreateCompatibleBitmap(IntPtr dc, int w, int h);
+        [DllImport("gdi32.dll")] private static extern IntPtr SelectObject(IntPtr dc, IntPtr obj);
+        [DllImport("gdi32.dll")] private static extern bool DeleteObject(IntPtr obj);
+        [DllImport("gdi32.dll")] private static extern bool DeleteDC(IntPtr dc);
+        [DllImport("gdi32.dll")] private static extern bool BitBlt(IntPtr dst, int x, int y, int w, int h,
+                                                                   IntPtr src, int sx, int sy, int rop);
 
         private string RunWindows(string id)
         {

--- a/nt8bridge/cli.py
+++ b/nt8bridge/cli.py
@@ -14,6 +14,10 @@ from nt8bridge import batch as ntbatch
 from nt8bridge import flatten as ntflatten
 from nt8bridge import watch as ntwatch
 from nt8bridge import connections as ntconnections
+from nt8bridge import playback as ntplayback
+from nt8bridge import screenshot as ntscreenshot
+from nt8bridge import ntstatus as ntntstatus
+from nt8bridge import workspace as ntworkspace
 from nt8bridge import reconnect as ntreconnect
 from nt8bridge import connwatch as ntconnwatch
 from nt8bridge import compile as ntcompile
@@ -61,6 +65,10 @@ Commands:
   python -m nt8bridge feedhealth --instrument 'MNQ 09-26' last-tick age (detect FROZEN feed)
   python -m nt8bridge feedwatch  --instrument 'MNQ 09-26' alert on a frozen-but-connected feed (loop)
   python -m nt8bridge connections                read connection status (live/dropped)
+  python -m nt8bridge playback                   replay transport: clock, MOVING?, speed, .nrd coverage
+  python -m nt8bridge ntstatus                   is NT running the code on disk? (catches a stale DLL)
+  python -m nt8bridge workspace                  charts + indicators + strategies AND their enabled state
+  python -m nt8bridge screenshot --title Conductor   capture a window as PNG (see the screen, don't relay it)
   python -m nt8bridge reconnect --name X         reconnect a dropped connection
   python -m nt8bridge connwatch --name X         auto-reconnect inadvertent drops (loop)
   python -m nt8bridge watchdog                   restart NT8 if it hangs/crashes
@@ -441,6 +449,92 @@ def _connections(timeout: float) -> int:
     return 0 if payload.get("status") == "ok" else 1
 
 
+def _playback(instrument: str | None, timeout: float, require_ready: bool) -> int:
+    try:
+        payload = ntplayback.run_playback(instrument, timeout=timeout)
+    except TimeoutError as e:
+        print(json.dumps({"command": "playback", "status": "timeout", "ok": False, "message": str(e)}, indent=2))
+        return 1
+    state = ntplayback.parse_playback_response(payload)
+    ready, why = state.ready_to_seek()
+    out = {"command": "playback"}
+    out.update(payload)
+    # State the judgement, do not leave the caller to derive it from movingSec. The whole point of
+    # this command is that a moving transport is not obvious from a single clock reading.
+    out["readyToSeek"] = ready
+    out["readyReason"] = why
+    print(json.dumps(out, indent=2))
+    if payload.get("status") != "ok":
+        return 1
+    # Reporting state is the default; ASSERTING it is opt-in. A box with no Playback configured is
+    # not a failure of this command, so --require-ready is what a bake script uses to make it one.
+    return 2 if (require_ready and not ready) else 0
+
+
+def _ntstatus(timeout: float) -> int:
+    try:
+        payload = ntntstatus.run_ntstatus(timeout=timeout)
+    except TimeoutError as e:
+        # Degrade rather than fail: a wedged or signed-out NT is exactly when this matters, and the
+        # filesystem half of the answer is still available.
+        built = ntntstatus.dll_built_utc()
+        print(json.dumps({
+            "command": "ntstatus", "status": "timeout", "ok": False, "message": str(e),
+            "dllOnDisk": {"path": str(ntntstatus.custom_dll_path()),
+                          "builtUtc": built.isoformat() if built else None},
+            "note": "AddOn did not answer — NT8 down, not signed in, or NT8BridgeServer not loaded. "
+                    "DLL build time above is from the filesystem.",
+        }, indent=2))
+        return 1
+    st = ntntstatus.assess(payload)
+    out = {"command": "ntstatus"}
+    out.update(payload)
+    out["stale"] = st.stale
+    out["verdict"] = st.reason
+    print(json.dumps(out, indent=2))
+    # A stale assembly is a FAILING condition, not a note: acting on it is a restart.
+    if payload.get("status") != "ok":
+        return 1
+    return 2 if st.stale else 0
+
+
+def _workspace(strategy: str | None, timeout: float) -> int:
+    try:
+        payload = ntworkspace.run_workspace(timeout=timeout)
+    except TimeoutError as e:
+        print(json.dumps({"command": "workspace", "status": "timeout", "ok": False, "message": str(e)}, indent=2))
+        return 1
+    state = ntworkspace.parse_workspace_response(payload)
+    out = {"command": "workspace"}
+    out.update(payload)
+    rc = 0 if payload.get("status") == "ok" else 1
+    if strategy:
+        ok, why = state.strategy_running(strategy)
+        out["strategyQuery"] = strategy
+        out["strategyRunning"] = ok
+        out["strategyReason"] = why
+        if rc == 0 and not ok:
+            rc = 2
+    print(json.dumps(out, indent=2))
+    return rc
+
+
+def _screenshot(title: str | None, hwnd: int | None, out: str | None, timeout: float) -> int:
+    try:
+        payload = ntscreenshot.run_screenshot(title, hwnd, out, timeout=timeout)
+    except TimeoutError as e:
+        print(json.dumps({"command": "screenshot", "status": "timeout", "ok": False, "message": str(e)}, indent=2))
+        return 1
+    result = {"command": "screenshot"}
+    result.update(payload)
+    if payload.get("status") == "ok":
+        # A valid PNG is not evidence that anything was captured — a session-0 grab produces a
+        # perfectly well-formed black frame. Flag the suspicion; the answer is to look at the image.
+        result["looksBlank"] = ntscreenshot.looks_blank(payload.get("path", ""))
+    print(json.dumps(result, indent=2))
+    return 0 if payload.get("status") == "ok" else 1
+
+
 def _reconnect(name: str, timeout: float) -> int:
     try:
         payload = ntreconnect.run_reconnect(name, timeout=timeout)
@@ -615,6 +709,21 @@ def main(argv: list[str]) -> int:
     p_watch.add_argument("--once", action="store_true", help="single scan (no loop) — for testing")
     p_conns = sub.add_parser("connections")
     p_conns.add_argument("--timeout", type=float, default=15.0)
+    p_pb = sub.add_parser("playback", help="replay transport state: clock, MOVING?, speed, .nrd coverage")
+    p_pb.add_argument("--instrument", help="limit .nrd coverage to one instrument (default: all)")
+    p_pb.add_argument("--require-ready", action="store_true",
+                      help="exit 2 unless the transport is connected, loaded and PARKED (for bake scripts)")
+    p_pb.add_argument("--timeout", type=float, default=30.0)
+    p_nts = sub.add_parser("ntstatus", help="is NT running the code on disk? exit 2 if the DLL is newer")
+    p_nts.add_argument("--timeout", type=float, default=15.0)
+    p_shot = sub.add_parser("screenshot", help="capture a window (or the whole screen) as PNG")
+    p_shot.add_argument("--title", help="substring of the window caption (case-insensitive)")
+    p_shot.add_argument("--hwnd", type=int, help="exact HWND from `windows`")
+    p_shot.add_argument("--out", help="PNG path ON THE NODE (default: NT8Bridge\\result\\shot_<id>.png)")
+    p_shot.add_argument("--timeout", type=float, default=30.0)
+    p_ws = sub.add_parser("workspace", help="charts, indicators, strategies + enabled state")
+    p_ws.add_argument("--strategy", help="assert a strategy matching this fragment is enabled (exit 2 if not)")
+    p_ws.add_argument("--timeout", type=float, default=30.0)
     p_recon = sub.add_parser("reconnect")
     p_recon.add_argument("--name", required=True, help="connection name to reconnect (REQUIRED)")
     p_recon.add_argument("--timeout", type=float, default=30.0)
@@ -722,6 +831,14 @@ def main(argv: list[str]) -> int:
         return _watch(args.name, args.grace, args.interval, args.once)
     if args.command == "connections":
         return _connections(args.timeout)
+    if args.command == "playback":
+        return _playback(args.instrument, args.timeout, args.require_ready)
+    if args.command == "ntstatus":
+        return _ntstatus(args.timeout)
+    if args.command == "screenshot":
+        return _screenshot(args.title, args.hwnd, args.out, args.timeout)
+    if args.command == "workspace":
+        return _workspace(args.strategy, args.timeout)
     if args.command == "reconnect":
         return _reconnect(args.name, args.timeout)
     if args.command == "connwatch":

--- a/nt8bridge/ntstatus.py
+++ b/nt8bridge/ntstatus.py
@@ -1,0 +1,128 @@
+"""Is the code NinjaTrader is RUNNING the code that is on disk?
+
+WHY THIS EXISTS
+    2026-08-02. A box ran an AddOn build for 33 minutes while the source on disk said a newer
+    version — a deploy had copied source without rebuilding the assembly, and NT had not been
+    restarted. Every conclusion drawn from that run was worthless. The version was displayed on
+    screen the entire time and went unread.
+
+    Comparing PROCESS START against ASSEMBLY BUILD makes that failure impossible to miss, and
+    unlike a chip on a panel it can be read across a fleet in one command.
+
+TWO SOURCES ON PURPOSE
+    The AddOn answers from inside NinjaTrader, because only that process knows which assembly it
+    actually loaded. This module ALSO stats the DLL on disk directly. The two can disagree — and
+    that disagreement is the finding, not an error.
+
+    The filesystem half also works when the AddOn does not answer at all, which is exactly when you
+    most want an answer: a wedged or not-yet-signed-in NT still has a process start time and a DLL
+    mtime. A timeout therefore degrades to a partial result rather than to nothing.
+
+JSON contract (the in-NT8 AddOn honors):
+  request : {"id": str, "kind": "ntstatus"}
+  response: {"id": str, "status": "ok"|"error", "ts": str, "pid": int,
+             "processStartUtc": str, "ntVersion": str, "userDataDir": str,
+             "loadedAssembly": {"version": str|None, "location": str|None,
+                                "inMemory": bool, "builtUtc": str|None},
+             "dllOnDisk": {"path": str, "builtUtc": str|None},
+             "assemblyOlderThanDisk": bool, "errors": [...]}
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from nt8bridge import ntio
+from nt8bridge.compile import new_request_id
+
+
+@dataclass
+class NtStatus:
+    ok: bool
+    stale: bool = False
+    reason: str = ""
+    pid: int | None = None
+    process_start: str | None = None
+    dll_built: str | None = None
+
+
+def build_ntstatus_request(request_id: str) -> dict:
+    return {"id": request_id, "kind": "ntstatus"}
+
+
+def custom_dll_path() -> Path:
+    return ntio.nt8_root() / "bin" / "Custom" / "NinjaTrader.Custom.dll"
+
+
+def dll_built_utc() -> datetime | None:
+    """Build time of NinjaTrader.Custom.dll on disk, or None if it is not there."""
+    p = custom_dll_path()
+    try:
+        return datetime.fromtimestamp(p.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return None
+
+
+def _parse(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def assess(payload: dict) -> NtStatus:
+    """Turn the raw payload into the one judgement callers actually want.
+
+    STALE means the assembly on disk was built AFTER this NinjaTrader process started, so the
+    running process cannot be executing it. That is the 33-minute-wasted-cell condition, and the
+    fix for it is a restart, not another deploy.
+    """
+    if payload.get("status") != "ok":
+        return NtStatus(ok=False, reason="AddOn returned status=" + str(payload.get("status")))
+
+    start = _parse(payload.get("processStartUtc"))
+    disk = _parse((payload.get("dllOnDisk") or {}).get("builtUtc"))
+    if start is None or disk is None:
+        return NtStatus(
+            ok=True,
+            stale=False,
+            reason="cannot compare (missing process start or DLL build time)",
+            pid=payload.get("pid"),
+            process_start=payload.get("processStartUtc"),
+            dll_built=(payload.get("dllOnDisk") or {}).get("builtUtc"),
+        )
+
+    stale = disk > start
+    mins = abs((disk - start).total_seconds()) / 60.0
+    reason = (
+        f"DLL built {mins:.0f} min AFTER NT started — NT is running older code; restart it"
+        if stale
+        else f"NT started {mins:.0f} min after the DLL was built — running current code"
+    )
+    return NtStatus(
+        ok=True,
+        stale=stale,
+        reason=reason,
+        pid=payload.get("pid"),
+        process_start=payload.get("processStartUtc"),
+        dll_built=(payload.get("dllOnDisk") or {}).get("builtUtc"),
+    )
+
+
+def run_ntstatus(timeout: float = 15.0) -> dict:
+    """Read process/assembly identity from the in-NT8 AddOn.
+
+    Raises TimeoutError if the AddOn does not respond; callers that want the degraded filesystem
+    answer should catch it and fall back to `dll_built_utc()`.
+    """
+    trigger, result = ntio.ensure_bridge_dirs()
+    request_id = new_request_id()
+    ntio.atomic_write_json(
+        trigger / f"ntstatus_{request_id}.json",
+        build_ntstatus_request(request_id),
+    )
+    return ntio.poll_for_json(result / f"ntstatus_{request_id}.json", timeout=timeout)

--- a/nt8bridge/playback.py
+++ b/nt8bridge/playback.py
@@ -1,0 +1,126 @@
+"""Market Replay transport state (request builder + response parser).
+
+WHY THIS EXISTS
+    2026-08-02. A replay-equivalence run compared two boxes proven byte-identical in every input
+    that had been made verifiable — code, replay `.nrd`, historical bars, and the serialised
+    chart+strategy blob. It still diverged: one box's replay clock was parked at the loaded range
+    start, the other's was 27 hours in and moving, so the same seek landed on one and silently
+    no-opped on the other.
+
+    Every input we could check was a FILE we could hash. The transport's own state lives only
+    inside a running NinjaTrader — no file, no hash, no read-back — so it was the one input still
+    set by hand, per box, at different moments. This command gives it a read-back.
+
+WHAT `movingSec` IS FOR
+    A single clock reading cannot tell a parked transport from a running one, and that distinction
+    is precisely what broke the run. The AddOn samples NowEst twice a real gap apart and reports the
+    delta, so the answer is measured rather than inferred.
+
+WHAT `coverage` IS FOR
+    `GetReplayMinMaxDates` per `.nrd`, straight from NT's own reader. This is NOT the Playback
+    slider: the slider's bounds are the CONNECTION range you typed, not the indexed data, and
+    reading it as proof that data was loaded cost hours on the same day.
+
+JSON contract (the in-NT8 AddOn honors):
+  request : {"id": str, "kind": "playback", "instrument": str|None}
+  response: {"id": str, "status": "ok"|"error", "ts": str,
+             "transportResolved": bool,
+             "connection": {"status": str, "connected": bool},
+             "clockEst": str|None, "clockEstFirst": str|None,
+             "sampleMs": int, "movingSec": float, "moving": bool,
+             "speed": int|None, "maxSpeedValue": int|None,
+             "coverage": [{"instrument": str, "files": int, "readable": int, "unreadable": int,
+                           "from": str|None, "to": str|None, "days": [...]}],
+             "errors": [...]}
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from nt8bridge import ntio
+from nt8bridge.compile import new_request_id
+
+
+@dataclass
+class PlaybackState:
+    ok: bool
+    connected: bool = False
+    moving: bool = False
+    clock_est: str | None = None
+    speed: int | None = None
+    coverage: list[dict] = field(default_factory=list)
+    errors: list[dict] = field(default_factory=list)
+
+    def span(self, instrument: str) -> tuple[str | None, str | None]:
+        """(from, to) across every readable .nrd for `instrument`, or (None, None)."""
+        for c in self.coverage:
+            if c.get("instrument") == instrument:
+                return c.get("from"), c.get("to")
+        return None, None
+
+    def clock_unset(self) -> bool:
+        """Is the replay clock at NT's far-future 'nothing loaded' sentinel?
+
+        A connected Playback with no replay data loaded reads back 2099-12-01 and speed 0 — which
+        is *stationary*, and so passed the moving/not-moving test as READY on the first live run.
+        A transport with no data is the emptiest possible kind of not-ready, and calling it ready
+        is exactly the success-shaped nothing these commands exist to stop.
+        """
+        return bool(self.clock_est) and self.clock_est[:4] >= "2090"
+
+    def ready_to_seek(self) -> tuple[bool, str]:
+        """Is this transport in a state a seek can be trusted from?
+
+        Measured, not assumed: a moving transport is the state in which Reset() has been observed
+        to no-op. Returns (ok, why) so the caller can print the reason rather than a bare False.
+        """
+        if not self.ok:
+            return False, "playback state unavailable"
+        if not self.connected:
+            return False, "playback connection is not connected"
+        if self.clock_unset():
+            return False, (f"replay clock reads {self.clock_est} — NT's 'no replay data loaded' "
+                           "sentinel. Connected is not the same as loaded.")
+        if self.moving:
+            return False, f"replay clock is advancing (clock {self.clock_est}) — playback is running"
+        if not any(c.get("readable", 0) for c in self.coverage):
+            return False, "no readable .nrd files on disk — nothing to replay"
+        return True, f"transport parked at {self.clock_est}"
+
+
+def build_playback_request(request_id: str, instrument: str | None = None) -> dict:
+    req = {"id": request_id, "kind": "playback"}
+    if instrument:
+        req["instrument"] = instrument
+    return req
+
+
+def parse_playback_response(payload: dict) -> PlaybackState:
+    conn = payload.get("connection") or {}
+    return PlaybackState(
+        ok=payload.get("status") == "ok",
+        connected=bool(conn.get("connected")),
+        moving=bool(payload.get("moving")),
+        clock_est=payload.get("clockEst"),
+        speed=payload.get("speed"),
+        coverage=payload.get("coverage", []),
+        errors=payload.get("errors", []),
+    )
+
+
+def run_playback(instrument: str | None = None, timeout: float = 30.0) -> dict:
+    """Read replay transport state from the in-NT8 AddOn.
+
+    Returns the raw response payload. Raises TimeoutError if the AddOn does not respond — itself
+    diagnostic: NT8 is down, or NT8BridgeServer is not loaded/compiled.
+
+    Note the default timeout is higher than most read commands: the handler deliberately sleeps
+    between its two clock samples, and coverage walks every .nrd on disk.
+    """
+    trigger, result = ntio.ensure_bridge_dirs()
+    request_id = new_request_id()
+    ntio.atomic_write_json(
+        trigger / f"playback_{request_id}.json",
+        build_playback_request(request_id, instrument),
+    )
+    return ntio.poll_for_json(result / f"playback_{request_id}.json", timeout=timeout)

--- a/nt8bridge/screenshot.py
+++ b/nt8bridge/screenshot.py
@@ -1,0 +1,67 @@
+"""Capture what a NinjaTrader node's screen actually says.
+
+WHY THIS EXISTS
+    2026-08-02, and it is a process failure rather than a code one. A replay would not seek on one
+    node. Every diagnosis was made by asking the operator what was on their screen and reasoning
+    about the answer — and the reasoning was wrong, repeatedly, because a relayed screen is a lossy
+    channel. The Playback window and the Conductor panel were showing two DIFFERENT clock values the
+    entire time and nobody caught it, because nobody was looking at both at once.
+
+    A fleet of six headless replay workers cannot be operated by a human describing a window. This
+    is the read-only sibling of `windows`: that command reports a window EXISTS, this one reports
+    what it SAYS.
+
+WHY THE CAPTURE HAPPENS INSIDE NT
+    SSH lands in session 0, which owns no desktop. A capture taken from there is black — and black
+    is worse than an error, because it looks like an answer. The AddOn runs in the interactive
+    session where the pixels are.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from nt8bridge import ntio
+from nt8bridge.compile import new_request_id
+
+
+def build_screenshot_request(request_id: str, title: str | None = None,
+                             hwnd: int | None = None, out: str | None = None) -> dict:
+    """Target precedence matches the AddOn: hwnd, then title, else the whole virtual screen."""
+    req = {"id": request_id, "kind": "screenshot"}
+    if hwnd is not None:
+        req["hwnd"] = str(hwnd)
+    elif title:
+        req["title"] = title
+    if out:
+        req["out"] = out
+    return req
+
+
+def run_screenshot(title: str | None = None, hwnd: int | None = None,
+                   out: str | None = None, timeout: float = 30.0) -> dict:
+    """Capture on the node and return the payload (including the PNG path ON THAT NODE).
+
+    Pulling the file back to the caller is a separate step — see `cli._screenshot` — because on a
+    remote node that is an scp, and this module has no business knowing the transport.
+    """
+    trigger, result = ntio.ensure_bridge_dirs()
+    request_id = new_request_id()
+    ntio.atomic_write_json(
+        trigger / f"screenshot_{request_id}.json",
+        build_screenshot_request(request_id, title, hwnd, out),
+    )
+    return ntio.poll_for_json(result / f"screenshot_{request_id}.json", timeout=timeout)
+
+
+def looks_blank(path: str | Path) -> bool:
+    """Cheap sanity check: is this PNG suspiciously small for its dimensions?
+
+    A session-0 capture, an occluded window, or a failed render all produce a valid PNG file — so
+    'the command succeeded' is not evidence that anything was captured. PNG compresses a uniformly
+    black frame to almost nothing, so a few-KB file for a full window is the tell. This is a HINT,
+    never a verdict: the answer is to look at the image.
+    """
+    try:
+        return Path(path).stat().st_size < 8192
+    except OSError:
+        return True

--- a/nt8bridge/workspace.py
+++ b/nt8bridge/workspace.py
@@ -1,0 +1,111 @@
+"""What is actually on each chart — instrument, bar type, indicators, strategies and their State.
+
+WHY THIS EXISTS
+    2026-08-02. Two replay runs were lost to a strategy that was silently DISABLED. Toggling the
+    Playback connection disables chart strategies, and a workspace restored on an unattended boot
+    can come back with the strategy off. Neither case announces itself: the replay runs, the clock
+    advances, the panel looks healthy, and the corpus comes back empty an hour later.
+
+    "Is my strategy enabled, on both boxes?" should be one command, not an RDP session per box.
+
+READING `state`
+    NT's own State enum is passed through verbatim — Active / Realtime / Historical / Terminated —
+    because the raw value is the evidence. `enabled` is a convenience derived from it, and where the
+    two ever disagree, believe `state`.
+
+`null` IS NOT `[]`
+    When the AddOn cannot resolve a member it emits null, never an empty list. A chart we could not
+    read and a chart with no strategies are different claims, and collapsing them is how "the run
+    produced nothing" gets mistaken for "the run was fine".
+
+JSON contract (the in-NT8 AddOn honors):
+  request : {"id": str, "kind": "workspace"}
+  response: {"id": str, "status": "ok"|"error", "ts": str,
+             "workspace": str|None, "chartCount": int,
+             "charts": [{"title": str, "type": str, "chartControlResolved": bool,
+                         "instrument": str|None, "barsPeriod": str|None,
+                         "indicators": [{"name","type","state","enabled"}]|None,
+                         "strategies": [{"name","type","state","enabled"}]|None}],
+             "notes": [str], "errors": [...]}
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from nt8bridge import ntio
+from nt8bridge.compile import new_request_id
+
+
+@dataclass
+class WorkspaceState:
+    ok: bool
+    workspace: str | None = None
+    charts: list[dict] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    errors: list[dict] = field(default_factory=list)
+
+    def enabled_strategies(self) -> list[dict]:
+        """Every enabled strategy across every chart, each tagged with its chart title."""
+        out = []
+        for c in self.charts:
+            for s in c.get("strategies") or []:
+                if s.get("enabled"):
+                    out.append({**s, "chart": c.get("title")})
+        return out
+
+    def strategy_running(self, name_fragment: str) -> tuple[bool, str]:
+        """Is a strategy whose name contains `name_fragment` enabled on any chart?
+
+        Matches on a FRAGMENT so a version bump cannot silently turn the check into a no-match —
+        the same reasoning the suite uses when detecting sibling indicators by type-name prefix.
+        Returns (ok, why) so a caller can report the reason rather than a bare False.
+        """
+        frag = name_fragment.lower()
+        seen = []
+        for c in self.charts:
+            strategies = c.get("strategies")
+            if strategies is None:
+                continue
+            for s in strategies:
+                # Match name OR type. A Sentinel tool blanks its Name at DataLoaded to hide the
+                # on-chart label, so `name` is frequently "" and only `type` carries the identity —
+                # a name-only match silently found nothing the first time this ran for real.
+                nm = s.get("name") or ""
+                ty = s.get("type") or ""
+                if frag not in nm.lower() and frag not in ty.lower():
+                    continue
+                seen.append(f"{nm or ty} on {c.get('title')} = {s.get('state')}")
+                if s.get("enabled"):
+                    return True, seen[-1]
+        if seen:
+            return False, "found but not enabled: " + "; ".join(seen)
+        return False, f"no strategy matching '{name_fragment}' on any chart"
+
+
+def build_workspace_request(request_id: str) -> dict:
+    return {"id": request_id, "kind": "workspace"}
+
+
+def parse_workspace_response(payload: dict) -> WorkspaceState:
+    return WorkspaceState(
+        ok=payload.get("status") == "ok",
+        workspace=payload.get("workspace"),
+        charts=payload.get("charts", []),
+        notes=payload.get("notes", []),
+        errors=payload.get("errors", []),
+    )
+
+
+def run_workspace(timeout: float = 30.0) -> dict:
+    """Read chart/indicator/strategy inventory from the in-NT8 AddOn.
+
+    Timeout is generous because the handler marshals to EVERY chart window's own dispatcher — NT is
+    multi-UI-threaded, so a busy chart answers slowly rather than not at all.
+    """
+    trigger, result = ntio.ensure_bridge_dirs()
+    request_id = new_request_id()
+    ntio.atomic_write_json(
+        trigger / f"workspace_{request_id}.json",
+        build_workspace_request(request_id),
+    )
+    return ntio.poll_for_json(result / f"workspace_{request_id}.json", timeout=timeout)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nt8bridge"
-version = "1.3.0"
+version = "1.5.0"
 license = {text = "MIT"}
 requires-python = ">=3.10"
 # numpy + pyarrow are required: histdump's default engine decodes .nrd offline to parquet.

--- a/tests/test_state_commands.py
+++ b/tests/test_state_commands.py
@@ -1,0 +1,172 @@
+"""playback / ntstatus / workspace — the read-only state commands.
+
+Every case below is a condition that actually occurred on 2026-08-02, not a hypothetical. The two
+marked REGRESSION are defects found by running the commands against a live NinjaTrader half an hour
+after they were written, which is the only reason they are here rather than in production.
+"""
+from nt8bridge import ntstatus as ntntstatus
+from nt8bridge import playback as ntplayback
+from nt8bridge import workspace as ntworkspace
+
+
+# ---- playback ----
+
+def test_playback_build_request():
+    assert ntplayback.build_playback_request("id1") == {"id": "id1", "kind": "playback"}
+    req = ntplayback.build_playback_request("id2", "NQ 06-26")
+    assert req["instrument"] == "NQ 06-26"
+
+
+def _pb(**over):
+    payload = {
+        "status": "ok",
+        "connection": {"status": "Connected", "connected": True},
+        "clockEst": "2026-04-20T00:00:00.0000000",
+        "moving": False,
+        "speed": 0,
+        "coverage": [{"instrument": "NQ 06-26", "files": 4, "readable": 4,
+                      "from": "2026-04-19T23:00:00", "to": "2026-04-23T22:59:00"}],
+    }
+    payload.update(over)
+    return ntplayback.parse_playback_response(payload)
+
+
+def test_parked_transport_with_data_is_ready():
+    ok, why = _pb().ready_to_seek()
+    assert ok is True
+    assert "parked" in why
+
+
+def test_moving_transport_is_refused():
+    """The Gate 3 divergence: node01's clock was parked and seeked; sentry-1's was moving and the
+    identical Reset() call silently no-opped."""
+    ok, why = _pb(moving=True, clockEst="2026-04-21T02:53:52").ready_to_seek()
+    assert ok is False
+    assert "advancing" in why
+
+
+def test_disconnected_is_refused():
+    ok, why = _pb(connection={"status": "Disconnected", "connected": False}).ready_to_seek()
+    assert ok is False
+    assert "not connected" in why
+
+
+def test_unset_clock_is_refused_even_though_it_is_stationary():
+    """REGRESSION. A connected Playback with nothing loaded reads 2099-12-01 at speed 0 — perfectly
+    stationary, and so passed the moving/not-moving test as READY on the first live run. A transport
+    with no data is the emptiest kind of not-ready; reporting it green is the exact success-shaped
+    nothing these commands exist to prevent."""
+    st = _pb(clockEst="2099-12-01T00:00:00.0000000", coverage=[])
+    assert st.clock_unset() is True
+    ok, why = st.ready_to_seek()
+    assert ok is False
+    assert "no replay data loaded" in why
+
+
+def test_no_readable_nrd_is_refused():
+    ok, why = _pb(coverage=[{"instrument": "NQ 06-26", "files": 3, "readable": 0}]).ready_to_seek()
+    assert ok is False
+    assert "no readable" in why
+
+
+def test_span_lookup():
+    st = _pb()
+    assert st.span("NQ 06-26") == ("2026-04-19T23:00:00", "2026-04-23T22:59:00")
+    assert st.span("ES 06-26") == (None, None)
+
+
+# ---- ntstatus ----
+
+def test_stale_when_dll_is_newer_than_the_process():
+    """The 33-minute wasted cell: source deployed, assembly never rebuilt, NT never restarted."""
+    st = ntntstatus.assess({
+        "status": "ok", "pid": 1234,
+        "processStartUtc": "2026-08-02T21:13:01Z",
+        "dllOnDisk": {"builtUtc": "2026-08-02T21:16:43Z"},
+    })
+    assert st.ok is True and st.stale is True
+    assert "restart it" in st.reason
+
+
+def test_not_stale_when_the_process_started_after_the_build():
+    st = ntntstatus.assess({
+        "status": "ok",
+        "processStartUtc": "2026-08-02T21:13:01Z",
+        "dllOnDisk": {"builtUtc": "2026-08-02T21:10:59Z"},
+    })
+    assert st.stale is False
+    assert "running current code" in st.reason
+
+
+def test_missing_timestamps_do_not_silently_pass_as_fresh():
+    """Absence is reported as 'cannot compare', never as 'not stale' — a check that could not look
+    must not answer."""
+    st = ntntstatus.assess({"status": "ok", "processStartUtc": None, "dllOnDisk": {}})
+    assert st.stale is False
+    assert "cannot compare" in st.reason
+
+
+def test_error_payload_is_not_ok():
+    assert ntntstatus.assess({"status": "error"}).ok is False
+
+
+# ---- workspace ----
+
+def _ws(strategies):
+    return ntworkspace.parse_workspace_response({
+        "status": "ok", "workspace": "Gate3", "chartCount": 1,
+        "charts": [{"title": "Chart - NQ 06-26", "instrument": "NQ 06-26 Globex",
+                    "barsPeriod": "1 Minute", "indicators": [], "strategies": strategies}],
+    })
+
+
+def test_enabled_strategy_is_found():
+    ok, why = _ws([{"name": "Sentinel Keel", "type": "SentinelKeel", "state": "Realtime", "enabled": True}]) \
+        .strategy_running("Keel")
+    assert ok is True and "Realtime" in why
+
+
+def test_disabled_strategy_is_reported_as_found_but_off():
+    """Toggling the Playback connection disables chart strategies. 'Present but off' and 'absent'
+    need different fixes, so they must not collapse to the same answer."""
+    ok, why = _ws([{"name": "Sentinel Keel", "type": "SentinelKeel", "state": "Terminated", "enabled": False}]) \
+        .strategy_running("Keel")
+    assert ok is False
+    assert "found but not enabled" in why
+
+
+def test_matches_on_type_when_the_name_is_blank():
+    """REGRESSION. Sentinel tools BLANK their own Name at DataLoaded — the on-chart label IS the
+    Name property — so name-only matching found nothing on the first live run against a real chart."""
+    ok, why = _ws([{"name": "", "type": "SentinelKeel_v0_1_0", "state": "Realtime", "enabled": True}]) \
+        .strategy_running("keel")
+    assert ok is True
+    assert "SentinelKeel_v0_1_0" in why
+
+
+def test_absent_strategy_says_absent():
+    ok, why = _ws([]).strategy_running("Keel")
+    assert ok is False
+    assert "no strategy matching" in why
+
+
+def test_unreadable_chart_is_skipped_not_counted_as_empty():
+    """`strategies: null` means the member did not resolve; it is NOT an empty list. Treating the
+    two alike would let an unreadable chart read as a chart with nothing on it."""
+    state = ntworkspace.parse_workspace_response({
+        "status": "ok",
+        "charts": [{"title": "Chart - NQ 06-26", "strategies": None},
+                   {"title": "Chart - ES 06-26",
+                    "strategies": [{"name": "Sentinel Keel", "type": "SentinelKeel",
+                                    "state": "Realtime", "enabled": True}]}],
+    })
+    ok, why = state.strategy_running("Keel")
+    assert ok is True and "ES 06-26" in why
+
+
+def test_enabled_strategies_are_tagged_with_their_chart():
+    state = _ws([{"name": "Sentinel Keel", "type": "SentinelKeel", "state": "Realtime", "enabled": True},
+                 {"name": "Other", "type": "Other", "state": "Terminated", "enabled": False}])
+    got = state.enabled_strategies()
+    assert len(got) == 1
+    assert got[0]["chart"] == "Chart - NQ 06-26"


### PR DESCRIPTION
Four **read-only** commands that answer questions which previously required an RDP session. None of them mutate NinjaTrader state. Independent of #2 — this branch is cut from current `main` and the two can merge in either order.

| command | answers |
|---|---|
| `playback` | connection + replay clock **sampled twice a real gap apart** + speed + per-`.nrd` coverage |
| `ntstatus` | is NinjaTrader running the code on disk? (**exit 2** when the DLL is newer than the process) |
| `workspace` | charts + indicators + strategies **and their `State`** |
| `screenshot` | capture a window or the screen as PNG |

Each exists because of a specific failure that cost real time:

- **`playback`** — a single clock reading cannot distinguish a parked transport from a running one, and that distinction blocked a replay-equivalence gate for a day: the same seek landed on a parked clock and silently no-opped on a moving one. Coverage comes from NinjaTrader's own `GetReplayMinMaxDates`, **not the Playback slider** — the slider's bounds are the connection range you typed, not the indexed data, and reading it as proof that data was loaded cost hours on the same day.
- **`ntstatus`** — the stale-DLL condition once ran a 33-minute cell against code the operator believed had been replaced. On a timeout it degrades rather than fails: a wedged or signed-out NinjaTrader is exactly when this matters, and the filesystem half of the answer is still available.
- **`workspace`** — toggling Playback silently disables chart strategies. It reports `null`, never `[]`, when a member does not resolve: an unreadable chart and an empty chart are different claims and must not share a representation.
- **`screenshot`** — ⚠ **must run inside NinjaTrader.** SSH lands in session 0, which owns no desktop, and a session-0 capture returns **black, which looks like an answer** rather than an error. GDI `PrintWindow` + `PW_RENDERFULLCONTENT`, encoded through WPF's `PngBitmapEncoder`, so no `System.Drawing` reference and no dispatcher is required.

### Two defects these found in themselves, within an hour of first use

Both are now regression tests, and they're the reason I'd argue for the commands rather than against:

- `playback` reported **ready** for a transport reading `2099-12-01` with nothing loaded. It was stationary, so it passed the moving/not-moving test — a false green of exactly the kind this command exists to eliminate.
- `workspace` matched strategies on `name` only. Tools that blank their own `Name` at `DataLoaded` (the on-chart label *is* the `Name` property) were invisible to it, so it found nothing on a real chart. Now matches name **or** type.

### Implementation notes

`PlaybackAdapter` members are bound by **reflection**, not directly. NinjaTrader compiles every `.cs` under `bin\Custom` into one assembly, so a hard binding to an internal API turns any NinjaTrader change into a whole-tree compile break — which takes down every unrelated tool sharing that tree.

`workspace` marshals to **each chart window's own dispatcher** with a bounded wait, consistent with the multi-UI-thread finding in 1.3.0's implementer notes.

### Versioning

Numbered **1.5.0** purely to stay clear of the in-flight 1.4.0 in #2. Happy to renumber to whatever fits your release order — say the word and I'll rebase.

`204 passed, 6 skipped` (current `main` baseline: `187 passed, 6 skipped`), **+17**.
