### PR TITLE
playbackrun: drive the Playback connection end to end (Market Replay …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 *.egg-info/
 *.pdf
 *.png
+
+# run transcripts written by playbackrun
+logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,384 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`optimize`, `walkforward`, `multiobjective`: NinjaTrader's own parameter search on the
+  Strategy Analyzer tab, with the headless runner's option syntax.**
+
+  One request kind, `analyzerrun`, serves the three commands. The AddOn puts the template on
+  the tab (as `satemplate`), writes the `--Name=value` overrides, fills the template's
+  `OptimizationParameters` from `--opt=Name:min:max:step[,...]` as NinjaTrader's own
+  `Parameter` objects, sets the optimizer (`default|genetic`), the fitness measure when asked
+  for, the strategy's `Category` and the tab's `BacktestType`, and executes `RunCommand`. The
+  result is read off the results grid once the tab's progress control has gone: one row per
+  new grid entry with window, optimized parameter values, ranges, performance and the
+  optimizer's ranked in-sample results, plus the CSV files the strategy wrote (`--out` copies
+  them as `<out>` / `<out>_<k><ext>` in creation order).
+
+  Measured first: with `BacktestType=WalkForward` set through `configure` and no optimization
+  parameter on the template, the Run button shows `The strategy must have at least one
+  parameter to optimize.` and runs nothing (NinjaTrader 8.1.8.2, 2026-09-08) — which is why
+  the ranges are written by the AddOn and a request without `--opt` is refused.
+
+  Measured against the headless runner (Nt8Cli `walkforward`, same template, same strategy
+  sources, 2026-09-08): 4 windows, out-of-sample parameter 250/250/250/150 with 7/3/14/3
+  trades on both hosts, in-sample ranking per window identical, 11 of 11 CSVs written on both
+  sides byte-identical (all 4 out-of-sample files among them); the grid held one summary
+  entry, one WalkForward entry per window and one Optimize entry per combination, the same
+  Guid on two entry objects, `OptimizationResults` empty everywhere - hence the rows are made
+  unique by Guid and the ranking is read from the Optimize entries' performance value.
+  Re-measured 2026-09-09 after those changes: 17 rows (one summary, four windows, twelve
+  combinations, no Guid twice), `parameters` carrying only the optimized name, `windows` and
+  `rankedWindows` 4, the template path echoed as sent, and only the run's own
+  `ntbridge-RoadToSuccess*.csv` files listed while eight headless runners wrote into the same
+  folder; out-of-sample 250/250/250/150 with 7/3/14/3 trades as before.
+
+### Fixed
+
+- **The driver lease no longer expires inside a long stage — the AddOn counts from the
+  answer, and a finished run releases the lease.**
+
+  Every request carries `leaseSec` (120): if the driver stops sending requests for that
+  long, the AddOn assumes it died and restores the baseline itself. The deadline was taken
+  at the RECEIPT of a request. A stage that runs longer than the lease — the first Playback
+  connect after a NinjaTrader start takes minutes — therefore outlived its own lease, and
+  on the poller's next tick the AddOn tore down what the stage had just built. Measured
+  2026-09-07 08:23 (`bridge.log` against NinjaTrader's trace): connect received with
+  `leaseSec 120`, `Connected` after 282 s at 08:23:17, then
+  `LEASE EXPIRED - the driver is gone. Restoring the baseline.` and
+  `Cbi.Connection.Disconnect` at 08:23:21.428 — the same millisecond in both files. The
+  driver was alive throughout, polling for the result; a synchronous stage gives it nothing
+  to send. The same line precedes every failed run of 2026-09-03 whose connect took longer
+  than 120 s (`__76`–`__81`: 225–385 s), and the run then died one to three stages later
+  with `Playback window not found`, `panel usable - STILL not usable` or
+  `5 range: Reset - TargetInvocationException`, none of which named the cause.
+
+  `HandleTrigger` now re-arms the lease in its `finally`: a request that has just been
+  answered is the proof of life, so the 120 s run from there. The AddOn cannot check the
+  lease WHILE a stage executes (one poller thread, one gate), so no stage duration can
+  ever expire it. The driver's `stage()` takes `lease` (default 120), and the run's last
+  two requests — the `restore` stage and the bot-output fetch after it — send `lease=0`,
+  the AddOn's clean exit: before that no request sent 0 (one write site, a constant), so
+  every finished run left a lease that fired a second, pointless restore two minutes later
+  (`bridge.log` 2026-09-07 06:24:01Z and 06:26:06Z after the 08:24:09 teardown).
+
+- **`playbackrun` opens NinjaTrader's Playback window itself (stage `openwindow`).**
+
+  Every stage that writes the panel — the source radios, the date editors, the speed,
+  the transport — looks the window up with `FindWindowByTitle("Playback")`, and nothing
+  in the run opened it. NinjaTrader does not persist that window in a workspace
+  (measured 2026-08-29 after a restart: 52 windows loaded across all 7 open workspaces,
+  none titled `Playback`), so after every NinjaTrader start the first run died at the
+  source check. Measured 2026-09-03: three attempts inside one call, each `rc 2`,
+  `3 source check: panel radios - Playback window not found`, each after a healthy
+  connect (`SLOW CONNECT: 225 s … Connected.`) — 1238 s of wall clock for no result.
+
+  The new stage runs before the source check and constructs NinjaTrader's own window
+  type on the UI thread (`NinjaTrader.Gui.Data.PlaybackControlCenter`, parameterless
+  constructor, `Show()`) — no clicks, no UI automation. It is idempotent: an existing
+  window is reported (`already open`) and never duplicated. Measured against a running
+  NinjaTrader 8.1.8.2 the same day: answered in 1.2 s with
+  `open PlaybackControlCenter ok "shown: Playback"` and `window present ok "found"`.
+
+- **`playbackrun` stage 2 (connect) gets its own budget — `CONNECT_WAIT`, min. 600 s.**
+
+  The connect shared `SLOW_WAIT` (2.5 × `--stage-wait`; 49 s at a caller's
+  `--stage-wait 20`). Measured 2026-08-28: of 23 playback connects that day, each took
+  16–30 s — and one sat silently inside `PlaybackAdapter.Connect` for 423 s (no log
+  lines, no disk reads) and then came back **Connected** and healthy. The 49 s bound
+  turned that one slow connect into an ERROR, which ended a ~29 h batch of runs that
+  stops on the first one. The stall is inside NinjaTrader's encrypted Core, so the
+  caller's budget is the only correct place: `CONNECT_WAIT = max(600, SLOW_WAIT)`,
+  and a connect slower than `SLOW_WAIT` is reported loudly
+  (`SLOW CONNECT: … s`) instead of vanishing into a green verdict.
+
+- **`playbackrun` refuses a malformed `--from`/`--to` before anything is sent to NinjaTrader.**
+
+  Both dates go through one validator in the driver (`iso_date`, the argparse `type=` of the
+  CLI's `playbackrun` subparser and of the driver's own parser, plus `date_order_error` for the
+  pair): exactly `YYYY-MM-DD`, a real calendar day, and `--to` not before `--from`.
+  `2026-13-07`, `2026-7-7`, `07/07/2026` or an end before its start are refused by the argument
+  parser — usage line on stderr, exit 2, the accepted form and the offending value in the
+  message — and no trigger file is written, no driver process started. A valid pair travels
+  unchanged: the request JSON and the archive carry the string that was typed.
+
+  Measured 2026-09-01: seven archived runs (05:16–08:23) carried `"to": "2026-13-07"`. Nothing
+  checked the value on the way in — the CLI declared both dates as plain strings and the AddOn
+  hands them to `DateTime.Parse` as they arrive — so every one of them ran stage 1a, lasted
+  45–58 s of wall clock, and died with
+  `2 connect: exception - FormatException: String was not recognized as a valid DateTime.`
+  The shape is pinned by a pattern and not by `date.fromisoformat` alone: on Python 3.11 that
+  also accepts `20260607` and `2026-W23-1`, two shapes nobody documented.
+
+- **`playbackrun --source historical` — the Historical run mode no longer dies on the panel's
+  source radios, the modal notice, or a coverage scan of the wrong store.** (AddOn
+  `NT8BridgeServerPlayback.cs`; measured 2026-08-30/31 in NinjaTrader.)
+
+  - **The source radios are DISPLAY ONLY.** Writing `rbHistoricalData.IsChecked` while the
+    connection is up threw `TargetInvocationException <- FormatException: "String was not
+    recognized as a valid DateTime"` — NinjaTrader re-parses the panel's date fields on that
+    write, the same wording as the modal `(Panic)` it raises when Playback connects without a
+    date range — and took the whole run with it (rc 2). The source itself is decided by
+    `PlaybackAdapter.IsSourceHistoricalData` at stage `3 source`; the radios only keep the
+    panel from contradicting the run. They are now written through a soft step: a refused
+    write is reported (`source radios ... panel keeps the PREVIOUS source ...`) and is never a
+    failure verdict.
+  - **The "no Level II market depth in this mode" notice is dismissed by a watcher armed BEFORE
+    the write.** Switching to Historical makes NinjaTrader raise that modal synchronously inside
+    the `IsChecked` write, so a handler placed after the write never ran (measured 2026-08-30:
+    the dialog came up unchanged). The watcher runs on its own thread, started before the
+    write, confirms through the dispatcher (which keeps pumping inside a modal's own frame),
+    identifies the dialog by its wording alone — text carrying both "Level II market depth" and
+    "Market Replay"; no other dialog is touched — ticks "Don't show this message again" and
+    invokes OK through the button's automation peer. The step `historical notice` reports the
+    outcome.
+  - **The coverage pre-flight asks the store this run reads.** Playback/Historical is served
+    from `db\tick` (NCD); only Market Replay reads `db\replay` (NRD). A Historical run on
+    `MNQ 09-26` was refused with `store scan unavailable, panel range used / requested
+    28.08.2026..28.08.2026 inside it: False` while that day held 24 Ask / 24 Bid / 23 Last NCD
+    files: the instrument has no `.nrd` at all (the recordings live under the continuous name
+    `MNQ ##-##`), so the `db\replay` scan could only return nothing, and the fallback then
+    judged the request against the PREVIOUS run's panel range (27.08.). New `TickCoverage`
+    scans `db\tick\<instrument>\*.ncd` when the trigger's `source` is `historical` — the day is
+    taken from the first 8 name characters, deliberately a pre-flight ("is there anything for
+    that day"); the content is decided when the series loads and a run with missing data still
+    fails loudly there. The step text says `NCD files` vs `files readable` accordingly.
+  - **`SetElementValue` reports the cause, not only the symptom.** A `TargetInvocationException`
+    carries only "the callee threw"; the step text now unwraps `InnerException` up to three
+    levels (`... <- FormatException: ...`). Dropping it had left the log naming a symptom with
+    no cause (measured 2026-08-30 on `rbHistoricalData.IsChecked`).
+
+- **`playbackrun` stage 0 (preflight) waits for a busy NinjaTrader instead of failing —
+  `PREFLIGHT_WAIT`, min. 1800 s — and refuses at once when there is no `NinjaTrader.exe` process.**
+
+  The preflight asked ONE `transport` question with a 20 s TTL and, on silence, aborted with
+  `preflight: the bridge did not answer` (rc 2, nothing started) and the advice to clear the
+  trigger folder and restart NinjaTrader. Seven archived runs ended that way between
+  2026-08-29 and 2026-09-02 (`NT8Bridge/runs/*/result.json`, every one with
+  `wallClockSeconds` 88.3–88.4). For the last of them NinjaTrader's own log shows what it was
+  doing: a Playback connect from 05:15:46 to 05:22:14 — 388 s — and the run's result.json is
+  stamped 05:20:59, inside that window. The AddOn's poller handles one trigger at a time on one
+  timer thread (`Poll` takes a gate; a tick that finds it taken reads nothing), and
+  `Stage_Connect` runs on that thread — it calls `Connection.Connect` and waits for `Connected`
+  in a sleep loop bounded by the request budget — so until the connect returns no request of
+  any kind is read or answered. `heartbeat.json` cannot tell: `TryBeat` writes it through
+  `Globals.MainThreadDispatcher`, not from the poller thread, so a fresh beat says the UI thread
+  is alive, not that the poller is free. Holds of the same kind measured 423/437/453 s
+  (2026-08-28/29); a cold-started NinjaTrader left its own log silent for 735 s (2026-09-01).
+
+  The preflight is now a poll: it repeats the cheap probe — each with the short 20 s TTL the
+  AddOn honours (`HandleTrigger` discards a trigger older than its `ttlSec` unexecuted), and
+  each unanswered trigger taken back before the next one is written, so nothing piles up —
+  until one is answered or `PREFLIGHT_WAIT = max(1800, SLOW_WAIT)` ends: 2.4× the longest
+  measured silence (735 s) and 4.0–4.6× the measured connects (388–453 s). While it waits the
+  console says so at most every 30 s (`NinjaTrader is busy - no answer for N s, waiting up to
+  M s`), an answer after a wait is reported (`Bridge answered after N s`), and result.json
+  carries `preflightSeconds` so a slow preflight stays visible in the archive instead of hiding
+  inside `wallClockSeconds`.
+
+  One silence is not waited out: no `NinjaTrader.exe` process at all. A stale or absent
+  `heartbeat.json` cannot prove that waiting is useless — the AddOn writes the file only once it
+  has loaded, so a cold start shows the same file while the wait is exactly right — but the
+  process list can: without the process nothing could ever answer. After every unanswered probe
+  the poll therefore reads the process list once (`restart.process_listed`, one `tasklist` call,
+  measured 0.065–0.072 s) and stops on the spot when the list was read and does not name the
+  process — one probe, 26 s, what the single ask cost, instead of the budget. A list that could
+  NOT be read (tasklist missing from PATH, timed out, exit non-zero, no output; measured
+  2026-09-02) is no verdict: it is said once per distinct failure, the silence stays a wait, and
+  the budget-exhausted report calls the process UNKNOWN. The check is made only after an
+  unanswered probe, never before the first one, so a run whose first probe is answered is
+  untouched. The error string is the same in every case — callers match on `preflight: the
+  bridge did not answer` — while the explanation names the cause. The poll and the process check
+  are covered without NinjaTrader in `tests/test_playback_run_preflight.py`; `restart.is_running()`
+  is unchanged for its other callers.
+
+- **`ntstatus` decides "stale" by comparing the sources with the code NinjaTrader executes.**
+
+  The verdict compared the DLL's build time with the process start, so after every `reload` it
+  answered `DLL built N min AFTER NT started — NT is running older code; restart it` while the
+  reloaded code was exactly what ran (measured 2026-09-02: three compile+reload rounds at 19:14,
+  19:41 and 20:17 in one process started at 16:02, each followed by that verdict and by runs on
+  the new code). Two attempts were dropped on measurement: remembering the last reload's time
+  (the old code handles the reload that deploys it), and matching the DLL's ModuleVersionId
+  against the loaded assemblies (NinjaTrader executes a reload from a temp assembly,
+  `Documents\NinjaTrader 8\tmp\<guid>.dll`, compiled once more from the sources - its own
+  MVID, never the DLL's; measured 2026-09-03 05:15 via `typeof(NT8BridgeServer).Assembly`).
+
+  What answers the operator's question is the executing assembly's build time against the
+  newest `.cs` under `bin\Custom`: a source newer than the running code is code NinjaTrader has
+  not compiled into what it runs. The AddOn reports `runningAssembly` (name, location, builtUtc),
+  `newestSource` (path, modifiedUtc) and `sourcesNewerThanRunningCode`; the verdict is that
+  answer, names the newer source, and falls back to the old time rule only when a side could not
+  be read - saying so (`time rule`).
+
+- **`playbackrun` teardown: the "strategy rows" verdict measures what the removal waited for, and
+  gives the grid a moment to catch up.**
+
+  `restore` removes the strategy rows and waits until no row carries a strategy object any more
+  (`restore: strategy rows 1 -> 0 after 103 ms`), then the stage's verdict re-read the grid's raw
+  entry count and, measured 2026-09-03 06:32 on a loaded machine (twelve concurrent headless
+  NinjaTrader hosts), got `1`: the grid had not refreshed yet. That made `baselineClean` false and
+  rc 2 for a run that had reached its data end with nothing running. The verdict now counts the
+  rows carrying a strategy (the removal's own measurement), reports the raw entry count next to it,
+  and polls for up to 10 s before it judges: `1 entries, 0 with a strategy after 250 ms` is clean,
+  `1 entries, 1 with a strategy after 10000 ms` is not.
+
+- **`playbackrun` confirms NinjaTrader's order-rejection notice during a run instead of letting it
+  stack.**
+
+  `Playback101, Stop price can't be changed above the market. affected Order: Sell 1 StopMarket @
+  29861,5` is an `NTMessageBox` NinjaTrader raises when a strategy's stop modification is refused
+  because the market crossed the stop between the strategy's own side check and NinjaTrader's
+  validation. Measured 2026-09-02 (Playback/Historical, NinjaTrader log 16:55:34): seven in one run,
+  every one handled by the strategy itself (the remainder closed at market), the run reached the data
+  end - but each box stays until someone clicks OK, so an unattended run collects one per rejection,
+  and a modal holds the UI thread every later stage needs.
+
+  This is the second, and only other, exception to "a modal must never be clicked away" (the first is
+  the Historical Level II notice), and it is as narrow: the `strategystate` stage the play loop runs
+  every sample confirms only a window whose type name carries `MessageBox` AND whose text carries
+  NinjaTrader's order-rejection trailer `affected Order:` (measured wordings on 2026-09-02:
+  `Stop price can't be changed above/below the market`, `Sell/Buy stop ... can't be placed
+  above/below the market`, `Order ... can't be submitted: The OCO ID ... cannot be reused` - a match
+  on the first wording alone confirmed one of seven boxes and left six standing), invokes its OK
+  through the button's automation peer, and reports
+  `order notices: N dismissed this sample, M in this run`. The driver prints every confirmation and
+  result.json carries `orderNoticesDismissed`. Every other modal stays standing and stays the finding.
+
+  NinjaTrader opens that box without an owner: it is in neither `Globals.AllWindows` nor any
+  window's `OwnedWindows` (measured 2026-09-02 19:22-19:24: seven rejections in NinjaTrader's log,
+  three `Error` windows in the Win32 inventory, and a scan over those two lists answered
+  `0 dismissed` every sample). The stage therefore also walks `PresentationSource.CurrentSources`
+  - every WPF top-level window of the process, each read and confirmed on the dispatcher of the
+  UI thread that owns it - and reports what it saw (`windows N, message boxes M, matching K`).
+  Measured right after: one sample against three standing boxes answered `3 dismissed ...
+  (windows 10, message boxes 3, matching 3)` and the inventory went from three `Error` windows to
+  none within five seconds.
+
+### Added
+
+- **`satemplate` — ask for a backtest by template FILE instead of by parameter list.**
+
+  ```bash
+  python -m nt8bridge satemplate --template "…\VariantA.xml"
+  python -m nt8bridge backtest            # --config is now optional
+  ```
+
+  `configure` writes individual properties from a config.json. NinjaTrader's own strategy
+  templates carry the *complete* parameter set plus instrument and window, and a test suite is
+  usually one strategy class against many of them. Naming the file is shorter and cannot drift
+  from what the GUI runs, because it is what the GUI runs.
+
+  The template is **assigned**, not copied member by member: `RestoreFullStrategyTemplate`
+  already returns the strategy a file describes, and `TabStrategyProperties.StrategyTemplate`
+  takes it (`canWrite=True`, read off a running instance with `probe`). When the template names
+  a different class the class is selected **first** — writing `Strategy` installs a fresh
+  template and drops the old one silently (see `configure.py`, issue #6), so the other order
+  loses everything.
+
+  The instrument travels too. NinjaTrader does not hand it over: after assigning a template
+  naming `NQ 06-26` the strategy read `NQ 06-26` while the tab still read `ES 09-26` — and it is
+  the tab's instrument the Analyzer runs. `applied` in the response is a *reference* comparison,
+  so a property that accepts a write and keeps its own object fails instead of passing.
+
+- **`playbackrun` — one Playback measurement, end to end.**
+
+  ```bash
+  python -m nt8bridge playbackrun --strategy MyBot --instrument "MNQ 09-26" --source marketreplay --tick-replay false --bars-type Minute --bars-value 1 --from 2026-08-10 --to 2026-08-10
+  ```
+
+  Every connection off, clean start, connect, source, dates, range, speed, attach the strategy,
+  play to the data end, restore the baseline — then one JSON verdict and an archived run
+  directory. Every value it writes is READ BACK, and it exits 0 only when the data end was
+  reached **and** the teardown restored the baseline, so a run that ended for any other reason
+  cannot be mistaken for a result. It waits on events, never on a fixed sleep: the transport is
+  confirmed by the clock moving, the data end by the clock reaching the requested end, and the
+  attach by NinjaTrader's own log entry `Enabling NinjaScript strategy`.
+
+  Adds a second AddOn file (`NT8BridgeServerPlayback.cs`) carrying the stages this needs.
+
+  - **`--account` — name the simulation account the strategy trades on.**
+
+    ```bash
+    python -m nt8bridge playbackrun --strategy MyBot --account Playback101 ...
+    ```
+
+    Without the switch the run asks NinjaTrader for its own playback account
+    (`Account.PlaybackAccountName`) instead of assuming a name. An account that does not exist
+    **stops the run** and lists the ones that do — it is never swapped for another, because a
+    strategy trading on an account nobody watches produces a run that looks successful.
+
+    Accounts separate bookkeeping, not the run's mode: `--source` and `--tick-replay` are
+    process-wide in NinjaTrader, so every bot in one pass shares them.
+
+  - **`--stage-wait` — seconds one ordinary stage may take.**
+
+    The connect and Reset stages get 2.5× that; without the switch the driver's own 10 / 25
+    apply. Raise it on a box where NinjaTrader is slow. Two stages keep their own floors on top
+    of it: the connect (`CONNECT_WAIT`, see Fixed) and the preflight (`PREFLIGHT_WAIT`).
+
+### Changed
+
+- **Every request now carries a TTL.** A trigger that has waited longer than `ttlSec` in the
+  server's queue is discarded instead of executed, and answered with `status: "expired"` and code
+  `EXPIRED`. The default is 300 s and it applies to **all** commands. Measured 2026-08-19: a
+  backlog released after 11 minutes enabled, disabled and removed a strategy in the middle of a
+  running measurement.
+
+- **`connections` says where each row came from.** A new `source` field reads `configured` for a
+  row from the connection list and `live-only` for one that is running without being in it — the
+  case that made a live connection invisible to a caller reading the configuration alone.
+
+- **`playback` — the `.nrd` coverage scan is opt-in: `--coverage` (every instrument) or
+  `--instrument X` (that one).**
+
+  ```bash
+  python -m nt8bridge playback                            # clock, MOVING?, speed — no store scan
+  python -m nt8bridge playback --instrument "MNQ 09-26"   # coverage of that one instrument
+  python -m nt8bridge playback --coverage --timeout 600   # coverage of every instrument
+  ```
+
+  The wide scan reads every `.nrd` of every instrument and holds the AddOn's poller for minutes
+  (measured 2026-08-19: 3-7 min, 5 MB, 35 instruments); a named instrument scans just that one
+  (17 s). The AddOn now scans only when the request names an instrument or carries
+  `"coverage": "true"`, and always answers `coverageScanned: true|false` before `coverage`
+  (an empty list when not scanned). The readiness verdict keeps the two apart: an unscanned
+  store reads `coverage not scanned (pass --coverage or --instrument)` instead of `no readable
+  .nrd files on disk — nothing to replay`, which was a claim about data nobody had looked at.
+  A response without the key — an AddOn built before this change always scanned — keeps its
+  old meaning. `--require-ready` implies the scan (of `--instrument` when given, else of every
+  instrument), so a bake script keeps its old meaning: connected, loaded and parked.
+
+### Fixed
+
+- **Subprocess output is decoded with `errors="replace"`.** `tasklist`, `schtasks` and `taskkill`
+  write in the console codepage, not UTF-8; on a non-English Windows the first non-ASCII byte
+  raised `UnicodeDecodeError` and took the command down with it.
+
+### Documentation
+
+- **`playbackrun` and `satemplate` added to the README's command list**, and the count in its
+  heading brought along: the list named 31 of the 33 commands (`performance` and `perfwindow`
+  had only their prose section), and now names 33 of 35.
+
+- **README: one public section "Run modes and the stores they read" replaces internal
+  test-project notes.** What backs its table is the AddOn's own code, not quoted log lines: for a
+  Historical run the coverage pre-flight scans `db\tick\<instrument>\*.ncd` (`TickCoverage`),
+  for a Market Replay run `db\replay\<instrument>\*.nrd` (`ReplayCoverage`), and `--source`
+  picks the scanner; the Strategy Analyzer has no such pre-flight and the README claims no store
+  for it. The section also documents what decides `playbackrun --source`
+  (`PlaybackAdapter.IsSourceHistoricalData`, written and read back; the panel radios are display
+  only), the store-aware pre-flight, the Level II notice the bridge dismisses without touching
+  any other dialog, and the teardown rule for a killed run (`alloff` + `restore`). A line break
+  that had cut `db\replay` in two is fixed. The command list says that `playback` scans
+  coverage only on request, and the `playbackrun` section documents the date format and the
+  preflight wait. New sections `satemplate` and `playback` (with `--require-ready` and
+  `coverageScanned`), and a flag reference for `playbackrun` (`--template`, `--name`,
+  `--stage-wait`, `--max-wait`, `--nt8-dir`); the `ntstatus` line names the rule it applies.
+
 ## [1.6.0] - 2026-08-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Set up a Strategy Analyzer tab once (strategy, instrument, dates, commission); `
 
 ## Commands
 
-33 commands, grouped by what they do:
+35 commands, grouped by what they do:
 
 **Setup & diagnostics**
 ```
@@ -87,10 +87,10 @@ peek          read the SA tab's latest result + param read-back, without a new R
 
 **Read-only state** — what is this NinjaTrader actually doing right now?
 ```
-ntstatus      is NT running the code on disk? (catches a stale DLL; exit 2 if so)
+ntstatus      is NT running the sources on disk? (newest .cs vs the code NT executes; exit 2 if not)
 workspace     charts + indicators + strategies on them, and their State
 strategies    Control Center strategies: enabled AND running? --enable/--disable to change
-playback      replay transport: clock, MOVING?, speed, .nrd coverage
+playback      replay transport: clock, MOVING?, speed; .nrd coverage only on request (--coverage = every instrument, minutes; --instrument X = that one); --require-ready = exit 2 unless parked and loaded
 screenshot    capture a window (or the screen) as PNG
 ```
 
@@ -100,6 +100,11 @@ backtest      run a configured Strategy Analyzer backtest (--pdf for a report)
 batch         run N param-sets -> one combined report (--pdf)
 sweep         backtest a matrix: instrument x bar-type x param-set
 configure      write instrument/dates/bar-type/fill/params onto the SA tab (headless setup)
+satemplate    put one of NinjaTrader's own strategy templates on the SA tab, by file
+optimize      NinjaTrader's parameter search on the SA tab: --template + --opt=Name:min:max:step
+walkforward   walk-forward optimization on the SA tab, same options plus --anchored
+multiobjective  multi-objective optimization on the SA tab, same options
+playbackrun   drive a Playback run end to end: connect, range, attach, play, archive
 ```
 
 **Data export**
@@ -292,6 +297,192 @@ unattended caller, and failing its no-op would make every retry look like a fail
 `alreadyEnabled` on a row whose `state` is *not* live: an enabled checkbox above a `Terminated` strategy
 is the looks-healthy-but-isn't case, and the checkbox is the less trustworthy of the two readings.
 
+### satemplate — a backtest by template file
+
+```bash
+python -m nt8bridge satemplate --template "C:\...\bin\Custom\Strategies\MyBot\Tests\VariantA.xml"
+python -m nt8bridge backtest                 # --config is now optional
+```
+
+`--template` is a full path to one of NinjaTrader's own strategy template `.xml` files, or a
+bare name looked up in the strategy's template folder. The template is **assigned** to the
+Strategy Analyzer tab (the complete parameter set plus instrument and window, exactly what the
+GUI would run); when it belongs to a different strategy than the tab shows, that strategy is
+selected first, and the instrument travels to the tab because NinjaTrader does not carry it over
+on its own. The response's `applied` is a reference comparison of the assigned template, and the
+run window is reported.
+
+### optimize / walkforward / multiobjective — NinjaTrader's own parameter search
+
+```bash
+python -m nt8bridge walkforward --template="C:\...\Tests\WFO_VariantA.xml" --opt=DeltaVolume1:150:250:50                                 --OptimizationPeriod=10 --TestPeriod=5 --out=C:
+uns\wfo.csv
+python -m nt8bridge optimize   --template=VariantA --opt="Fast:20:30:5,Slow:50:100:10" --fitness=MaxProfitFactor
+python -m nt8bridge walkforward --template=VariantA --opt=Fast:20:30:5 --anchored --optimizer=genetic
+```
+
+The three commands drive the Strategy Analyzer's Optimize, Walk Forward and Multi-objective
+runs the way the Run button does, and take the **same options as the headless runner
+Nt8Cli's `optimize` / `walkforward` / `multiobjective`**, so a run moves between the two hosts
+by changing nothing but the program name:
+
+* `--template` names the strategy template file (full path, or a bare name in the strategy's
+  template folder, as `satemplate`); it carries the complete parameter set, instrument and window.
+* `--opt="Name:min:max:step[,...]"` names the parameters to search. The AddOn writes them onto
+  the template's `OptimizationParameters` as NinjaTrader's own `Parameter` objects — the
+  collection the GUI's parameter grid fills. NinjaTrader refuses a run without one: with the
+  run type set and the collection empty, Run shows `The strategy must have at least one
+  parameter to optimize.` and runs nothing (measured on 8.1.8.2).
+* `--optimizer=default|genetic` (exactly these two; anything else is refused rather than run
+  as the default), `--fitness=<OptimizationFitness class name>` (default: the template's).
+* Any further `--Name=value` is written to the strategy property of that name after the
+  template — `--OptimizationPeriod=<days>` and `--TestPeriod=<days>` are the walk-forward
+  window lengths. A token of another shape is refused (exit 2), never silently dropped.
+* `--anchored` (walkforward only) selects the anchored walk-forward.
+* `--out=<csv>` copies the CSV files the strategy wrote during the run — read from the
+  strategy's `LogModes` folder when it has that property, else `<MyDocuments>\cAlgo\Logfiles`
+  — as `<out>` for one file and `<out>_<k><ext>` in creation order for several (Nt8Cli's rule).
+  When the strategy has a `LogFilePrefix` property the AddOn sets it to `ntbridge-<Strategy>`
+  for the run and counts only files with that prefix, so a headless fleet writing into the
+  same folder meanwhile cannot land in this run's output (Nt8Cli sets its own prefix the same way).
+  Measured 2026-09-09 with eight headless runners writing into the folder during the run: 14
+  files listed, all `ntbridge-RoadToSuccess*.csv`, none of the runners' `ntcliinst<N>-*` files
+  (the first build of this feature had listed four of them).
+* `--timeout` (default 1800 s) bounds the wait on both sides: the AddOn stops polling the grid
+  when the client stops polling the file.
+
+The AddOn sets the tab's `BacktestType` and the strategy's `Category` to the run mode, executes
+the view model's `RunCommand`, and reads the result off the tab's results grid once its progress
+control has gone (`IsProgressVisible` was true from the first poll tick to the last but one of a
+594 s walk-forward, measured 2026-09-08) and every new row carries a `SystemPerformance`. The
+response lists one `rows` entry per grid entry that did not exist before the run (compared by
+reference — the grid REPLACES a re-run's entry, so a count says nothing; two entry objects with
+one Guid become one row). What NinjaTrader 8.1.8.2 puts into the grid for a walk-forward: one
+summary row (`isSummary`, `children` = the windows), per window a row of `category` WalkForward
+carrying the OUT-OF-SAMPLE run, and per combination a row of `category` Optimize (`parentGuid` =
+the window's `guid`) carrying the IN-SAMPLE run, ranked by `results.performanceValue`. Each row
+carries window, the values of the optimized parameters, the ranges, `results` (trades, net
+profit, profit factor, drawdown, performance value) and the entry's own `optimizationResults`
+(empty on every entry of the measured walk-forward). `windows` counts the WalkForward rows,
+`rankedWindows` those with an Optimize child whose performance value is real; `csvFiles` are
+the files copied by `--out`. Exit 0 on `status: ok`, 1 on an error from the AddOn, 2 on a
+refused option.
+
+Parity with the headless runner, measured 2026-09-08 on NinjaTrader 8.1.8.2 (RoadToSuccess,
+NQ 09-26, 16.06.–13.07.2026, `--opt=DeltaVolume1:150:250:50`, in-sample 10 / out-of-sample 5
+days; bridge run 594 s, Nt8Cli `walkforward` on the same template and Custom.dll sources):
+4 windows, out-of-sample parameter 250 / 250 / 250 / 150 with 7 / 3 / 14 / 3 trades on both
+hosts; in-sample ranking per window identical (250 > 200 > 150 three times, 150 > 200 > 250 in
+the last window); every CSV written on both sides byte-identical (11 of 11, all 4 out-of-sample
+files among them). The SET of in-sample iteration CSVs differs: the GUI run wrote 12 of the 16
+instances' files, the headless run 15, each missing different iterations — a strategy instance
+that never reaches its termination step leaves no file, on either host.
+
+### playback — the replay transport's state
+
+```bash
+python -m nt8bridge playback                            # clock, MOVING?, speed - no store scan
+python -m nt8bridge playback --instrument "MNQ 09-26"   # plus .nrd coverage of that instrument
+python -m nt8bridge playback --coverage --timeout 600   # plus coverage of every instrument (minutes)
+python -m nt8bridge playback --require-ready            # exit 2 unless connected, loaded and parked
+```
+
+The `.nrd` coverage scan is opt-in because the wide scan holds the AddOn's poller for minutes;
+the response says `coverageScanned: true|false`, and an unscanned store is reported as
+`coverage not scanned`, never as "nothing to replay". `--require-ready` asserts "connected, loaded
+and parked" for bake scripts and therefore implies the scan (of `--instrument` when given).
+
+### playbackrun — one Playback measurement, end to end
+
+Drives NinjaTrader's **Playback** connection through a whole run and archives the result:
+every connection off, clean start, connect, source, dates, range, speed, attach the strategy,
+play to the data end, restore the baseline. Every value it writes is read back.
+
+```bash
+python -m nt8bridge playbackrun --strategy EmptyStrategy --instrument 'NQ ##-##' \
+    --source marketreplay --tick-replay false --bars-type Minute --bars-value 1 \
+    --from 2026-08-10 --to 2026-08-10
+```
+
+`--source` is `marketreplay` (recorded .nrd data) or `historical` (the historical store);
+`--tick-replay` turns Tick Replay on or off; `--bars-type` is `Tick`, `Minute` or `Wave` and
+`--bars-value` is its period. Exit **0** only when the run reached the data end **and** the
+teardown restored the baseline; **2** when it did not (the JSON says which), **1** on an error.
+
+`--from` and `--to` are calendar days written `YYYY-MM-DD`, the end inclusive and not before
+the start. Anything else — `2026-13-07`, `2026-7-7`, `07/07/2026`, an end before its start —
+is refused by the argument parser (usage line on stderr, exit 2, the accepted form and the
+offending value in the message) before a single request is written. Measured 2026-09-01: seven
+runs carried `--to 2026-13-07` all the way into NinjaTrader, and each lasted 45–58 s of wall
+clock before it died with `FormatException: String was not recognized as a valid DateTime.`
+
+Before anything else the run asks the bridge one cheap question (stage 0, the preflight). A
+NinjaTrader that is busy answers nothing for minutes - a Playback connect measured 388-453 s, a
+cold start 735 s - so silence is waited out, up to 1800 s, with a console line at most every
+30 s and the wait recorded as `preflightSeconds` in the result. One silence is refused at once:
+no `NinjaTrader.exe` process at all.
+
+**Accounts — which one the strategy trades on.** A Playback connection carries one or more
+simulation accounts; their names come from NinjaTrader, and an unknown one is refused with the
+list of what exists. A run uses one of them:
+
+```bash
+# on the account NinjaTrader itself calls the playback account
+python -m nt8bridge playbackrun --strategy MyBot ...
+
+# on a named account
+python -m nt8bridge playbackrun --strategy MyBot --account Playback2 ...
+```
+
+- **`--account <name>`** — the account the strategy trades on. Omit it and the run asks
+  NinjaTrader for its own playback account name (`Account.PlaybackAccountName`) rather than
+  assuming one. A name that does not exist **stops the run** and lists what does exist; it is
+  never silently swapped for another, because a strategy trading on an account nobody watches
+  produces a run that looks successful.
+- **`--template <file>`** — attach the strategy from one of NinjaTrader's own template `.xml`
+  files (the complete parameter set); without it the strategy runs with its defaults.
+- **`--name <archive>`** — name of the run directory under `NT8Bridge
+uns` (default
+  `PB_<strategy>`; a suffix `__N` keeps repeated runs apart).
+- **`--stage-wait <s>`** — seconds one ordinary stage may take; the connect and Reset stages get
+  2.5× that. Defaults to the driver's 10 / 25; raise it on a box where NinjaTrader is slow. Two
+  stages keep their own floors on top: the connect (`CONNECT_WAIT`, min. 600 s) and the preflight
+  (`PREFLIGHT_WAIT`, min. 1800 s, see above).
+- **`--max-wait <rounds>`** — the play loop's budget once the clock has reached the range end,
+  in rounds of 30 s (default 40).
+- **`--nt8-dir <path>`** — the NinjaTrader data directory this run talks to (the mailbox lives
+  under it); give each run its own to keep several NinjaTrader installations apart.
+
+> ⚠ **One bot per pass — and running several is not worth it.** The driver accepted a list of
+> bots until the idea was measured: two bots on one connection took **1163.8 s** for a week of
+> Market Replay against roughly **606 s** for one. They SHARE the replay walk rather than
+> parallelising it. The whole two-variant pass came to 1214.6 s against 1311.7 s run one after
+> the other — 7.4 %, and that saving is the second connect it avoided, not the bots. The clock,
+> the window, `--source` and `--tick-replay` are process-wide in NinjaTrader anyway, so a second
+> bot could only ever vary its own bookkeeping.
+
+`--account` also exists on the driver itself
+(`python nt8bridge/playback_run.py --help`), which additionally offers `--step` for a
+stop-after-every-sub-step walkthrough and `--archive` for where the run is written.
+
+**The census — an optional counter file the strategy may write.**
+
+At the end of a run the driver looks for `botlog_*/DEBUG_callbacks.json` inside the archive
+and, if it finds one, prints what it holds. **Nothing in this repository writes that file** —
+it is a convention a strategy can opt into, not a requirement, and a strategy that writes
+none is a perfectly good run.
+
+It is a **measurement, never a control**: the exit code does not depend on the file existing.
+Two things are read by name when they are present, and both say so when they are not:
+
+| key | used for |
+|---|---|
+| `IsTickReplay`, `Instrument` | compared against what the run asked for — a mismatch is reported and sets exit 2, because a run whose settings differ from the request is not a measurement of that request |
+| `MarketData_LastDataTime` | the timestamp of the last market-data event, to tell "no data at all" from "data stopped early". Absent, the cut-short check prints that it cannot run rather than passing quietly |
+
+Every other key in the file is printed as it comes, so a strategy can add counters without
+this driver having to know their names.
+
 ### chartseries
 
 Change a **live** chart's data series (instrument and/or bar type + period) from the CLI:
@@ -327,6 +518,58 @@ python -m nt8bridge peek                                   # re-read the result 
 ## precheck note
 
 `precheck` is an optional fast offline gate. It needs an external NinjaScript offline-compiler PowerShell script — point at it with the `NT8BRIDGE_COMPILER` environment variable. Without it, `precheck` errors clearly (it will not pretend your code is clean), and its fixture tests skip. The in-NinjaTrader `compile` command does **not** need it and is the primary error-checking path.
+
+## Run modes and the stores they read
+
+The bridge runs a strategy over recorded data in three ways: the Strategy Analyzer (`backtest`)
+and Playback from one of two sources (`playbackrun --source historical|marketreplay`). The two
+Playback sources do **not** read the same store. What backs the table is the AddOn's own code,
+not a log line: the coverage pre-flight in `addon/NT8BridgeServerPlayback.cs` scans exactly the
+store the run will read, and its two scanners name the folders.
+
+| Playback source | Store | The AddOn's scanner |
+|---|---|---|
+| **Historical** | `db\tick` (`.ncd`, one file per hour and data type) | `TickCoverage` lists `db\tick\<instrument>\*.ncd` |
+| **Market Replay** | `db\replay` (`.nrd`, one file per instrument and day) | `ReplayCoverage` lists `db\replay\<instrument>\*.nrd` — the store `histget` fills and `histdump` decodes |
+
+Only Market Replay reads the `.nrd` recordings. The Strategy Analyzer is driven as its tab was
+configured (`backtest`) and has no such pre-flight: the bridge scans no store for it, and this
+section claims none.
+
+`playbackrun --source historical|marketreplay` chooses between the two. What decides the
+source is the adapter static `PlaybackAdapter.IsSourceHistoricalData`: the bridge writes it for the
+connect, re-asserts it after the connect and verifies it at the `source` stage, and every write is
+read back. The two radio buttons on the Playback panel are display only: the `source` stage reads
+them and reports what the panel shows, and a radio write NinjaTrader refuses is reported as a
+display defect, never as a failed run, because the source was already settled by the static.
+
+The coverage pre-flight after the connect asks the store the run will read: a Historical run
+checks `db\tick` for the requested days, a Market Replay run checks `db\replay`. Measured
+2026-08-30: a Historical run whose instrument had NCD files for the day but no `.nrd` at all was
+refused by a scan of `db\replay`, and the fallback then judged the request against the panel
+range of the previous run.
+
+Switching the panel to Historical makes NinjaTrader raise a modal notice that Level II market
+depth is not available in this mode. The bridge ticks "Don't show this message again" and confirms
+that one notice, identified by its wording, and touches no other dialog: any other modal is left
+standing and reported as the finding.
+
+One more kind of box is confirmed during a run: NinjaTrader's order-rejection notices for the
+playback account - `Stop price can't be changed above/below the market`, `... stop orders can't be
+placed above/below the market`, `Order ... can't be submitted: The OCO ID ... cannot be reused` -
+raised when the market crosses a strategy's stop between the strategy's own check and NinjaTrader's
+validation (measured 2026-09-02: seven in one Historical run, every one handled by the strategy
+itself). They are informational but modal, and an unattended run collects one per rejection. The
+`strategystate` stage the play loop runs every sample confirms exactly those boxes - type name
+`MessageBox`, text carrying NinjaTrader's trailer `affected Order:` - and counts them in its `order
+notices` step; the driver prints each confirmation and result.json carries `orderNoticesDismissed`.
+Any other modal still stands and is still the finding.
+
+A playback run that is killed instead of torn down leaves the transport running. The next run then
+refuses with `the transport was already running before step 8 - the strategy has lost the ticks up
+to <time>`. The cure is the stage pair every run starts with: `alloff` (every connection off, from
+the live list) and `restore` (strategy rows removed, dialogs closed, transport parked). NinjaTrader
+stays up.
 
 ## How it actually works (the interesting bits)
 

--- a/addon/NT8BridgeServer.cs
+++ b/addon/NT8BridgeServer.cs
@@ -33,7 +33,7 @@ using NinjaTrader.NinjaScript;
 
 namespace NinjaTrader.NinjaScript.AddOns
 {
-    public class NT8BridgeServer : AddOnBase
+    public partial class NT8BridgeServer : AddOnBase
     {
         private readonly object _gate = new object();
         private Timer _poller;
@@ -94,6 +94,13 @@ namespace NinjaTrader.NinjaScript.AddOns
             try
             {
                 if (_triggerDir == null) return;
+                CheckLease();
+                SubscribePlaybackEvents();
+                // Subscribe from the poller, not from the first `botout` request:
+                // a line printed BEFORE the driver first asks would otherwise be
+                // lost, and a missing line is indistinguishable from a silent bot.
+                SubscribeBotOutput();
+                PruneResults();
                 foreach (string file in Directory.GetFiles(_triggerDir, "*.json"))
                     HandleTrigger(file);
             }
@@ -134,9 +141,33 @@ namespace NinjaTrader.NinjaScript.AddOns
             try
             {
                 string text = File.ReadAllText(file);
+                DateTime writtenUtc;
+                try { writtenUtc = File.GetLastWriteTimeUtc(file); }
+                catch { writtenUtc = DateTime.UtcNow; }
                 try { File.Delete(file); } catch { }   // consume the trigger
                 id = ExtractJsonString(text, "id");
                 kind = ExtractJsonString(text, "kind");
+                NoteLease(text);      // the driver is alive - push the deadline out
+
+                // A caller that has timed out is gone; running its command now acts on
+                // a state it never saw. Measured 2026-08-19: a backlog released after
+                // 11 minutes enabled, disabled and removed a strategy in the middle of
+                // a running measurement (see the file header).
+                double ageSec = (DateTime.UtcNow - writtenUtc).TotalSeconds;
+                double ttlSec = RequestTtlSec(text);
+                if (ageSec > ttlSec)
+                {
+                    LogSafe("expired " + kind + " " + id + ": " + ageSec.ToString("0") +
+                            "s old, ttl " + ttlSec.ToString("0") + "s - NOT executed");
+                    WriteResult(ResultPrefixEx(kind, ResultPrefix(kind)) + id + ".json",
+                        "{\"id\":" + JsonStr(id) + ",\"status\":\"expired\",\"executed\":false" +
+                        ",\"ageSec\":" + ageSec.ToString("0.###", InvCi) +
+                        ",\"ttlSec\":" + ttlSec.ToString("0.###", InvCi) +
+                        ",\"errors\":[{\"code\":\"EXPIRED\",\"message\":" +
+                        JsonStr("request waited " + ageSec.ToString("0") + "s in the queue, past its " +
+                                ttlSec.ToString("0") + "s TTL; not executed") + "}]}");
+                    return;
+                }
                 if (kind == "compile")
                     WriteResult("compile_" + id + ".json", RunCompile(id));
                 else if (kind == "reload")
@@ -154,7 +185,9 @@ namespace NinjaTrader.NinjaScript.AddOns
                 else if (kind == "reconnect")
                     WriteResult("reconnect_" + id + ".json", RunReconnect(id, ExtractJsonString(text, "connection")));
                 else if (kind == "playback")
-                    WriteResult("playback_" + id + ".json", RunPlayback(id, ExtractJsonString(text, "instrument")));
+                    WriteResult("playback_" + id + ".json", RunPlayback(id, ExtractJsonString(text, "instrument"), ExtractJsonString(text, "coverage")));
+                else if (kind == "playbackrun")
+                    WriteResult("playbackrun_" + id + ".json", RunPlaybackRun(id, text));
                 else if (kind == "ntstatus")
                     WriteResult("ntstatus_" + id + ".json", RunNtStatus(id));
                 else if (kind == "workspace")
@@ -169,6 +202,10 @@ namespace NinjaTrader.NinjaScript.AddOns
                     WriteResult("probe_" + id + ".json", RunProbe(id));
                 else if (kind == "configure")
                     WriteResult("configure_" + id + ".json", RunConfigure(id, text));
+                else if (kind == "satemplate")
+                    WriteResult("satemplate_" + id + ".json", RunSaTemplate(id, text));
+                else if (kind == "analyzerrun")
+                    RunAnalyzerRun(id, text);   // async: the poll writes the result
                 else if (kind == "feedhealth")
                     WriteResult("feedhealth_" + id + ".json", RunFeedHealth(id, ExtractJsonString(text, "instruments")));
                 else if (kind == "performance")
@@ -191,9 +228,15 @@ namespace NinjaTrader.NinjaScript.AddOns
                 LogSafe("HandleTrigger: " + ex.Message);
                 if (id != null)
                     // route the fallback error to the file the caller polls (compile_/backtest_/account_).
-                    WriteResult(ResultPrefix(kind) + id + ".json",
+                    WriteResult(ResultPrefixEx(kind, ResultPrefix(kind)) + id + ".json",
                         "{\"id\":" + JsonStr(id) + ",\"status\":\"error\",\"errors\":[{\"file\":\"\",\"line\":0," +
                         "\"code\":\"BRIDGE\",\"message\":" + JsonStr(ex.Message) + "}],\"assemblyReloaded\":false}");
+            }
+            finally
+            {
+                // The answer has just been written: the driver is alive and will read it.
+                // Its lease runs from HERE, not from the receipt - see RearmLease.
+                RearmLease();
             }
         }
 
@@ -270,7 +313,7 @@ namespace NinjaTrader.NinjaScript.AddOns
         //  ⭐ `movingSec` is the field this was written for. A single clock reading cannot distinguish a
         //  parked transport from a running one, and that distinction is exactly what broke Gate 3. Two
         //  samples a real gap apart can. REPORT THE OUTCOME, NOT THE INTENT.
-        private string RunPlayback(string id, string instrument)
+        private string RunPlayback(string id, string instrument, string coverageFlag)
         {
             var sb = new StringBuilder();
             try
@@ -320,8 +363,15 @@ namespace NinjaTrader.NinjaScript.AddOns
                 // Coverage — what the .nrd files actually contain, from NT's own reader. The Playback
                 // slider is NOT this: its bounds are the CONNECTION range you typed, not indexed data,
                 // and misreading it as proof of loaded data cost hours on 2026-08-02.
-                sb.Append(",\"coverage\":");
-                AppendCoverage(sb, miMinMax, instrument);
+                // Opt-in: the wide scan reads every .nrd of every instrument and holds the
+                // poller's gate for minutes (measured 2026-08-19: 3-7 min, 5 MB, 35
+                // instruments). A named instrument scans just that one (17 s).
+                bool wantCoverage = !string.IsNullOrWhiteSpace(instrument)
+                                    || string.Equals(coverageFlag, "true", StringComparison.OrdinalIgnoreCase);
+                sb.Append(",\"coverageScanned\":").Append(wantCoverage ? "true" : "false")
+                  .Append(",\"coverage\":");
+                if (wantCoverage) AppendCoverage(sb, miMinMax, instrument);
+                else sb.Append("[]");
                 sb.Append("}");
                 return sb.ToString();
             }
@@ -432,7 +482,7 @@ namespace NinjaTrader.NinjaScript.AddOns
                     {
                         loadedVer = custom.GetName().Version != null ? custom.GetName().Version.ToString() : null;
                         try { loadedPath = custom.Location; } catch { }
-                        // An in-memory (byte[]-loaded) assembly has no Location — NT swaps NinjaScript in
+                        // An in-memory (byte[]-loaded) assembly has no Location - NT swaps NinjaScript in
                         // that way on a reload, so an empty Location is INFORMATION, not an error.
                         if (!string.IsNullOrEmpty(loadedPath) && File.Exists(loadedPath))
                             loadedBuilt = File.GetLastWriteTimeUtc(loadedPath);
@@ -440,11 +490,54 @@ namespace NinjaTrader.NinjaScript.AddOns
                 }
                 catch (Exception ex) { LogSafe("ntstatus assembly: " + ex.Message); }
 
+                // The assembly THIS code executes from - the one NinjaTrader actually runs.
+                // Measured 2026-09-03: after a reload it is NOT bin\Custom\NinjaTrader.Custom.dll
+                // but a temp assembly (Documents\NinjaTrader 8\tmp\<guid>.dll) - NinjaTrader
+                // compiles the sources once more for loading - so neither the DLL's build time
+                // nor its identity says what runs. The executing file's own build time does.
+                string selfName = null, selfLoc = null;
+                DateTime? selfBuilt = null;
+                try
+                {
+                    Assembly self = typeof(NT8BridgeServer).Assembly;
+                    selfName = self.GetName().Name;
+                    try { selfLoc = self.Location; } catch { }
+                    if (!string.IsNullOrEmpty(selfLoc) && File.Exists(selfLoc))
+                        selfBuilt = File.GetLastWriteTimeUtc(selfLoc);
+                }
+                catch (Exception ex) { LogSafe("ntstatus self assembly: " + ex.Message); }
+
+                // The newest NinjaScript source under bin\Custom: a source newer than the
+                // executing assembly is code NinjaTrader has not compiled into what it runs -
+                // the 33-minute-wasted-cell condition (deployed, never rebuilt or reloaded).
+                string newestSrc = null;
+                DateTime? newestSrcUtc = null;
+                try
+                {
+                    string custDir = Path.Combine(Globals.UserDataDir, "bin", "Custom");
+                    foreach (string f in Directory.GetFiles(custDir, "*.cs", SearchOption.AllDirectories))
+                    {
+                        DateTime m = File.GetLastWriteTimeUtc(f);
+                        if (!newestSrcUtc.HasValue || m > newestSrcUtc.Value) { newestSrcUtc = m; newestSrc = f; }
+                    }
+                }
+                catch (Exception ex) { LogSafe("ntstatus sources: " + ex.Message); }
+
                 string dllOnDisk = Path.Combine(Globals.UserDataDir, "bin", "Custom", "NinjaTrader.Custom.dll");
                 DateTime? diskBuilt = File.Exists(dllOnDisk) ? (DateTime?)File.GetLastWriteTimeUtc(dllOnDisk) : null;
 
-                // The finding, stated rather than left for the reader to compute.
-                bool stale = diskBuilt.HasValue && diskBuilt.Value > procStart;
+                // The finding, stated rather than left for the reader to compute: a source on
+                // disk newer than the executing assembly means NinjaTrader is not running the
+                // code on disk. Reload or restart fixes it, another deploy does not. Measured
+                // 2026-09-02: three compile+reload rounds in one process started 16:02 - the
+                // old rule (DLL newer than the process) said "restart it" after every one of
+                // them while the reloaded code was what ran. The time rule against the process
+                // start remains the fallback when a side could not be read.
+                bool? sourcesNewer = null;
+                if (selfBuilt.HasValue && newestSrcUtc.HasValue)
+                    sourcesNewer = newestSrcUtc.Value > selfBuilt.Value;
+                bool stale = sourcesNewer.HasValue ? sourcesNewer.Value
+                             : (diskBuilt.HasValue && diskBuilt.Value > procStart);
 
                 var sb = new StringBuilder();
                 sb.Append("{\"id\":").Append(JsonStr(id))
@@ -459,6 +552,12 @@ namespace NinjaTrader.NinjaScript.AddOns
                   .Append(",\"builtUtc\":").Append(loadedBuilt.HasValue ? JsonStr(loadedBuilt.Value.ToString("o")) : "null").Append("}")
                   .Append(",\"dllOnDisk\":{\"path\":").Append(JsonStr(dllOnDisk))
                   .Append(",\"builtUtc\":").Append(diskBuilt.HasValue ? JsonStr(diskBuilt.Value.ToString("o")) : "null").Append("}")
+                  .Append(",\"runningAssembly\":{\"name\":").Append(JsonStr(selfName))
+                  .Append(",\"location\":").Append(JsonStr(selfLoc))
+                  .Append(",\"builtUtc\":").Append(selfBuilt.HasValue ? JsonStr(selfBuilt.Value.ToString("o")) : "null").Append("}")
+                  .Append(",\"newestSource\":{\"path\":").Append(JsonStr(newestSrc))
+                  .Append(",\"modifiedUtc\":").Append(newestSrcUtc.HasValue ? JsonStr(newestSrcUtc.Value.ToString("o")) : "null").Append("}")
+                  .Append(",\"sourcesNewerThanRunningCode\":").Append(sourcesNewer.HasValue ? (sourcesNewer.Value ? "true" : "false") : "null")
                   .Append(",\"assemblyOlderThanDisk\":").Append(stale ? "true" : "false")
                   .Append("}");
                 return sb.ToString();
@@ -3624,6 +3723,20 @@ namespace NinjaTrader.NinjaScript.AddOns
                 sb.Append("{\"id\":").Append(JsonStr(id))
                   .Append(",\"status\":\"ok\",\"ts\":").Append(JsonStr(DateTime.UtcNow.ToString("o")))
                   .Append(",\"connections\":[");
+                // ⚠ A CONNECTED CONNECTION MUST NEVER BE MISSING FROM THIS REPORT.
+                //
+                // The loop below walks the CONFIGURATION and looks the live status up by
+                // name. A connection that is live but has no ConnectOptions entry under
+                // that name therefore did not appear at all - and the report is used to
+                // answer "is anything else connected?", where a missing row reads as
+                // "no". Measured 2026-08-20: NinjaTrader's connection menu listed 8
+                // entries with "Live" connected; this report listed 6 without it, and a
+                // reader concluded from it that nothing was connected.
+                //
+                // Fix: after the configured rows, append every LIVE connection whose
+                // name was not already emitted. `source` says where a row came from, so
+                // a caller can tell a configured entry from one only NinjaTrader knows.
+                var emitted = new List<string>();
                 bool first = true;
                 foreach (ConnectOptions o in cfg)
                 {
@@ -3632,12 +3745,30 @@ namespace NinjaTrader.NinjaScript.AddOns
                     bool connected = liveStatus == "Connected";
                     string cls; if (!_dropClass.TryGetValue(nm, out cls)) cls = "";
                     bool inadvertent = cls == "inadvertent" && !connected;
+                    emitted.Add(nm);
                     if (!first) sb.Append(",");
                     first = false;
                     sb.Append("{\"name\":").Append(JsonStr(nm))
                       .Append(",\"status\":").Append(JsonStr(liveStatus))
                       .Append(",\"connected\":").Append(connected ? "true" : "false")
                       .Append(",\"inadvertentlyDropped\":").Append(inadvertent ? "true" : "false")
+                      .Append(",\"source\":\"configured\"")
+                      .Append("}");
+                }
+                foreach (Connection c in live)
+                {
+                    string nm = SafeStr(delegate { return c.Options == null ? "" : c.Options.Name; });
+                    if (nm.Length == 0 || emitted.Contains(nm)) continue;
+                    emitted.Add(nm);
+                    string liveStatus = SafeStr(delegate { return c.Status.ToString(); });
+                    bool connected = liveStatus == "Connected";
+                    if (!first) sb.Append(",");
+                    first = false;
+                    sb.Append("{\"name\":").Append(JsonStr(nm))
+                      .Append(",\"status\":").Append(JsonStr(liveStatus))
+                      .Append(",\"connected\":").Append(connected ? "true" : "false")
+                      .Append(",\"inadvertentlyDropped\":false")
+                      .Append(",\"source\":\"live-only\"")
                       .Append("}");
                 }
                 sb.Append("]}");

--- a/addon/NT8BridgeServerPlayback.cs
+++ b/addon/NT8BridgeServerPlayback.cs
@@ -1,0 +1,7689 @@
+/* MIT License
+Copyright (c) 2026 Quantrosoft Pty. Ltd.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// NT8BridgeServerPlayback.cs — the DRIVING half of the playback path.
+//
+// It is a `partial` of NT8BridgeServer so that the existing file keeps almost all
+// of its own text: what it gains is the lease hooks, the dispatch for kind
+// "playbackrun", the `partial` keyword and a result-prefix hook. Nothing existing
+// is deleted, so a later change to that file cannot collide with this one.
+//
+// Upstream's `playback` command READS the transport - connection, clock, speed,
+// coverage - and its changelog states it mutates nothing. This file is the half
+// that acts: connect, source, range, speed, set a strategy up from a TEMPLATE, arm
+// it, start it, detect the end, and restore the baseline.
+//
+// ⚠ It contains no GUI click of any kind, and it must stay that way. The check:
+//     grep -c "OnCli""ck()|Automation""Peer|IInvoke""Provider|Click""Event"   ->   0
+//   (the pattern is split so this very line does not match it - a self-matching
+//    check line reports 1 forever and hides the day a real click comes back)
+// The call behind a button is found with stage `findmethod`, never simulated.
+
+#region Using declarations
+using System;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Windows;
+using System.Windows.Input;
+using NinjaTrader.Cbi;
+using NinjaTrader.Core;
+using NinjaTrader.Data;
+using NinjaTrader.Gui.NinjaScript.StrategyAnalyzer;
+using NinjaTrader.NinjaScript;
+#endregion
+
+namespace NinjaTrader.NinjaScript.AddOns
+{
+    public partial class NT8BridgeServer
+    {
+        // ── The calls behind the Strategies grid's context menu ──────────────────────────────
+        //  Asked of NinjaTrader with `findmethod`, not guessed:
+        //      static StrategiesGrid.StrategyEnable(StrategyBase, Window, StrategiesGridEntry)
+        //      static StrategiesGrid.StrategyDisable(StrategyBase)
+        //      static StrategiesGrid.StrategyRemove(StrategyBase)
+        //  Enable takes the row object; the other two do not. All three are FIRED with
+        //  BeginInvoke and never awaited from inside the dispatcher: awaiting one from
+        //  the dispatcher froze NinjaTrader. The memory dump that established it is
+        //  quoted at the `attach` stage, where the strategy is created.
+        private static Type StrategiesGridType()
+        {
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type ty = null;
+                try { ty = asm.GetType("NinjaTrader.Gui.NinjaScript.StrategiesGrid", false); }
+                catch { }
+                if (ty != null) return ty;
+            }
+            return null;
+        }
+
+        private static MethodInfo StrategiesGridStatic(string name, int argc)
+        {
+            Type ty = StrategiesGridType();
+            if (ty == null) return null;
+            foreach (MethodInfo mi in ty.GetMethods(BFStatic))
+                if (mi.Name == name && mi.GetParameters().Length == argc) return mi;
+            return null;
+        }
+
+        // The strategy a grid row carries. The row is a view object; the strategy hangs off
+        // it under a property, and identity against it is what makes a row OURS.
+        private static StrategyBase RowStrategy(object row)
+        {
+            if (row == null) return null;
+            foreach (PropertyInfo pr in row.GetType().GetProperties(
+                         BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (pr.GetIndexParameters().Length > 0) continue;
+                object v = null;
+                try { v = pr.GetValue(row, null); } catch { continue; }
+                StrategyBase s = v as StrategyBase;
+                if (s != null) return s;
+            }
+            return null;
+        }
+
+        // Every row of the Strategies grid, as (row, strategy). Read on the dispatcher by
+        // the caller; this method itself only walks the collection it is handed.
+        // ⚠ THIS COLLECTION BELONGS TO NINJATRADER AND CHANGES WHILE IT IS READ.
+        //
+        // Measured 25.08.2026, on the teardown of a run that had just reached the
+        // data end:
+        //     restore disconnect confirmed: ... 15:18:19.657 ...
+        //     RestoreBaselineNow: Collection was modified; enumeration operation
+        //                         may not execute.
+        // A `foreach` over the live DataSource threw, the exception unwound the
+        // whole handler into its catch, and the handler therefore never answered.
+        // The caller reported "NO REACTION in 36 s" for work NinjaTrader had
+        // finished 4 s earlier - the worst kind of report, because it names the
+        // wrong component. A disconnect disables and removes strategy rows by
+        // itself, so the window in which this enumerator is invalid is exactly
+        // the window every teardown runs in.
+        //
+        // An IList is read BY INDEX and needs no enumerator, which removes the
+        // race rather than surviving it. The enumerating path stays for anything
+        // that is not an IList, and both are retried: a collection that is being
+        // rewritten right now is readable a moment later, on the same thread.
+        //
+        // FAIL LOUD at the end. Returning an empty list would say "no strategy
+        // rows" - which reads as a clean baseline and is exactly the silent wrong
+        // answer this file exists to avoid.
+        private static List<KeyValuePair<object, StrategyBase>> GridRows(object grid)
+        {
+            var outp = new List<KeyValuePair<object, StrategyBase>>();
+            if (grid == null) return outp;
+            PropertyInfo pSrc = grid.GetType().GetProperty("DataSource");
+            System.Collections.IEnumerable rows =
+                pSrc == null ? null : pSrc.GetValue(grid, null) as System.Collections.IEnumerable;
+            if (rows == null) return outp;
+
+            System.Collections.IList list = rows as System.Collections.IList;
+            string lastError = null;
+            for (int attempt = 0; attempt < 5; attempt++)
+            {
+                outp.Clear();
+                try
+                {
+                    if (list != null)
+                    {
+                        for (int i = 0; i < list.Count; i++)
+                        {
+                            object o = list[i];
+                            if (o == null) continue;
+                            outp.Add(new KeyValuePair<object, StrategyBase>(o, RowStrategy(o)));
+                        }
+                    }
+                    else
+                    {
+                        foreach (object o in rows)
+                        {
+                            if (o == null) continue;
+                            outp.Add(new KeyValuePair<object, StrategyBase>(o, RowStrategy(o)));
+                        }
+                    }
+                    if (attempt > 0)
+                        LogStatic("GridRows: read on attempt " + (attempt + 1)
+                                  + " after: " + lastError);
+                    return outp;
+                }
+                catch (InvalidOperationException ex) { lastError = ex.Message; }
+                catch (ArgumentOutOfRangeException ex) { lastError = ex.Message; }
+            }
+            throw new InvalidOperationException(
+                "GridRows: the strategies grid kept changing across 5 reads ("
+                + lastError + "). Reporting no rows here would read as a clean "
+                + "baseline, so this is raised instead.");
+        }
+
+        // Disable, then Remove - in that order and never the other way round. NinjaTrader
+        // only asks "are you sure" for a strategy that is still ENABLED, and that modal
+        // blocks every later command. Disabling an already-disabled strategy is a no-op, so
+        // the order costs nothing and removes the dialog instead of answering it.
+        private static void FireDisableRemove(Window cc, StrategyBase strat)
+        {
+            if (cc == null || strat == null) return;
+            MethodInfo dis = StrategiesGridStatic("StrategyDisable", 1);
+            MethodInfo rem = StrategiesGridStatic("StrategyRemove", 1);
+            StrategyBase s = strat;
+            cc.Dispatcher.BeginInvoke(new Action(delegate
+            {
+                try { if (dis != null) dis.Invoke(null, new object[] { s }); } catch { }
+                try { if (rem != null) rem.Invoke(null, new object[] { s }); } catch { }
+            }));
+        }
+
+        // A modal must never be clicked away. If one is standing, that is the finding.
+        private string StandingModal()
+        {
+            foreach (Window w in AllWindowsIncludingOwned())
+            {
+                string ty = null;
+                try { ty = w.GetType().Name; } catch { }
+                if (ty != null && ty.IndexOf("MessageBox", StringComparison.OrdinalIgnoreCase) >= 0)
+                    return ty;
+            }
+            return null;
+        }
+
+        // ── The transport, without the play button ───────────────────────────────────────────
+        //  Writing PlaybackAdapter.PlaybackSpeed IS the run control: a positive value runs,
+        //  0 parks. Bisected on 2026-08-19 (writing the speed started the
+        //  transport) and independently documented upstream in PR #5 ("Setting a speed starts
+        //  the transport", and "ZERO IS A REAL SPEED, not a missing argument"). The play
+        //  button was therefore never needed - it was only ever a slower way to do this.
+        // A range that cannot be right must never be armed. Measured 2026-08-19: a
+        // strategy restored from a template carried From 2099-12-01 / To 1800-01-01 -
+        // the placeholder values of a fresh NinjaScript instance - and arming it made
+        // NinjaTrader load until it stopped answering. Refusing costs one run.
+        private static string RangeProblem(DateTime from, DateTime to)
+        {
+            if (from > to)
+                return "From " + from.ToString("yyyy-MM-dd") + " is AFTER To "
+                     + to.ToString("yyyy-MM-dd") + " - inverted range";
+            if (from.Year < 1990 || from.Year > 2090)
+                return "From " + from.ToString("yyyy-MM-dd") + " is outside 1990..2090 - "
+                     + "this is a placeholder, not a range";
+            if (to.Year < 1990 || to.Year > 2090)
+                return "To " + to.ToString("yyyy-MM-dd") + " is outside 1990..2090 - "
+                     + "this is a placeholder, not a range";
+            if ((to - from).TotalDays > 3660.0)
+                return "range spans " + ((int)(to - from).TotalDays) + " days - "
+                     + "more than ten years is not a run, it is a mistake";
+            return null;
+        }
+
+        // ── NinjaTrader's OWN log, in memory ─────────────────────────────────────────────────
+        //  `NinjaTrader.Cbi.Log` raises a STATIC event for every entry it writes, carrying
+        //  Time, LogLevel, LogCategory and Message. Subscribing once turns that into a
+        //  bot-free channel that is strictly better than reading the log file:
+        //
+        //    * no file rotation, no retention window, no ".en.txt" twin to pick between
+        //    * event-driven, so there is nothing to be "0.8 s too early" for - which is
+        //      exactly the mistake that made me report "NinjaTrader never armed it" three
+        //      times on 2026-08-19 while it had armed it a moment later
+        //    * a bot cannot write into it, cannot suppress it, and does not have to exist
+        //
+        //  That last point is the mission: the remote control has to work with a COMPLETELY
+        //  EMPTY bot, so no evidence may come from the bot.
+        private static readonly List<string> _ntLog = new List<string>();
+        private static readonly object _ntLogGate = new object();
+
+        // How many entries have fallen off the FRONT of _ntLog so far.
+        //
+        // ⚠ A LIST INDEX CANNOT MARK A POSITION IN A RING. The mark a caller takes
+        // before it acts, and the position it later searches from, must be a running
+        // SEQUENCE NUMBER - otherwise, once the buffer sits at NtLogMax, Count stops
+        // growing, the mark is pinned at NtLogMax and every new entry lands BELOW it.
+        // The search `for (i = since; i < snap.Count; i++)` then has nothing to do and
+        // the wait can never succeed again for the life of the process.
+        //
+        // Measured 27.08.2026: after about two hours of playback runs the buffer was
+        // saturated by order events, and from then on every attach failed with
+        // "NinjaTrader never reported NinjaScriptStrategyBaseEnabling" - while
+        // NinjaTrader's own log carried the entry 21 seconds after the request. Six
+        // variants had passed before it; every one after it failed identically, and a
+        // restart of the run did not help because this buffer is process-wide.
+        private static long _ntLogDropped;
+        private static bool _ntLogSubscribed;
+        private static string _ntLogFile;
+
+        // ── THE BOT'S OWN OUTPUT, LIVE ──────────────────────────────────────
+        //
+        // Everything a NinjaScript writes with Print() goes through ONE public
+        // static event (measured 2026-08-21 by decompiling NinjaTrader.Core):
+        //     NinjaTrader.Code.Output.OutputEvent : EventHandler<OutputEventArgs>
+        //     OutputEventArgs { string Message; PrintTo OutputTab; bool IsReset; }
+        // Subscribing to it gives the driver the bot's output WHILE the run is
+        // going on, without touching the bot and without reading the Output
+        // window's visual tree. That is what makes a console that shows harness
+        // lines and [BOT] lines together possible.
+        //
+        // ⚠ This is an OUTPUT channel, never an evidence channel. The remote
+        // control must work with a bot that prints nothing, so nothing in the
+        // chain may wait for, or conclude from, a line that appears here.
+        private static readonly List<string> _botOut = new List<string>();
+        private static readonly object _botOutGate = new object();
+        private static bool _botOutSubscribed;
+        // A run can print a lot. The buffer keeps the newest lines; the driver
+        // polls it faster than it fills, and the count of dropped lines is
+        // reported so a gap can never pass unnoticed.
+        private const int BotOutMax = 20000;
+        private static long _botOutDropped;
+
+        // ⚠ DEBUGGING AID, OFF BY DEFAULT.
+        //
+        // The in-memory buffer plus the `ntlog` stage is the normal channel and costs
+        // nothing. Mirroring every entry into a FILE exists for one situation only: the
+        // request worker is stuck inside a UI call, so no stage answers - and then the
+        // file, written from NinjaTrader's own log thread, is the only way to see what it
+        // reported last. That was the open blind spot on 2026-08-19.
+        //
+        // It is a switch and not a permanent feature, so it cannot quietly stay on:
+        //     {"stage":"ntlog","toFile":"true"}   turn it on for a debugging session
+        //     {"stage":"ntlog","toFile":"false"}  off again
+        private static bool _ntLogToFile;
+        private const int NtLogMax = 2000;
+
+        // ── Wait for one of NinjaTrader's own log entries ────────────────────────────────────
+        //
+        //  The building block for "trigger and wait belong together" without inventing a
+        //  duration. A caller notes the log index, does the thing, and then waits HERE for
+        //  the entry NinjaTrader writes when it is done:
+        //
+        //      int mark = NtLogCount();
+        //      pc.Disconnect();
+        //      WaitForLogName(mark, "CbiConnectionProcessConnectionStatusUpdate", "Disconnected", ttl)
+        //
+        //  Matching is on `Name` - the resource identifier - so it survives a NinjaTrader
+        //  update and a different UI language. `contains` is an optional extra filter on the
+        //  rendered text for cases where one name covers several transitions (Connecting and
+        //  Connected share a name).
+        //
+        //  ⚠ The only bound is the caller's own patience. Nothing in here decides how long
+        //  NinjaTrader is allowed to take.
+        // ── Phase 3 of the handshake: wait until the state CHANGES ───────────────────────────
+        //
+        //  User, 2026-08-20 (translated from German): "if you do not wait at all after an
+        //  action, it can happen that the system has not reacted to your action yet and
+        //  therefore reports ready straight away."
+        //
+        //  Exactly what happened with `ready`: it answered after 1.0 s with the state from
+        //  BEFORE the connect. Phase 3 closes that hole - the value has to leave where it was,
+        //  or reach where it was sent, before anything is called done.
+        //
+        //  The sleep in here is a SAMPLING RATE, not a wait: it decides how often the value is
+        //  looked at, never how long NinjaTrader may take. The only bound is the caller's ttl.
+        private static bool WaitUntilChanged(Func<string> read, string before, string want,
+                                             double ttlSec, out string got, out long ms)
+        {
+            System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+            got = before;
+            while (true)
+            {
+                try { got = read(); } catch { }
+                bool done = want == null
+                            ? (got != before)                                   // just: it moved
+                            : string.Equals(got, want, StringComparison.OrdinalIgnoreCase);
+                if (done) { ms = sw.ElapsedMilliseconds; return true; }
+                if (sw.Elapsed.TotalSeconds >= ttlSec) { ms = sw.ElapsedMilliseconds; return false; }
+                Thread.Sleep(100);
+            }
+        }
+
+        // ⚠ THE HANDSHAKE FOR "NINJATRADER IS DONE WITH THE PREVIOUS STEP".
+        //
+        // Between two stages there was no handshake at all. Each stage waited for its
+        // OWN effect and then returned, while NinjaTrader kept working - and the next
+        // stage fired into that. When the user stepped through the chain by hand, his
+        // keypresses were accidentally supplying the missing pause; measured
+        // 2026-08-20, the same `attach` that came back in 1.9 s between keypresses left
+        // its enable operation Pending when the steps ran back to back.
+        //
+        // The signal is NinjaTrader's own: a delegate posted at ApplicationIdle runs
+        // only once the dispatcher has processed everything of higher priority. When it
+        // completes, the UI thread has drained its queue. That is an event, not a
+        // duration - nothing here guesses how long anything takes.
+        //
+        // ⚠ The wait happens on the WORKER thread. BeginInvoke posts, and the returned
+        // operation is waited on from outside the dispatcher - never inside it, which is
+        // the mistake that froze NinjaTrader twice on 2026-08-20. The only bound is the
+        // caller's own ttlSec.
+        private static bool WaitForUiIdle(Window w, double ttlSec, out long ms, out string status)
+        {
+            ms = 0;
+            status = "no window";
+            if (w == null) return false;
+            System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+            try
+            {
+                System.Windows.Threading.DispatcherOperation op =
+                    w.Dispatcher.BeginInvoke(new Action(delegate { }),
+                        System.Windows.Threading.DispatcherPriority.ApplicationIdle);
+                System.Windows.Threading.DispatcherOperationStatus st =
+                    op.Wait(TimeSpan.FromSeconds(ttlSec));
+                ms = sw.ElapsedMilliseconds;
+                status = st.ToString();
+                return st == System.Windows.Threading.DispatcherOperationStatus.Completed;
+            }
+            catch (Exception ex)
+            {
+                ms = sw.ElapsedMilliseconds;
+                status = ex.GetType().Name;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// The mark a caller takes before it acts: the number of log entries seen SO
+        /// FAR, dropped ones included. It only ever grows, so it stays a valid
+        /// position even after the buffer has wrapped.
+        /// </summary>
+        private static int NtLogCount()
+        {
+            SubscribeNtLog();
+            lock (_ntLogGate) return (int)(_ntLogDropped + _ntLog.Count);
+        }
+
+        /// <summary>
+        /// Turn a mark from <see cref="NtLogCount"/> into an offset into the buffer as
+        /// it stands now. Entries between the mark and the oldest one still held were
+        /// dropped and cannot be searched; the offset is then 0, i.e. everything left.
+        /// Call it under _ntLogGate together with the snapshot it belongs to.
+        /// </summary>
+        private static int NtLogOffset(int since)
+        {
+            long off = since - _ntLogDropped;
+            if (off < 0) return 0;
+            if (off > _ntLog.Count) return _ntLog.Count;
+            return (int)off;
+        }
+
+        private static bool WaitForLogName(int since, string name, string contains, double ttlSec,
+                                           out string hit, out int nowIndex)
+        {
+            SubscribeNtLog();
+            hit = null;
+            System.Diagnostics.Stopwatch sw = System.Diagnostics.Stopwatch.StartNew();
+            while (true)
+            {
+                List<string> snap; int from;
+                lock (_ntLogGate)
+                {
+                    snap = new List<string>(_ntLog);
+                    from = NtLogOffset(since);   // the mark counts entries; this is its slot
+                }
+                for (int i = from; i < snap.Count; i++)
+                {
+                    string[] f = snap[i].Split('|');
+                    if (f.Length < 6) continue;
+                    if (!string.IsNullOrEmpty(name)
+                        && f[3].IndexOf(name, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                    if (!string.IsNullOrEmpty(contains)
+                        && f[5].IndexOf(contains, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                    hit = snap[i];
+                    nowIndex = NtLogCount();
+                    return true;
+                }
+                if (sw.Elapsed.TotalSeconds >= ttlSec)
+                {
+                    nowIndex = NtLogCount();
+                    return false;
+                }
+                // sampling rate, NOT a deadline: this only decides how often the buffer is
+                // looked at, never how long NinjaTrader may take.
+                Thread.Sleep(100);
+            }
+        }
+
+        /// <summary>The static twin of LogSafe - same file, same shape. Needed
+        /// because the bot-output subscription runs from static context (the event
+        /// is static) while LogSafe is an instance method.</summary>
+        private static void LogStatic(string msg)
+        {
+            try
+            {
+                string dir = Path.Combine(NinjaTrader.Core.Globals.UserDataDir, "NT8Bridge", "result");
+                Directory.CreateDirectory(dir);
+                File.AppendAllText(Path.Combine(dir, "bridge.log"),
+                    DateTime.UtcNow.ToString("o") + "  " + msg + Environment.NewLine);
+            }
+            catch { }
+        }
+
+        /// <summary>Subscribe to NinjaTrader's own Print() event so the driver can
+        /// show the bot's output live. Idempotent; every failure is logged with the
+        /// reflection step that failed, because a silent miss here would look like
+        /// "the bot printed nothing".</summary>
+        private static void SubscribeBotOutput()
+        {
+            if (_botOutSubscribed) return;
+            try
+            {
+                Type ot = null;
+                foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    try { ot = asm.GetType("NinjaTrader.Code.Output", false); } catch { }
+                    if (ot != null) break;
+                }
+                if (ot == null) { LogStatic("SubscribeBotOutput: type NinjaTrader.Code.Output not found"); return; }
+                EventInfo ev = ot.GetEvent("OutputEvent", BFStatic);
+                if (ev == null) { LogStatic("SubscribeBotOutput: event OutputEvent not found"); return; }
+                MethodInfo handler = typeof(NT8BridgeServer).GetMethod("OnBotOutput",
+                    BindingFlags.NonPublic | BindingFlags.Static);
+                if (handler == null) { LogStatic("SubscribeBotOutput: handler OnBotOutput not found"); return; }
+                ev.AddEventHandler(null, Delegate.CreateDelegate(ev.EventHandlerType, handler));
+                _botOutSubscribed = true;
+                LogStatic("subscribed to NinjaTrader.Code.Output.OutputEvent (bot Print() stream)");
+            }
+            catch (Exception ex) { LogStatic("SubscribeBotOutput: " + Deep(ex)); }
+        }
+
+        /// <summary>One Print() line from any NinjaScript. Runs on whatever thread
+        /// printed, so it only appends to the buffer - no dispatcher, no file IO,
+        /// nothing that could slow the strategy down.</summary>
+        private static void OnBotOutput(object sender, EventArgs e)
+        {
+            try
+            {
+                Type et = e.GetType();
+                PropertyInfo pm = et.GetProperty("Message");
+                PropertyInfo pt = et.GetProperty("OutputTab");
+                PropertyInfo pr = et.GetProperty("IsReset");
+                bool isReset = pr != null && pr.GetValue(e, null) is bool && (bool)pr.GetValue(e, null);
+                string msg = pm == null ? "" : (pm.GetValue(e, null) as string ?? "");
+                string tab = pt == null ? "" : ("" + pt.GetValue(e, null));
+                // A reset (the user clearing the window) is an event of its own -
+                // reported, never silently swallowed.
+                string line = isReset ? ("<<output reset, tab " + tab + ">>")
+                                      : (tab.Length > 0 ? ("[" + tab + "] " + msg) : msg);
+                lock (_botOutGate)
+                {
+                    _botOut.Add(line);
+                    if (_botOut.Count > BotOutMax)
+                    {
+                        int cut = _botOut.Count - BotOutMax;
+                        _botOut.RemoveRange(0, cut);
+                        _botOutDropped += cut;
+                    }
+                }
+            }
+            catch { }   // never let a print break the printer
+        }
+
+        private static void SubscribeNtLog()
+        {
+            if (_ntLogSubscribed) return;
+            try
+            {
+                Type lt = null;
+                foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    try { lt = asm.GetType("NinjaTrader.Cbi.Log", false); } catch { }
+                    if (lt != null) break;
+                }
+                if (lt == null) return;
+                EventInfo ev = lt.GetEvent("LogEvent", BFStatic);
+                if (ev == null) return;
+                MethodInfo handler = typeof(NT8BridgeServer).GetMethod("OnNtLogEvent",
+                    BindingFlags.NonPublic | BindingFlags.Static);
+                if (handler == null) return;
+                Delegate d = Delegate.CreateDelegate(ev.EventHandlerType, handler);
+                ev.AddEventHandler(null, d);
+                _ntLogSubscribed = true;
+                if (!_ntLogToFile) return;
+                try
+                {
+                    string dir0 = Path.Combine(Globals.UserDataDir, "NT8Bridge");
+                    Directory.CreateDirectory(dir0);
+                    _ntLogFile = Path.Combine(dir0, "ntlog.txt");
+                    File.AppendAllText(_ntLogFile,
+                        DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")
+                        + "|Information|Bridge|BridgeNtLogSubscribed|-|channel open"
+                        + Environment.NewLine);
+                }
+                catch { }
+            }
+            catch { }   // reported by the stage as subscribed=false, not swallowed silently
+        }
+
+        private static void OnNtLogEvent(object sender, EventArgs e)
+        {
+            try
+            {
+                // ⚠ THE NAME IS THE IDENTIFIER, THE MESSAGE IS ONLY ITS RENDERING.
+                //
+                // LogEventArgs carries `Name` (a resource name) and `ResourceType` next to
+                // `Message`, and NinjaTrader builds the text from those two through a
+                // ResourceManager - the signature says so:
+                //     Log.Process(Type resourceType, String name, Object[] args, LogLevel, LogCategories)
+                // So matching on the English wording would break on a NinjaTrader update or a
+                // different UI language, while the NAME is what the caller passed and stays.
+                // Both are captured; callers should match on the name.
+                Type et = e.GetType();
+                object tm = null, lv = null, cat = null, msg = null, nm = null, rt = null;
+                PropertyInfo p1 = et.GetProperty("Time");         if (p1 != null) tm = p1.GetValue(e, null);
+                PropertyInfo p2 = et.GetProperty("LogLevel");     if (p2 != null) lv = p2.GetValue(e, null);
+                PropertyInfo p3 = et.GetProperty("LogCategory");  if (p3 != null) cat = p3.GetValue(e, null);
+                PropertyInfo p4 = et.GetProperty("Message");      if (p4 != null) msg = p4.GetValue(e, null);
+                PropertyInfo p5 = et.GetProperty("Name");         if (p5 != null) nm = p5.GetValue(e, null);
+                PropertyInfo p6 = et.GetProperty("ResourceType"); if (p6 != null) rt = p6.GetValue(e, null);
+                Type rtt = rt as Type;
+                string line = (tm is DateTime ? ((DateTime)tm).ToString("yyyy-MM-dd HH:mm:ss.fff") : "?")
+                            + "|" + lv + "|" + cat
+                            + "|" + (nm == null ? "-" : nm.ToString())
+                            + "|" + (rtt == null ? "-" : rtt.Name)
+                            + "|" + msg;
+                lock (_ntLogGate)
+                {
+                    _ntLog.Add(line);
+                    if (_ntLog.Count > NtLogMax)
+                    {
+                        int drop = _ntLog.Count - NtLogMax;
+                        _ntLog.RemoveRange(0, drop);
+                        _ntLogDropped += drop;      // the mark counts entries, not slots
+                    }
+                }
+
+                // ⚠ ALSO TO A FILE, and that is the whole point.
+                //
+                // This handler runs on NinjaTrader's own log thread. The bridge's request
+                // worker is a different thread, and when it is stuck inside a UI call - which
+                // happened three times on 2026-08-19 - every stage stops answering, including
+                // the one that would report this buffer. A file written from HERE stays
+                // readable while that is going on, so for the first time the question "what
+                // did NinjaTrader report last before it stopped?" has an answer.
+                //
+                // Appending is deliberate: a reader that arrives late must still see what
+                // happened, and a run produces a handful of entries, not a stream.
+                if (!_ntLogToFile) return;   // off unless a debugging session asked for it
+                try
+                {
+                    if (_ntLogFile == null)
+                    {
+                        string dir = Path.Combine(Globals.UserDataDir, "NT8Bridge");
+                        Directory.CreateDirectory(dir);
+                        _ntLogFile = Path.Combine(dir, "ntlog.txt");
+                    }
+                    File.AppendAllText(_ntLogFile, line + Environment.NewLine);
+                }
+                catch { }   // never let logging break the thing being logged
+            }
+            catch { }
+        }
+
+        // ── When the Playback panel becomes usable, as an EVENT ──────────────────────────────
+        //
+        //  Polling `slider.IsEnabled` against a deadline was wrong twice over:
+        //    * it needs a number nobody can know. It took ~6 s here and the user says it can
+        //      take minutes; any deadline is either a false alarm or a long stall.
+        //    * running it late reports "never went grey" for a panel that is perfectly fine.
+        //
+        //  WPF raises IsEnabledChanged whenever the value flips, so the change can be
+        //  RECORDED instead of hunted for. The stage then answers instantly with the history
+        //  and the caller waits for what it needs - as long as that takes - without anyone
+        //  guessing a duration.
+        private static readonly List<string> _panelFlips = new List<string>();
+        private static readonly object _panelGate = new object();
+        private static bool _panelWatched;
+        private static string _panelWatchedIdent;
+        // How many flips have fallen off the FRONT, so the mark handed to a caller can
+        // be a running sequence number rather than a slot index - see _ntLogDropped.
+        private static long _panelDropped;
+
+        private void WatchPanelEnabled()
+        {
+            if (_panelWatched) return;
+            Window wp0 = FindWindowByTitle("Playback");
+            if (wp0 == null) return;
+            wp0.Dispatcher.Invoke(new Action(delegate
+            {
+                object sl = FindElement(wp0, "slider");
+                System.Windows.FrameworkElement fe = sl as System.Windows.FrameworkElement;
+                if (fe == null) return;
+                fe.IsEnabledChanged += OnPanelEnabledChanged;
+                _panelWatched = true;
+                _panelWatchedIdent = fe.GetType().Name + "#" + fe.GetHashCode();
+                NotePanelFlip(fe.IsEnabled ? "enabled" : "disabled", "subscribed");
+            }));
+        }
+
+        private static void NotePanelFlip(string state, string why)
+        {
+            lock (_panelGate)
+            {
+                _panelFlips.Add(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff") + "|" + state + "|" + why);
+                if (_panelFlips.Count > 400)
+                {
+                    int cutP = _panelFlips.Count - 400;
+                    _panelFlips.RemoveRange(0, cutP);
+                    _panelDropped += cutP;
+                }
+            }
+        }
+
+        private static void OnPanelEnabledChanged(object sender,
+            System.Windows.DependencyPropertyChangedEventArgs e)
+        {
+            try { NotePanelFlip(((bool)e.NewValue) ? "enabled" : "disabled", "IsEnabledChanged"); }
+            catch { }
+        }
+
+        // ── Waiting on an EVENT, never on a clock ────────────────────────────────────────────
+        //
+        //  User, 2026-08-20 (translated from German): "NO TIMEOUTS!!!! ON NO ACTION!!! this
+        //  can take several minutes when the cache is not loaded."
+        //
+        //  Right. Any constant in here is a guess about NinjaTrader's workload, and every
+        //  guess is either a false alarm or a stall. WPF already says when the work is done:
+        //
+        //    EventManager.RegisterClassHandler(typeof(Window), Loaded)  -> the Playback
+        //        window has been created and laid out. Registered once, class-wide, so it
+        //        also catches the window NinjaTrader builds AFTER the connect returns -
+        //        measured 2026-08-20: it does not exist yet at that moment.
+        //    slider.IsEnabledChanged -> the controls became usable. Subscribed on the object
+        //        that exists NOW, because the panel is rebuilt and a subscription on the
+        //        discarded control is silent forever.
+        //
+        //  The wait is on a handle. The only bound is the CALLER's ttlSec - the caller's own
+        //  decision about how long it is willing to wait - and never a number invented here.
+        private static readonly System.Threading.ManualResetEventSlim _panelUsable
+            = new System.Threading.ManualResetEventSlim(false);
+        private static bool _panelClassHandler;
+        private static string _panelTrace = "";
+
+        /// <summary>Does this process have a WPF user interface at all?
+        ///
+        /// Inside NinjaTrader.exe it does. Inside a host that starts the platform
+        /// itself there is no window and no Application object, and the whole panel
+        /// machinery below has nothing to attach to.
+        ///
+        /// Application.Current is the discriminator: WPF sets it when an Application
+        /// is constructed, which only the GUI does. Reading it can itself throw if
+        /// the WPF stack is not initialised, which answers the same question.</summary>
+        private static bool NoUiHost()
+        {
+            try { return System.Windows.Application.Current == null; }
+            catch { return true; }
+        }
+
+        private void ArmPanelWatch()
+        {
+            _panelUsable.Reset();
+            _panelTrace = "";
+            // ⚠ NOTHING TO WATCH WITHOUT A UI - and the old code CRASHED here.
+            //
+            // Measured 2026-08-24, first headless run: no "Control Center" window,
+            // so the fallback Application.Current.Dispatcher ran, and
+            // Application.Current is null in a process that never built an
+            // Application. The connect stage died on its very first statement,
+            // which is why its run.json held no steps at all.
+            //
+            // What is recorded is what was FOUND, not what was expected - if
+            // Application.Current is ever non-null here, this guard does not fire
+            // and the trace says so.
+            if (NoUiHost())
+            {
+                _panelTrace += "noUi:appCurrentNull;";
+                return;
+            }
+            _panelTrace += "ui:appCurrentPresent;";
+            Window cc0 = FindWindowByTitle("Control Center");
+            System.Windows.Threading.Dispatcher disp = cc0 != null ? cc0.Dispatcher
+                : System.Windows.Application.Current.Dispatcher;
+            disp.Invoke(new Action(delegate
+            {
+                if (!_panelClassHandler)
+                {
+                    System.Windows.EventManager.RegisterClassHandler(typeof(Window),
+                        System.Windows.FrameworkElement.LoadedEvent,
+                        new System.Windows.RoutedEventHandler(OnAnyWindowLoaded));
+                    _panelClassHandler = true;
+                }
+            }));
+            // OUTSIDE the dispatcher: HookPlaybackSlider marshals to each window's
+            // own dispatcher, and a nested cross-dispatcher Invoke is exactly what
+            // froze NinjaTrader three times on 2026-08-19.
+            HookPlaybackSlider();
+        }
+
+        private static void OnAnyWindowLoaded(object sender, System.Windows.RoutedEventArgs e)
+        {
+            try
+            {
+                Window w = sender as Window;
+                if (w == null) return;
+                string ti = null;
+                try { ti = w.Title; } catch { }
+                // Every load is recorded, not just the match: with only the match
+                // recorded, an empty trace could not tell "the handler never fired"
+                // from "it fired and the title did not match yet" - the title may
+                // still be empty when Loaded is raised.
+                if (_panelTrace.Length < 400)
+                    _panelTrace += "wl:" + (ti == null ? "<null>" : ti) + ";";
+                if (ti == null || ti.IndexOf("Playback", StringComparison.OrdinalIgnoreCase) < 0) return;
+                _panelTrace += "windowLoaded;";
+                HookPlaybackSlider();
+            }
+            catch { }
+        }
+
+        // ⚠ MEASURED BROKEN 2026-08-20, and fixed here. The wait reported "panel
+        // STILL not usable after 120000 ms" with an EMPTY trace, while reading the
+        // very same controls directly said window=enabled after 12236 ms - the
+        // documented ~11.3/11.9 s. Two defects, both in this one method:
+        //
+        //   1. It enumerated Application.Current.Windows. FindWindowByTitle says
+        //      why that is wrong: NinjaTrader is multi-UI-threaded and that
+        //      collection does not list every window. Every other lookup in this
+        //      file already uses AllWindowsIncludingOwned(); this was the outlier.
+        //   2. Every failure returned SILENTLY, so an empty trace could mean "no
+        //      events yet" or "never even found the window". A guard that cannot
+        //      say it failed is not a guard - every path now writes its outcome.
+        //
+        // WPF members are thread-affine, so the tree is touched on the window's OWN
+        // dispatcher. This method must therefore NOT be called from inside another
+        // dispatcher - nested waiting across dispatchers froze NinjaTrader three
+        // times on 2026-08-19. ArmPanelWatch calls it from the worker thread.
+        private static void HookPlaybackSlider()
+        {
+            try
+            {
+                foreach (Window w0 in AllWindowsIncludingOwned())
+                {
+                    Window w = w0;
+                    string ti = null;
+                    try { ti = (string)w.Dispatcher.Invoke(new Func<string>(delegate { return w.Title; })); }
+                    catch { continue; }
+                    if (ti == null || ti.IndexOf("Playback", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                    string res;
+                    try
+                    {
+                        res = (string)w.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            object sl = FindElementStatic(w, "slider");
+                            System.Windows.FrameworkElement f = sl as System.Windows.FrameworkElement;
+                            if (f == null) return "windowButNoSlider;";
+                            f.IsEnabledChanged -= OnPanelUsableChanged;
+                            f.IsEnabledChanged += OnPanelUsableChanged;
+                            if (f.IsEnabled) { _panelUsable.Set(); return "hooked;alreadyEnabled;"; }
+                            return "hooked;";
+                        }));
+                    }
+                    catch (Exception ex) { res = "hookThrew:" + ex.GetType().Name + ";"; }
+                    _panelTrace += res;
+                    return;
+                }
+                _panelTrace += "noPlaybackWindow;";
+            }
+            catch (Exception ex) { _panelTrace += "enumThrew:" + ex.GetType().Name + ";"; }
+        }
+
+        private static void OnPanelUsableChanged(object sender,
+            System.Windows.DependencyPropertyChangedEventArgs e)
+        {
+            try
+            {
+                bool v = (bool)e.NewValue;
+                _panelTrace += v ? "enabled;" : "disabled;";
+                if (v) _panelUsable.Set(); else _panelUsable.Reset();
+            }
+            catch { }
+        }
+
+        // Static twin of FindElement, so the class handler can use it without an instance.
+        private static object FindElementStatic(System.Windows.DependencyObject root, string name)
+        {
+            if (root == null) return null;
+            System.Windows.FrameworkElement fe = root as System.Windows.FrameworkElement;
+            if (fe != null && fe.Name == name) return fe;
+            int n = 0;
+            try { n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root); } catch { return null; }
+            for (int i = 0; i < n; i++)
+            {
+                object hit = FindElementStatic(System.Windows.Media.VisualTreeHelper.GetChild(root, i), name);
+                if (hit != null) return hit;
+            }
+            return null;
+        }
+
+        // The build's own maximum, so "run" means the same thing the panel means by Max.
+        private static int MaxSpeedOrOne()
+        {
+            try
+            {
+                Type pbT = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                FieldInfo fi = pbT == null ? null : pbT.GetField("MaxSpeedValue", BFStatic);
+                object v = fi != null ? fi.GetValue(null) : null;
+                if (v is int && (int)v > 0) return (int)v;
+            }
+            catch { }
+            return 1;
+        }
+
+        private static string SetPlaybackSpeed(int want, out int readBack)
+        {
+            readBack = -1;
+            Type pbT = null;
+            try { pbT = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false); }
+            catch { }
+            if (pbT == null) return "PlaybackAdapter did not resolve";
+            PropertyInfo pi = pbT.GetProperty("PlaybackSpeed", BFStatic);
+            if (pi == null || !pi.CanWrite) return "PlaybackSpeed is not writable on this build";
+            try { pi.SetValue(null, want, null); }
+            catch (Exception ex) { return "write threw " + ex.GetType().Name + ": " + ex.Message; }
+            try { object v = pi.GetValue(null, null); if (v is int) readBack = (int)v; } catch { }
+            return readBack == want ? null
+                 : "wrote " + want + " but it reads back " + (readBack < 0 ? "unreadable" : readBack.ToString());
+        }
+        // Is the transport advancing? Two NowEst samples a real gap apart. A single
+        // reading cannot tell a parked clock from a running one, and btnPlay.IsChecked
+        // answers a different question entirely (see ParkTransport).
+        private bool TransportMoving(out DateTime seen)
+        {
+            seen = DateTime.MinValue;
+            try
+            {
+                Type pbT = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                if (pbT == null) return false;
+                PropertyInfo piNow = pbT.GetProperty("NowEst", BFStatic);
+                if (piNow == null) return false;
+                // NinjaTrader refreshes NowEst on its own timer (playbackUiTimerMs =
+                // 1000), so the gap has to clear one tick of that timer - but only just.
+                // 1200 ms is enough: at the slowest possible rate, 1x, that is 1.2 s of
+                // data time, comfortably over a 0.5 s threshold.
+                //
+                // It used to be 2 x 2500 ms. Five seconds per measurement, called up to
+                // five times by ParkTransport, made a cleanup take ~25 s - and a teardown
+                // that slow does not get run when it matters. The cost was mine, not
+                // NinjaTrader's.
+                DateTime prev = (DateTime)piNow.GetValue(null);
+                seen = prev;
+                Thread.Sleep(1200);
+                DateTime now1 = (DateTime)piNow.GetValue(null);
+                seen = now1;
+                return (now1 - prev).TotalSeconds > 0.5;
+            }
+            catch (Exception ex) { LogSafe("TransportMoving: " + ex.Message); return false; }
+        }
+
+        // Stop the transport and PROVE it stopped.
+        //
+        // Parking is a write of PlaybackSpeed=0 - no button, no window, no dispatcher.
+        // The result is verified against the CLOCK, never against the button: measured
+        // 2026-08-19, btnPlay.IsChecked read false while NowEst kept advancing, and the
+        // caller went on to configure a strategy on top of a running transport.
+        private bool ParkTransport(Action<string, bool, string> step, int tries)
+        {
+            DateTime seen;
+            if (!TransportMoving(out seen))
+            {
+                if (step != null) step("transport parked", true, "already parked at " + seen);
+                return true;
+            }
+
+            // Speed 0 parks it. No window, no button, no dispatcher: PlaybackSpeed is a
+            // static property. The play button used to be pressed here, which needed the
+            // Playback window to exist and to be in a state that accepts the press.
+            for (int i = 0; i < tries; i++)
+            {
+                int back;
+                string problem = SetPlaybackSpeed(0, out back);
+                // Wait OUTSIDE any dispatcher - NinjaTrader has to act on the write.
+                Thread.Sleep(500);
+                if (!TransportMoving(out seen))
+                {
+                    if (step != null)
+                        step("transport parked", true,
+                             "parked at " + seen + " after writing PlaybackSpeed=0"
+                             + (problem == null ? "" : "  (" + problem + ")"));
+                    return true;
+                }
+                if (problem != null && step != null) LogSafe("park: " + problem);
+            }
+            if (step != null)
+                step("transport parked", false,
+                     "STILL RUNNING at " + seen + " after " + tries + " write(s) of PlaybackSpeed=0");
+            return false;
+        }
+
+        // Where a dialog sat before it was moved off-screen, so `unhide` can put it
+        // back. Keyed by the window instance.
+        private readonly Dictionary<object, double[]> _hiddenAt = new Dictionary<object, double[]>();
+
+        private const double OffScreenX = -32000.0;
+        private const double OffScreenY = -32000.0;
+
+        // Move every open ObjectDialog off-screen. It stays realised and fully
+        // functional - unlike Visibility=Hidden, which stops the window rendering and
+        // can leave property-grid items unrealised, and an unrealised item has no
+        // visual-tree node for SetByLabel to find.
+        private int HideDialogs(Action<string, bool, string> step)
+        {
+            int moved = 0;
+            foreach (Window w in AllWindowsIncludingOwned())
+            {
+                string ty = null;
+                try { ty = w.GetType().FullName; } catch { }
+                if (ty == null || ty.IndexOf("Dialog", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                Window ww = w;
+                try
+                {
+                    // Move it out of sight, then READ THE POSITION BACK. A step that
+                    // reports "-> off-screen" without looking is the same self-confirming
+                    // pattern that made an unset account read as set (2026-08-19).
+                    // WindowState and ShowInTaskbar go with it: a maximised window ignores
+                    // Left/Top, and a taskbar button is visible even when the window is not.
+                    double[] pos = (double[])ww.Dispatcher.Invoke(new Func<double[]>(delegate
+                    {
+                        if (!_hiddenAt.ContainsKey(ww))
+                            _hiddenAt[ww] = new double[] { ww.Left, ww.Top };
+                        if (ww.WindowState != System.Windows.WindowState.Normal)
+                            ww.WindowState = System.Windows.WindowState.Normal;
+                        ww.ShowInTaskbar = false;
+                        ww.Left = OffScreenX;
+                        ww.Top = OffScreenY;
+                        ww.UpdateLayout();
+                        return new double[] { ww.Left, ww.Top };
+                    }));
+                    bool gone = pos[0] <= -10000.0 && pos[1] <= -10000.0;
+                    moved++;
+                    if (step != null)
+                        step(gone ? "hidden" : "hide DID NOT STICK", gone,
+                             ty + " at (" + pos[0].ToString("0", InvCi) + "," +
+                             pos[1].ToString("0", InvCi) + ")");
+                }
+                catch (Exception ex)
+                {
+                    if (step != null) step("hide failed", false, ty + ": " + ex.Message);
+                }
+            }
+            if (step != null && moved == 0) step("hidden", true, "no dialog open");
+            return moved;
+        }
+
+        private int UnhideDialogs(Action<string, bool, string> step)
+        {
+            int moved = 0;
+            foreach (Window w in AllWindowsIncludingOwned())
+            {
+                Window ww = w;
+                double[] at;
+                if (!_hiddenAt.TryGetValue(ww, out at)) continue;
+                try
+                {
+                    double[] a = at;
+                    ww.Dispatcher.Invoke(new Action(delegate { ww.Left = a[0]; ww.Top = a[1]; }));
+                    _hiddenAt.Remove(ww);
+                    moved++;
+                    if (step != null) step("shown", true, ww.GetType().FullName + " -> back");
+                }
+                catch (Exception ex)
+                {
+                    if (step != null) step("unhide failed", false, ex.Message);
+                }
+            }
+            if (step != null && moved == 0) step("shown", true, "nothing was hidden");
+            return moved;
+        }
+
+        // ---- driver lease -------------------------------------------------
+        // A driver announces "I am working" with `leaseSec`. If it stops sending
+        // requests before the deadline, it died - and the AddOn cleans up, because
+        // a killed process cannot run its own teardown. See the file header.
+        private DateTime _leaseUntilUtc = DateTime.MinValue;
+        private bool _leaseRestoreDone = true;
+        // The last lease span the driver declared - it becomes the budget of a
+        // lease-triggered RestoreBaselineNow (the caller's ttl, per the rule that
+        // no wait invents its own bound). 120 is the span the driver sends today
+        // (playback_run.py stage(): leaseSec=120); overwritten by every request.
+        private double _lastLeaseSec = 120.0;
+
+        private void NoteLease(string json)
+        {
+            if (json == null) return;
+            const string pat = "\"leaseSec\"";
+            int i = json.IndexOf(pat, StringComparison.Ordinal);
+            if (i < 0) return;
+            int c = json.IndexOf(':', i + pat.Length);
+            if (c < 0) return;
+            int p2 = c + 1;
+            while (p2 < json.Length && (char.IsWhiteSpace(json[p2]) || json[p2] == '"')) p2++;
+            int s = p2;
+            while (p2 < json.Length && (char.IsDigit(json[p2]) || json[p2] == '.')) p2++;
+            double v;
+            if (p2 <= s || !double.TryParse(json.Substring(s, p2 - s),
+                    System.Globalization.NumberStyles.Float, InvCi, out v)) return;
+            if (v <= 0.0)
+            {
+                _leaseUntilUtc = DateTime.MinValue;      // clean exit - nothing to guard
+                _leaseRestoreDone = true;
+                return;
+            }
+            _leaseUntilUtc = DateTime.UtcNow.AddSeconds(v);
+            _lastLeaseSec = v;
+            _leaseRestoreDone = false;
+        }
+
+        // The deadline runs from the moment a request was ANSWERED, not received.
+        //
+        // Measured 2026-09-07 08:23 (bridge.log against NinjaTrader's trace): the
+        // connect stage arrived with leaseSec=120, took 282 s, reported Connected
+        // at 08:23:17 - and on the poller's next tick CheckLease found a deadline
+        // that had passed at 08:20, logged "LEASE EXPIRED - the driver is gone" and
+        // disconnected the connection the stage had just built (08:23:21.428, the
+        // same millisecond as Cbi.Connection.Disconnect in the trace). The driver
+        // was alive the whole time, polling for the result; a synchronous stage
+        // gives it nothing to send. The same line precedes every run of 2026-09-03
+        // whose connect took longer than 120 s (__76..__81).
+        //
+        // CheckLease cannot run WHILE a stage executes - one poller thread, one
+        // gate - so the receipt-time deadline is never consulted mid-stage, only
+        // the stale one afterwards. HandleTrigger therefore re-arms the lease in
+        // its finally: a request that has just been answered is the proof of life.
+        private void RearmLease()
+        {
+            if (_leaseRestoreDone) return;                // released (leaseSec <= 0) or fired
+            if (_leaseUntilUtc == DateTime.MinValue) return;
+            _leaseUntilUtc = DateTime.UtcNow.AddSeconds(_lastLeaseSec);
+        }
+
+        private void CheckLease()
+        {
+            try
+            {
+                if (_leaseRestoreDone) return;
+                if (_leaseUntilUtc == DateTime.MinValue) return;
+                if (DateTime.UtcNow <= _leaseUntilUtc) return;
+                _leaseRestoreDone = true;                 // fire exactly once
+                _leaseUntilUtc = DateTime.MinValue;
+                LogSafe("LEASE EXPIRED - the driver is gone. Restoring the baseline.");
+                RestoreBaselineNow(_lastLeaseSec);
+            }
+            catch (Exception ex) { LogSafe("CheckLease: " + ex.Message); }
+        }
+
+        // The same repair the driver would have done: park, disable, remove, close.
+        // Runs off the poller thread; every UI touch goes through the owning
+        // dispatcher, and nothing here sleeps inside one.
+        //
+        // ttlSec is the CALLER's budget - the only bound any wait in here may use
+        // (restore stage: the request's ttlSec; lease restore: the lease span the
+        // driver declared). Measured 2026-08-20 (bridge.log): with the previous
+        // hard-coded 300.0 the strategy-row block sat out the FULL five minutes
+        // after every finished run - two pairs "restore disconnect confirmed" ->
+        // "LEASE RESTORE done." lie exactly 300.07 s apart (20:31:56->20:36:56Z,
+        // 20:41:43->20:46:43Z), while empty cases finish in 2-3 ms. Cause: the
+        // wait watched for a 'Disabling' LOG LINE, but the disconnect right above
+        // had already disabled the strategy BEFORE the mark was taken (NT8 log
+        // 22:13:45.913 Disabling vs .919 Disconnecting), and no line arrived
+        // after the mark. The row block below now waits for the EFFECT instead.
+        private void RestoreBaselineNow(double ttlSec)
+        {
+            try
+            {
+                // ⚠ PUT THE SOURCE BACK TO MARKET REPLAY *BEFORE* DISCONNECTING.
+                //
+                // This is what makes a Historical run repeatable within one NinjaTrader
+                // session, and it has to happen before the disconnect, because that is
+                // when NinjaTrader persists the value.
+                //
+                // NOT the panel radios. That was tried first and did nothing, and the
+                // measurement says why: at the teardown of a Historical run the panel
+                // still showed Market Replay - it follows the adapter only on the next
+                // connect, as the note in the connect stage records - so a condition on
+                // rbHistoricalData never fired, silently. NinjaTrader nevertheless wrote
+                // True, so the persisted value comes from the ADAPTER STATIC, not from
+                // the radio buttons.
+                //
+                // What it prevents, measured three times on 25.08.2026:
+                //     15:39:37.897 Playback: Disconnected   -> 15:39:37.926 UI.xml = True
+                //     16:18:13.016 Playback: Disconnected   -> 16:18:13.045 UI.xml = True
+                // Both writes land 29 ms after the disconnect of a HISTORICAL run, and
+                // every connect afterwards dies with
+                //     Playback: Error in opening connection Playback, exception caught:
+                //     String was not recognized as a valid DateTime. (Panic)
+                // - 4 attempts, 4 panics, including Market Replay, which had connected
+                // three times an hour earlier. With the value at False: 10 connects, 0
+                // panics. The GUI-less host never sees any of this, because it has no
+                // Playback panel to rebuild.
+                //
+                // BeginInvoke, not Invoke: writing IsChecked makes NinjaTrader rebuild
+                // the transport on the UI thread, and a synchronous call from inside
+                // that same dispatcher waits on itself (measured 2026-08-18/19, the
+                // stage stopped answering). Posting it is enough - the disconnect right
+                // below gives NinjaTrader the whole rebuild it wants.
+                try
+                {
+                    // Same lookup as everywhere else in this file: the adapter lives
+                    // in the assembly that carries Connection.
+                    Type pbT = typeof(Connection).Assembly
+                        .GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                    PropertyInfo piSrc = pbT == null
+                        ? null : pbT.GetProperty("IsSourceHistoricalData", BFStatic);
+                    if (piSrc == null)
+                        LogStatic("restore: IsSourceHistoricalData not reachable - "
+                                  + "the next connect may panic (see the note above)");
+                    else
+                    {
+                        object before = piSrc.GetValue(null);
+                        piSrc.SetValue(null, false, null);
+                        object after = piSrc.GetValue(null);
+                        LogStatic("restore: IsSourceHistoricalData " + before + " -> " + after
+                                  + " (before the disconnect, so NinjaTrader persists False)");
+                    }
+                }
+                catch (Exception ex) { LogStatic("restore source reset: " + ex.Message); }
+
+                // ⚠ DISCONNECT FIRST - it is the universal abort.
+                //
+                // Measured 2026-08-19: a disconnect stops the transport immediately
+                // (timer.Enabled=False, RealtimeTickCount delta=0, clock frozen), while
+                // parking has to press a button and then MEASURE whether it worked. The
+                // cleanup used to park first and cost ~25 s of its own sleeps; a teardown
+                // that slow does not get run when it is needed. Disconnecting costs one
+                // call and cannot fail to stop things.
+                try
+                {
+                    PropertyInfo piPC = typeof(Connection).GetProperty("PlaybackConnection", BFStatic);
+                    Connection pc = piPC != null ? piPC.GetValue(null) as Connection : null;
+                    if (pc != null && pc.Status != ConnectionStatus.Disconnected)
+                    {
+                        // ⚠ TRIGGER, THEN WAIT FOR NINJATRADER'S OWN ENTRY - not for 600 ms.
+                        // The old sleep was a guess; disconnecting a busy connection can take
+                        // longer, and then everything measured afterwards was measured too early.
+                        int mark = NtLogCount();
+                        pc.Disconnect();
+                        string hit; int idx;
+                        bool got = WaitForLogName(mark, "CbiConnectionProcessConnectionStatusUpdate",
+                                                  "Disconnected", ttlSec, out hit, out idx);
+                        LogSafe(got ? ("restore disconnect confirmed: " + hit)
+                                    : "restore disconnect: NinjaTrader never reported Disconnected");
+                    }
+                }
+                catch (Exception ex) { LogSafe("restore disconnect: " + ex.Message); }
+
+                Window cc = FindWindowByTitle("Control Center");
+                if (cc != null)
+                {
+                    // Disable + Remove through the statics behind the menu entries. No
+                    // selection, no context menu, no modal to answer: Disable comes first,
+                    // so NinjaTrader never asks.
+                    for (int guard = 0; guard < 10; guard++)
+                    {
+                        Window ccx = cc;
+                        List<StrategyBase> live = (List<StrategyBase>)ccx.Dispatcher.Invoke(
+                            new Func<List<StrategyBase>>(delegate
+                        {
+                            var outp = new List<StrategyBase>();
+                            object grid = FindElement(ccx, "grdStrategies");
+                            foreach (var kv in GridRows(grid))
+                                if (kv.Value != null) outp.Add(kv.Value);
+                            return outp;
+                        }));
+                        if (live.Count == 0) break;
+                        // ⚠ One entry per strategy, and NinjaTrader says when each is off.
+                        // The key is MEASURED, not derived from the message text: stage `resname`
+                        // over NinjaTrader.Resource returns
+                        //     NinjaScriptStrategyBaseDisabling   = "Disabling NinjaScript strategy '{0}'"
+                        //     NinjaScriptStrategyBaseEnabling1/2 = "Enabling NinjaScript strategy '{0}' : ..."
+                        // The first version here said "NinjaScriptStrategyDisabl", invented from the
+                        // English wording. It would never have matched - and a wait that never
+                        // matches is indistinguishable from a hang.
+                        // The old sleep(1200) assumed every disable finishes inside 1.2 s.
+                        LogSafe("restore: " + live.Count + " strategy row(s) live - firing Disable+Remove");
+                        foreach (StrategyBase s in live) FireDisableRemove(ccx, s);
+                        // ⚠ WAIT FOR THE EFFECT, NOT FOR A LOG LINE.
+                        //
+                        // The goal of this block is: the rows are GONE. The old wait
+                        // watched for NinjaTrader's 'Disabling' log entry per row - a
+                        // line that only appears when the row was still enabled, and
+                        // after a finished run the disconnect above has already
+                        // disabled it (measured 2026-08-20, see the method header):
+                        // the wait then sat out its full bound on every clean run.
+                        // The row count in the grid is the direct, bot-free effect
+                        // channel - the same source `attach` uses for row-appeared.
+                        string rowsGotR; long rowsMsR;
+                        Window ccR = ccx;
+                        WaitUntilChanged(delegate
+                        {
+                            try
+                            {
+                                return "" + (int)ccR.Dispatcher.Invoke(new Func<int>(delegate
+                                {
+                                    object gR = FindElement(ccR, "grdStrategies");
+                                    int nR = 0;
+                                    foreach (var kvR in GridRows(gR)) if (kvR.Value != null) nR++;
+                                    return nR;
+                                }));
+                            }
+                            catch { return "?"; }
+                        }, "" + live.Count, "0", ttlSec, out rowsGotR, out rowsMsR);
+                        LogSafe("restore: strategy rows " + live.Count + " -> " + rowsGotR
+                                + " after " + rowsMsR + " ms");
+                        string modal = ccx.Dispatcher.Invoke(new Func<string>(delegate { return StandingModal(); })) as string;
+                        if (modal != null) LogSafe("LEASE RESTORE: a modal is standing (" + modal
+                                                   + ") - not clicked, reported");
+                    }
+                }
+
+                HideDialogs(null);          // park them out of sight first
+                foreach (Window w in AllWindowsIncludingOwned())
+                {
+                    string ty = null;
+                    try { ty = w.GetType().FullName; } catch { }
+                    if (ty == null || ty.IndexOf("Dialog", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                    Window ww = w;
+                    try { ww.Dispatcher.Invoke(new Action(delegate { ww.Close(); })); } catch { }
+                }
+                LogSafe("LEASE RESTORE done.");
+            }
+            catch (Exception ex) { LogSafe("RestoreBaselineNow: " + ex.Message); }
+        }
+
+        // ---- playback events -----------------------------------------------
+        // A real end-of-run signal instead of "the clock has not moved for 60 s".
+        //
+        // PlaybackAdapter exposes STATIC events (seen in the member dump). Two of
+        // them are subscribed here, IsAvailableChanged and OnReset, which turns
+        // "finished" from something inferred into something reported - with the DATA
+        // timestamp of the moment it happened, which is the only timestamp worth
+        // recording in a run that spans months of trading days. One handler serves
+        // both, so an entry says that an event arrived, not which one.
+        private readonly List<string> _pbEvents = new List<string>();
+        private bool _pbSubscribed;
+
+        private void NotePlaybackEvent(string name)
+        {
+            try
+            {
+                Type pbT = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                string nowEst = "?", avail = "?";
+                if (pbT != null)
+                {
+                    PropertyInfo pn = pbT.GetProperty("NowEst", BFStatic);
+                    if (pn != null) { try { nowEst = ((DateTime)pn.GetValue(null)).ToString("dd.MM.yyyy HH:mm:ss"); } catch { } }
+                    PropertyInfo pa = pbT.GetProperty("IsAvailable", BFStatic);
+                    if (pa != null) { try { avail = "" + pa.GetValue(null); } catch { } }
+                }
+                lock (_pbEvents)
+                {
+                    _pbEvents.Add(name + " | dataTime=" + nowEst + " | IsAvailable=" + avail);
+                    while (_pbEvents.Count > 60) _pbEvents.RemoveAt(0);
+                }
+                LogSafe("playback event: " + name + " dataTime=" + nowEst + " IsAvailable=" + avail);
+            }
+            catch { }
+        }
+
+        private void SubscribePlaybackEvents()
+        {
+            if (_pbSubscribed) return;
+            try
+            {
+                Type pbT = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                if (pbT == null) return;
+                foreach (string evName in new string[] { "IsAvailableChanged", "OnReset" })
+                {
+                    EventInfo ev = pbT.GetEvent(evName, BFStatic);
+                    if (ev == null) { LogSafe("event " + evName + " not found"); continue; }
+                    string captured = evName;
+                    Delegate h = Delegate.CreateDelegate(
+                        ev.EventHandlerType, this,
+                        GetType().GetMethod("OnPbEvent", BindingFlags.Instance | BindingFlags.NonPublic));
+                    // The handler signature has to match the event; both are
+                    // EventHandler<EventArgs>, so one method serves both. Which one fired
+                    // is recovered from the sender-less call by subscribing separately.
+                    ev.AddEventHandler(null, h);
+                    LogSafe("subscribed to PlaybackAdapter." + captured);
+                }
+                _pbSubscribed = true;
+            }
+            catch (Exception ex) { LogSafe("SubscribePlaybackEvents: " + ex.Message); }
+        }
+
+        private void OnPbEvent(object sender, EventArgs e)
+        {
+            NotePlaybackEvent("PlaybackAdapter event");
+        }
+
+        // Property accessors would flood the listing; they show up as properties anyway.
+        private static bool IsAccessor(MethodInfo mi)
+        {
+            return mi.IsSpecialName && (mi.Name.StartsWith("get_", StringComparison.Ordinal)
+                                     || mi.Name.StartsWith("set_", StringComparison.Ordinal)
+                                     || mi.Name.StartsWith("add_", StringComparison.Ordinal)
+                                     || mi.Name.StartsWith("remove_", StringComparison.Ordinal));
+        }
+
+        // ── Templates, without a dialog and without a click ──────────────────────────────────
+        //  The `load` button in the strategy dialog calls
+        //      StrategyTemplate.LoadTemplate(Window owner, StrategyBase, out StrategyBase)
+        //  which needs a WINDOW and opens a picker - the path ruled out on 2026-08-19
+        //  ("no mouse clicks in the GUI - in the cli bridge or the cli"). The three statics
+        //  below do the same work with no UI at all. Their signatures were read back from the
+        //  running NinjaTrader with the `findmethod` stage rather than assumed:
+        //      GetTemplateFolder(StrategyBase)                    : String
+        //      RestoreFullStrategyTemplate(XContainer)            : StrategyBase
+        //      SaveFullStrategyTemplate(XContainer, StrategyBase) : Void
+        // Reflection wraps everything in TargetInvocationException("Exception has been thrown
+        // by the target of an invocation."), which names neither the cause nor the place. The
+        // real exception sits in InnerException - report that one.
+        private static string Deep(Exception ex)
+        {
+            if (ex == null) return "(null)";
+            Exception cur = ex;
+            int guard = 0;
+            while (cur.InnerException != null && guard++ < 8) cur = cur.InnerException;
+            string s = cur.GetType().Name + ": " + cur.Message;
+            if (!ReferenceEquals(cur, ex)) s = s + "   [via " + ex.GetType().Name + "]";
+            if (!string.IsNullOrEmpty(cur.StackTrace))
+            {
+                string[] lines = cur.StackTrace.Split(new char[] { (char)10 });
+                if (lines.Length > 0) s = s + "   @ " + lines[0].Trim();
+            }
+            return s;
+        }
+
+        private static Type TemplateType()
+        {
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type ty = null;
+                try { ty = asm.GetType("NinjaTrader.Gui.NinjaScript.StrategyTemplate", false); }
+                catch { }
+                if (ty != null) return ty;
+            }
+            return null;
+        }
+
+        // The folder is asked of NinjaTrader, never assembled from a naming rule: it differs
+        // per bot (flat "Strategy\Foo" vs nested "Strategy\Foo.Foo") and NT8 creates it when
+        // the strategy first appears.
+        private static string TemplateFolder(StrategyBase strat)
+        {
+            Type tt = TemplateType();
+            if (tt == null || strat == null) return null;
+            MethodInfo mi = tt.GetMethod("GetTemplateFolder",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            if (mi == null) return null;
+            try { return (string)mi.Invoke(null, new object[] { strat }); }
+            catch { return null; }
+        }
+
+        // Resolve a strategy type by simple name. Bots declare either Strategies.Foo or
+        // Strategies.Foo.Foo, so both are tried before a full type scan; ambiguity is
+        // REPORTED, never silently resolved.
+        private static Type ResolveStrategyType(string typeName, out string problem)
+        {
+            problem = null;
+            if (string.IsNullOrWhiteSpace(typeName)) { problem = "no strategy name given"; return null; }
+            string[] candidates = new string[] {
+                "NinjaTrader.NinjaScript.Strategies." + typeName,
+                "NinjaTrader.NinjaScript.Strategies." + typeName + "." + typeName };
+            // Every `reload` leaves the PREVIOUS NinjaTrader.Custom in the AppDomain, so the
+            // same class exists more than once with identical FullName and different Type
+            // identity. Taking the first hit would silently instantiate the OLD build of the
+            // strategy. GetAssemblies() returns load order, so the LAST match is the freshest.
+            Type newest = null;
+            int seen = 0;
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+                foreach (string c in candidates)
+                {
+                    Type hit = null;
+                    try { hit = asm.GetType(c, false); } catch { }
+                    if (hit != null) { newest = hit; seen++; }
+                }
+            if (newest != null)
+            {
+                if (seen > 1) problem = "note: " + seen + " loaded copies, took the newest";
+                return newest;
+            }
+            List<Type> hits2 = new List<Type>();
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] all;
+                try { all = asm.GetTypes(); }
+                catch (ReflectionTypeLoadException rtl) { all = rtl.Types; }
+                catch { continue; }
+                foreach (Type ty in all)
+                    if (ty != null && ty.Name == typeName && typeof(StrategyBase).IsAssignableFrom(ty))
+                        hits2.Add(ty);
+            }
+            if (hits2.Count == 1) return hits2[0];
+            if (hits2.Count > 1)
+            {
+                List<string> n2 = new List<string>();
+                foreach (Type ty in hits2) n2.Add(ty.FullName);
+                problem = "ambiguous: " + string.Join(" | ", n2.ToArray());
+                return null;
+            }
+            problem = typeName + " in no loaded assembly";
+            return null;
+        }
+
+        // A bare name is resolved inside the bot's own template folder; an absolute path is
+        // taken as given, because that is the form the CLI parameter carries.
+        private static string TemplatePath(StrategyBase strat, string nameOrPath)
+        {
+            if (string.IsNullOrWhiteSpace(nameOrPath)) return null;
+            if (nameOrPath.IndexOf(Path.DirectorySeparatorChar) >= 0 || nameOrPath.IndexOf(':') >= 0)
+                return nameOrPath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)
+                     ? nameOrPath : nameOrPath + ".xml";
+            string folder = TemplateFolder(strat);
+            if (string.IsNullOrEmpty(folder)) return null;
+            return Path.Combine(folder, nameOrPath.EndsWith(".xml", StringComparison.OrdinalIgnoreCase)
+                                        ? nameOrPath : nameOrPath + ".xml");
+        }
+
+        // Returns the strategy the template describes. NOT a property copy onto an existing
+        // instance: that would require deciding member by member what is configuration and what
+        // is runtime state (State, Account, Instrument), and every wrong call there is silent.
+        private static StrategyBase RestoreTemplate(string file, out string problem)
+        {
+            problem = null;
+            Type tt = TemplateType();
+            if (tt == null) { problem = "StrategyTemplate type not found"; return null; }
+            MethodInfo mi = tt.GetMethod("RestoreFullStrategyTemplate",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            if (mi == null) { problem = "RestoreFullStrategyTemplate not found"; return null; }
+            if (!File.Exists(file)) { problem = "not found: " + file; return null; }
+            try
+            {
+                System.Xml.Linq.XDocument doc = System.Xml.Linq.XDocument.Load(file);
+                // Hand over the ROOT ELEMENT, symmetric to Save, which fills that element.
+                // A whole document looks for <StrategyType>/<Strategy> as its own children -
+                // and below a document there is only <StrategyTemplate>, so it found nothing
+                // and returned null. Proven by the positive control: a template written by
+                // NinjaTrader ITSELF failed the same way, which ruled out the file.
+                System.Xml.Linq.XContainer node =
+                    (System.Xml.Linq.XContainer)doc.Root ?? (System.Xml.Linq.XContainer)doc;
+                object r = mi.Invoke(null, new object[] { node });
+                StrategyBase sbr = r as StrategyBase;
+                if (sbr == null) { problem = "template produced no StrategyBase"; return null; }
+                return sbr;
+            }
+            catch (Exception ex) { problem = ex.GetType().Name + ": " + ex.Message; return null; }
+        }
+
+        // ── what the replay STORE holds ─────────────────────────────────────────
+        //  The days available for one instrument, read from the files. Upstream's
+        //  `playback` command reports exactly this as its "coverage" block, using
+        //  NinjaTrader's own GetReplayMinMaxDates; this is the same call without
+        //  the JSON, for the guard that has to decide whether a requested window
+        //  can play at all.
+        //
+        //  The file NAME is used only to find the files. Every date comes from the
+        //  bytes - a day whose name says 20260707 but whose content is another day
+        //  would be counted where its content puts it, which is the only place it
+        //  can be played from.
+        //
+        //  Returns false when the scan cannot be done at all (no such method, no
+        //  such folder, nothing readable). The caller then says so instead of
+        //  treating an unavailable scan as an empty store.
+        private static bool ReplayCoverage(string instrument, out DateTime lo,
+                                           out DateTime hi, out int readable)
+        {
+            lo = DateTime.MaxValue;
+            hi = DateTime.MinValue;
+            readable = 0;
+            try
+            {
+                Type pb = typeof(Connection).Assembly.GetType(
+                    "NinjaTrader.Adapter.PlaybackAdapter", false);
+                MethodInfo mi = pb == null ? null : pb.GetMethod(
+                    "GetReplayMinMaxDates", BFStatic, null,
+                    new[] { typeof(string), typeof(DateTime).MakeByRefType(),
+                            typeof(DateTime).MakeByRefType() }, null);
+                if (mi == null || string.IsNullOrWhiteSpace(instrument)) return false;
+                string dir = Path.Combine(Globals.UserDataDir, "db", "replay", instrument);
+                if (!Directory.Exists(dir)) return false;
+                foreach (string f in Directory.GetFiles(dir, "*.nrd"))
+                {
+                    try
+                    {
+                        object[] args = new object[] { f, DateTime.MinValue, DateTime.MinValue };
+                        mi.Invoke(null, args);
+                        DateTime a = (DateTime)args[1], b = (DateTime)args[2];
+                        if (a < lo) lo = a;
+                        if (b > hi) hi = b;
+                        readable++;
+                    }
+                    catch { }
+                }
+                return readable > 0;
+            }
+            catch { return false; }
+        }
+
+        /// <summary>Coverage of the NCD tick store - what Playback/Historical reads.
+        ///
+        ///  The counterpart to ReplayCoverage, which answers for db\replay. NCD files
+        ///  are one per hour and data type (YYYYMMDDHH.Last.ncd), so the DAY is taken
+        ///  from the first 8 characters of the name. That is deliberately a name-based
+        ///  scan, and it is only ever used as a PRE-FLIGHT: it answers "is there
+        ///  anything for that day", not "is the content that day". The content is
+        ///  decided when the series loads, and a run whose data is missing still fails
+        ///  loudly there. Returns false when the folder does not exist or holds no
+        ///  .ncd at all - the caller then says the scan was unavailable instead of
+        ///  treating it as an empty store.</summary>
+        private static bool TickCoverage(string instrument, out DateTime lo,
+                                         out DateTime hi, out int readable)
+        {
+            lo = DateTime.MaxValue;
+            hi = DateTime.MinValue;
+            readable = 0;
+            try
+            {
+                if (string.IsNullOrWhiteSpace(instrument)) return false;
+                string dir = Path.Combine(Globals.UserDataDir, "db", "tick", instrument);
+                if (!Directory.Exists(dir)) return false;
+                foreach (string f in Directory.GetFiles(dir, "*.ncd"))
+                {
+                    string name = Path.GetFileName(f);
+                    if (name.Length < 8) continue;
+                    DateTime d;
+                    if (!DateTime.TryParseExact(name.Substring(0, 8), "yyyyMMdd",
+                            System.Globalization.CultureInfo.InvariantCulture,
+                            System.Globalization.DateTimeStyles.None, out d)) continue;
+                    readable++;
+                    if (d < lo) lo = d;
+                    if (d > hi) hi = d;
+                }
+                if (readable == 0) return false;
+                hi = hi.Date.AddDays(1).AddSeconds(-1);
+                lo = lo.Date;
+                return true;
+            }
+            catch { return false; }
+        }
+
+        // ── analyzerrun: optimize / walkforward / multiobjective ─────────────
+        //  NinjaTrader's own parameter search, started on the Strategy Analyzer
+        //  tab the way the Run button starts it. One request kind serves the
+        //  three CLI commands; the tab's BacktestType decides which run NinjaTrader
+        //  performs (enum StrategyAnalyzerGuiBacktestType: Backtest, Optimize,
+        //  WalkForward, WalkForwardAnchored, MultiObjective, AiGenerate - read off
+        //  NinjaTrader.Gui 8.1.8.2).
+        //
+        //  What the run needs, each item measured on 8.1.8.2:
+        //   * the template on the tab (same steps as `satemplate`, so a run is
+        //     asked for by FILE and cannot drift from what the GUI runs);
+        //   * the property overrides from `params` written to that template
+        //     (OptimizationPeriod / TestPeriod are the walk-forward window lengths
+        //     in days);
+        //   * OptimizationParameters filled from `opt` ("Name:min:max:step[,...]")
+        //     as NinjaTrader's own Parameter objects - the collection the GUI's
+        //     parameter grid fills. With the type set and this collection empty the
+        //     Run button shows "The strategy must have at least one parameter to
+        //     optimize." and runs nothing (measured 08.09.2026, walk-forward on a
+        //     template without ranges);
+        //   * an Optimizer instance on the template (default | genetic) and, when
+        //     asked for, an OptimizationFitness by class name;
+        //   * the strategy's Category set to the run mode - what the headless
+        //     runner (Nt8Cli) had to set itself before its walk-forward applied the
+        //     in-sample optimization; set here too, so both hosts run the same
+        //     template state whatever the GUI's own Run handler does with it;
+        //   * BacktestType on TabStrategyProperties, then RunCommand.
+        //
+        //  The result is read off the tab's results grid: every StrategyAnalyzerGridEntry
+        //  that did not exist before the run (compared by reference - the grid
+        //  REPLACES a re-run's entry, so a count says nothing), with its window,
+        //  parameters, optimization ranges, performance and the optimizer's ranked
+        //  results, plus the CSV files the strategy wrote during the run into its
+        //  LogModes folder (the same folder rule the headless runner applies).
+        //
+        //  Completion is taken from the tab's own progress control: the run is over
+        //  when the progress had been visible and is not any more, and the new rows
+        //  carry a SystemPerformance. `timeoutSec` (the client's own budget) bounds
+        //  the wait; the answer then says that the run may still be going.
+        private void RunAnalyzerRun(string id, string text)
+        {
+            string mode      = JsonUnescape(ExtractJsonString(text, "mode"));
+            string want      = JsonUnescape(ExtractJsonString(text, "template"));
+            string optSpec   = JsonUnescape(ExtractJsonString(text, "opt"));
+            string optimizer = JsonUnescape(ExtractJsonString(text, "optimizer"));
+            string fitness   = JsonUnescape(ExtractJsonString(text, "fitness"));
+            double timeoutSec = JsonNumberField(text, "timeoutSec", 1800.0);
+            Dictionary<string, string> prms = ParseParams(text);
+            string resultFile = "analyzerrun_" + id + ".json";
+            if (string.IsNullOrWhiteSpace(mode))
+            { WriteResult(resultFile, BtErr(id, "analyzerrun: no mode given")); return; }
+            if (string.IsNullOrWhiteSpace(want))
+            { WriteResult(resultFile, BtErr(id, "analyzerrun: no template given")); return; }
+            if (string.IsNullOrWhiteSpace(optSpec))
+            { WriteResult(resultFile, BtErr(id, "analyzerrun: " + mode + " needs opt=Name:min:max:step[,...]")); return; }
+            Window saWin = FindStrategyAnalyzerWindow();
+            if (saWin == null)
+            { WriteResult(resultFile, BtErr(id, "analyzerrun: no Strategy Analyzer window open")); return; }
+            saWin.Dispatcher.BeginInvoke(new Action(delegate
+            {
+                try
+                {
+                    StrategyAnalyzerViewModel vm = saWin.DataContext as StrategyAnalyzerViewModel;
+                    StrategyAnalyzerTabControl tab = vm != null ? vm.SelectedTab : null;
+                    if (tab == null) { WriteResult(resultFile, BtErr(id, "analyzerrun: no active SA tab")); return; }
+                    StrategyAnalyzerTabProperties tsp = tab.TabStrategyProperties;
+                    if (tsp == null) { WriteResult(resultFile, BtErr(id, "analyzerrun: the tab has no TabStrategyProperties")); return; }
+
+                    // 1. The template, exactly as satemplate puts it there.
+                    StrategyBase before = tsp.StrategyTemplate;
+                    string file = TemplatePath(before, want);
+                    if (string.IsNullOrEmpty(file))
+                    { WriteResult(resultFile, BtErr(id, "analyzerrun: cannot resolve template " + want)); return; }
+                    string problem;
+                    StrategyBase strat = RestoreTemplate(file, out problem);
+                    if (strat == null) { WriteResult(resultFile, BtErr(id, "analyzerrun: " + problem)); return; }
+                    string had = before != null ? before.GetType().FullName : "(none)";
+                    if (!string.Equals(strat.GetType().FullName, had, StringComparison.Ordinal))
+                        tsp.Strategy = strat.GetType().Name;
+                    tsp.StrategyTemplate = strat;
+                    if (!string.IsNullOrWhiteSpace(strat.InstrumentOrInstrumentList))
+                        tsp.InstrumentOrInstrumentList = strat.InstrumentOrInstrumentList;
+                    if (!ReferenceEquals(tsp.StrategyTemplate, strat))
+                    { WriteResult(resultFile, BtErr(id, "analyzerrun: the tab kept its previous StrategyTemplate instance")); return; }
+
+                    // 2. Property overrides (--Name=value), after the template.
+                    if (prms.Count > 0) InjectParams(strat, prms);
+
+                    // 3. The ranges, as NinjaTrader's own Parameter objects.
+                    var parJson = new StringBuilder("[");
+                    HashSet<string> optNames = new HashSet<string>(StringComparer.Ordinal);
+                    strat.OptimizationParameters.Clear();
+                    foreach (string part in optSpec.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        string[] f = part.Split(':');
+                        if (f.Length != 4)
+                        { WriteResult(resultFile, BtErr(id, "analyzerrun: --opt entry '" + part + "' needs 4 fields Name:min:max:step.")); return; }
+                        string name = f[0].Trim();
+                        PropertyInfo prop = strat.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance);
+                        if (prop == null)
+                        { WriteResult(resultFile, BtErr(id, "analyzerrun: '" + name + "' is not a public property of " + strat.GetType().Name + ".")); return; }
+                        object min, max;
+                        double step;
+                        try
+                        {
+                            min  = Convert.ChangeType(f[1].Trim(), prop.PropertyType, InvCi);
+                            max  = Convert.ChangeType(f[2].Trim(), prop.PropertyType, InvCi);
+                            step = double.Parse(f[3].Trim(), InvCi);
+                        }
+                        catch (Exception ex)
+                        { WriteResult(resultFile, BtErr(id, "analyzerrun: '" + part + "' does not fit " + prop.PropertyType.Name + ": " + ex.Message)); return; }
+                        if (step <= 0)
+                        { WriteResult(resultFile, BtErr(id, "analyzerrun: step width in '" + part + "' must be > 0.")); return; }
+                        NinjaTrader.NinjaScript.Parameter par = new NinjaTrader.NinjaScript.Parameter();
+                        par.Name          = name;
+                        par.ParameterType = prop.PropertyType;
+                        par.Min           = min;
+                        par.Max           = max;
+                        par.Increment     = step;
+                        par.Value         = min;
+                        strat.OptimizationParameters.Add(par);
+                        optNames.Add(name);
+                        if (parJson.Length > 1) parJson.Append(",");
+                        parJson.Append("{\"name\":").Append(JsonStr(name))
+                               .Append(",\"type\":").Append(JsonStr(prop.PropertyType.Name))
+                               .Append(",\"min\":").Append(JsonStr(Convert.ToString(min, InvCi)))
+                               .Append(",\"max\":").Append(JsonStr(Convert.ToString(max, InvCi)))
+                               .Append(",\"increment\":").Append(Num(step)).Append("}");
+                    }
+                    parJson.Append("]");
+
+                    // 4. The optimizer. Exactly default | genetic; anything else is
+                    //    refused rather than silently run as the default.
+                    string optName = string.IsNullOrWhiteSpace(optimizer) ? "default" : optimizer.Trim().ToLowerInvariant();
+                    if (optName != "default" && optName != "genetic")
+                    { WriteResult(resultFile, BtErr(id, "analyzerrun: --optimizer=" + optName + " is not a known optimizer. Valid: default | genetic.")); return; }
+                    string optTypeName = optName == "genetic"
+                        ? "NinjaTrader.NinjaScript.Optimizers.GeneticOptimizer"
+                        : "NinjaTrader.NinjaScript.Optimizers.DefaultOptimizer";
+                    Type optType = NewestLoadedType(optTypeName);
+                    if (optType == null)
+                    { WriteResult(resultFile, BtErr(id, "analyzerrun: optimizer type not found: " + optTypeName)); return; }
+                    NinjaTrader.NinjaScript.Optimizers.Optimizer opt =
+                        (NinjaTrader.NinjaScript.Optimizers.Optimizer)Activator.CreateInstance(optType);
+                    opt.SetState(NinjaTrader.NinjaScript.State.SetDefaults);
+                    strat.Optimizer = opt;
+
+                    // 5. The fitness measure, by class name, when asked for.
+                    string fitUsed = strat.OptimizationFitness != null ? strat.OptimizationFitness.GetType().Name : "";
+                    if (!string.IsNullOrWhiteSpace(fitness))
+                    {
+                        Type fitType = FindFitnessType(fitness.Trim());
+                        if (fitType == null)
+                        { WriteResult(resultFile, BtErr(id, "analyzerrun: fitness measure '" + fitness + "' not found.")); return; }
+                        NinjaTrader.NinjaScript.OptimizationFitnesses.OptimizationFitness fit =
+                            (NinjaTrader.NinjaScript.OptimizationFitnesses.OptimizationFitness)Activator.CreateInstance(fitType);
+                        fit.SetState(NinjaTrader.NinjaScript.State.SetDefaults);
+                        strat.OptimizationFitness = fit;
+                        fitUsed = fitType.Name;
+                    }
+
+                    // 6. Category and the tab's run type.
+                    NinjaTrader.NinjaScript.Category cat;
+                    StrategyAnalyzerGuiBacktestType bt;
+                    try
+                    {
+                        cat = (NinjaTrader.NinjaScript.Category)Enum.Parse(typeof(NinjaTrader.NinjaScript.Category), mode, true);
+                        bt  = (StrategyAnalyzerGuiBacktestType)Enum.Parse(typeof(StrategyAnalyzerGuiBacktestType), mode, true);
+                    }
+                    catch (Exception)
+                    { WriteResult(resultFile, BtErr(id, "analyzerrun: mode '" + mode + "' is not Optimize | WalkForward | WalkForwardAnchored | MultiObjective")); return; }
+                    strat.Category = cat;
+                    tsp.BacktestType = bt;
+
+                    long combos = -1;
+                    try { combos = NinjaTrader.NinjaScript.Optimizers.Optimizer.GetParametersCombinationsCount(strat); }
+                    catch (Exception) { }
+
+                    // 7. Where the strategy writes, and what the grid holds, before the run.
+                    //    The CSV prefix is set per host, as Nt8Cli sets its own: several
+                    //    writers share one log folder (a headless fleet beside this GUI),
+                    //    and only files with this host's prefix are this run's output.
+                    string logDir = StrategyLogDir(strat);
+                    string csvPrefix = SetLogFilePrefix(strat, "ntbridge-" + strat.GetType().Name);
+                    HashSet<string> csvBefore = CsvNames(logDir);
+                    HashSet<StrategyAnalyzerGridEntry> gridBefore = new HashSet<StrategyAnalyzerGridEntry>();
+                    CollectEntries(tab.Results, gridBefore);
+
+                    RoutedCommand rc = StrategyAnalyzerViewModel.RunCommand as RoutedCommand;
+                    if (rc == null) { WriteResult(resultFile, BtErr(id, "analyzerrun: RunCommand is not a RoutedCommand")); return; }
+                    if (!rc.CanExecute(null, saWin))
+                    { WriteResult(resultFile, BtErr(id, "analyzerrun: RunCommand.CanExecute=false - the tab is not ready to run")); return; }
+                    string head = "\"mode\":" + JsonStr(mode)
+                        + ",\"backtestType\":" + JsonStr(tsp.BacktestType.ToString())
+                        + ",\"category\":" + JsonStr(strat.Category.ToString())
+                        + ",\"template\":" + JsonStr(file)
+                        + ",\"strategy\":" + JsonStr(strat.GetType().FullName)
+                        + ",\"instrument\":" + JsonStr(tsp.InstrumentOrInstrumentList)
+                        + ",\"from\":" + JsonStr(strat.From.ToString("yyyy-MM-dd"))
+                        + ",\"to\":" + JsonStr(strat.To.ToString("yyyy-MM-dd"))
+                        + ",\"optimizationPeriod\":" + strat.OptimizationPeriod
+                        + ",\"testPeriod\":" + strat.TestPeriod
+                        + ",\"parameters\":" + parJson.ToString()
+                        + ",\"optimizer\":" + JsonStr(optType.Name)
+                        + ",\"fitness\":" + JsonStr(fitUsed)
+                        + ",\"combinations\":" + combos
+                        + ",\"logDir\":" + JsonStr(logDir)
+                        + ",\"logFilePrefix\":" + JsonStr(csvPrefix ?? "");
+                    LogSafe("analyzerrun: " + mode + " " + Path.GetFileName(file) + " opt=" + optSpec
+                        + " optimizer=" + optType.Name + " combinations=" + combos + " -> RunCommand");
+                    DateTime started = DateTime.UtcNow;
+                    rc.Execute(null, saWin);
+                    StartAnalyzerRunPoll(id, resultFile, saWin, head, optNames, gridBefore, logDir, csvPrefix, csvBefore, started, timeoutSec);
+                }
+                catch (Exception ex)
+                {
+                    LogSafe("analyzerrun: " + Deep(ex));
+                    WriteResult(resultFile, BtErr(id, "analyzerrun: " + Deep(ex)));
+                }
+            }));
+        }
+
+        // Every 2 s on the UI thread: is the tab's progress still showing, which
+        // grid entries are new. Finished = the progress had been visible and is
+        // gone, and every new entry carries a SystemPerformance - for two ticks
+        // in a row, because the grid is filled row by row.
+        private void StartAnalyzerRunPoll(string id, string resultFile, Window saWin, string head,
+                                          HashSet<string> optNames,
+                                          HashSet<StrategyAnalyzerGridEntry> gridBefore, string logDir,
+                                          string csvPrefix, HashSet<string> csvBefore, DateTime started,
+                                          double timeoutSec)
+        {
+            int[] ticks = { 0 };
+            bool[] seenProgress = { false };
+            int[] stable = { 0 };
+            Timer[] tref = new Timer[1];
+            tref[0] = new Timer(delegate
+            {
+                try
+                {
+                    ticks[0]++;
+                    string json = (string)saWin.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        try
+                        {
+                            StrategyAnalyzerViewModel vm = saWin.DataContext as StrategyAnalyzerViewModel;
+                            StrategyAnalyzerTabControl tab = vm != null ? vm.SelectedTab : null;
+                            if (tab == null) return null;
+                            bool progress = tab.IsProgressVisible;
+                            if (progress) seenProgress[0] = true;
+                            List<StrategyAnalyzerGridEntry> fresh = new List<StrategyAnalyzerGridEntry>();
+                            NewEntries(tab.Results, gridBefore, fresh);
+                            bool complete = fresh.Count > 0;
+                            foreach (StrategyAnalyzerGridEntry e in fresh)
+                                if (e.Results == null) { complete = false; break; }
+                            if (ticks[0] % 15 == 1)
+                                LogSafe("analyzerrun: tick " + ticks[0] + " progressVisible=" + progress
+                                    + " newRows=" + fresh.Count + " complete=" + complete);
+                            if (progress || !complete) { stable[0] = 0; return null; }
+                            // Fast runs may finish between two ticks without the progress
+                            // ever being seen; then the settled rows decide by themselves.
+                            stable[0]++;
+                            if (stable[0] < 2) return null;
+                            double elapsed = (DateTime.UtcNow - started).TotalSeconds;
+                            return BuildAnalyzerRunJson(id, head, optNames, fresh, elapsed, logDir, csvPrefix, csvBefore);
+                        }
+                        catch (Exception ex) { LogSafe("analyzerrun poll: " + Deep(ex)); return null; }
+                    }));
+                    if (json != null)
+                    {
+                        WriteResult(resultFile, json);
+                        LogSafe("analyzerrun: result captured for " + id + " after " + ticks[0] + " ticks");
+                        try { tref[0].Dispose(); } catch { }
+                    }
+                    else if ((DateTime.UtcNow - started).TotalSeconds > timeoutSec)
+                    {
+                        WriteResult(resultFile, BtErr(id, "analyzerrun: no completed result within "
+                            + timeoutSec.ToString("0", InvCi) + " s (run may still be going, or the grid"
+                            + " received no new entry; progress seen=" + seenProgress[0] + ")"));
+                        try { tref[0].Dispose(); } catch { }
+                    }
+                }
+                catch (Exception ex) { LogSafe("analyzerrun poll outer: " + ex.Message); }
+            }, null, 2000, 2000);
+        }
+
+        private static void CollectEntries(IEnumerable<StrategyAnalyzerGridEntry> entries,
+                                           HashSet<StrategyAnalyzerGridEntry> into)
+        {
+            if (entries == null) return;
+            foreach (StrategyAnalyzerGridEntry e in entries)
+            {
+                if (e == null) continue;
+                into.Add(e);
+                CollectEntries(e.Children, into);
+            }
+        }
+
+        private static void NewEntries(IEnumerable<StrategyAnalyzerGridEntry> entries,
+                                       HashSet<StrategyAnalyzerGridEntry> known,
+                                       List<StrategyAnalyzerGridEntry> fresh)
+        {
+            if (entries == null) return;
+            foreach (StrategyAnalyzerGridEntry e in entries)
+            {
+                if (e == null) continue;
+                if (!known.Contains(e)) fresh.Add(e);
+                NewEntries(e.Children, known, fresh);
+            }
+        }
+
+        // One JSON object per new grid entry. What NinjaTrader 8.1.8.2 puts into the
+        // grid for a walk-forward (measured 08.09.2026, run 5636bb75): one summary
+        // entry (IsWalkForwardSummaryRow, Children = the windows); per window an
+        // entry of Category WalkForward carrying the OUT-OF-SAMPLE run - the same
+        // Guid on two entry objects, one with 1 child and one with 3 - and three
+        // entries of Category Optimize (ParentGuid = the window's Guid), one per
+        // combination, carrying the IN-SAMPLE run with its PerformanceValue.
+        // OptimizationResults stayed empty on every entry. So the rows are made
+        // unique by Guid (the fuller object wins), the window count is taken from
+        // the WalkForward entries, and "ranked" from their Optimize children.
+        private string BuildAnalyzerRunJson(string id, string head, HashSet<string> optNames,
+                                            List<StrategyAnalyzerGridEntry> rows,
+                                            double elapsedSec, string logDir, string csvPrefix,
+                                            HashSet<string> csvBefore)
+        {
+            Dictionary<string, StrategyAnalyzerGridEntry> byGuid = new Dictionary<string, StrategyAnalyzerGridEntry>();
+            List<StrategyAnalyzerGridEntry> unique = new List<StrategyAnalyzerGridEntry>();
+            foreach (StrategyAnalyzerGridEntry e in rows)
+            {
+                string g = e.Guid ?? "";
+                StrategyAnalyzerGridEntry seen;
+                if (g.Length > 0 && byGuid.TryGetValue(g, out seen))
+                {
+                    if ((e.Children != null ? e.Children.Count : 0) > (seen.Children != null ? seen.Children.Count : 0))
+                    {
+                        unique[unique.IndexOf(seen)] = e;
+                        byGuid[g] = e;
+                    }
+                    continue;
+                }
+                if (g.Length > 0) byGuid[g] = e;
+                unique.Add(e);
+            }
+            int windows = 0, ranked = 0;
+            foreach (StrategyAnalyzerGridEntry w in unique)
+            {
+                string act = w.Action.ToString();
+                if (w.IsWalkForwardSummaryRow || (act != "WalkForward" && act != "WalkForwardAnchored")) continue;
+                windows++;
+                foreach (StrategyAnalyzerGridEntry c in unique)
+                    if (c.Action.ToString() == "Optimize" && c.ParentGuid == w.Guid
+                        && c.Results != null && c.Results.PerformanceValue > double.MinValue)
+                    { ranked++; break; }
+            }
+            var sb = new StringBuilder();
+            sb.Append("{\"id\":").Append(JsonStr(id)).Append(",\"status\":\"ok\",").Append(head);
+            sb.Append(",\"elapsedSec\":").Append(Num(elapsedSec));
+            sb.Append(",\"rows\":[");
+            bool first = true;
+            foreach (StrategyAnalyzerGridEntry e in unique)
+            {
+                if (!first) sb.Append(",");
+                first = false;
+                sb.Append("{\"guid\":").Append(JsonStr(e.Guid))
+                  .Append(",\"parentGuid\":").Append(JsonStr(e.ParentGuid))
+                  .Append(",\"isSummary\":").Append(e.IsWalkForwardSummaryRow ? "true" : "false")
+                  .Append(",\"category\":").Append(JsonStr(e.Action.ToString()))
+                  .Append(",\"strategy\":").Append(JsonStr(e.StrategyName))
+                  .Append(",\"instrument\":").Append(JsonStr(e.Instrument))
+                  .Append(",\"from\":").Append(JsonStr(e.From.ToString("yyyy-MM-dd HH:mm:ss")))
+                  .Append(",\"to\":").Append(JsonStr(e.To.ToString("yyyy-MM-dd HH:mm:ss")))
+                  .Append(",\"parametersString\":").Append(JsonStr(e.ParametersString))
+                  .Append(",\"optimizerType\":").Append(JsonStr(e.OptimizerType));
+                // The parameter values this row ran with - only those the request put
+                // under optimization, which is what the comparison between hosts is
+                // about (the combination rows carry no OptimizationParameters of their
+                // own, so the request's names are the filter, not the row's).
+                sb.Append(",\"parameters\":{");
+                bool fp = true;
+                if (e.Parameters != null)
+                    foreach (NinjaTrader.Gui.NinjaScript.ParameterWrapper pw in e.Parameters)
+                    {
+                        if (pw == null || pw.Name == null) continue;
+                        if (optNames.Count > 0 && !optNames.Contains(pw.Name)) continue;
+                        if (!fp) sb.Append(",");
+                        fp = false;
+                        sb.Append(JsonStr(pw.Name)).Append(":").Append(JsonStr(Convert.ToString(pw.Value, InvCi)));
+                    }
+                sb.Append("}");
+                sb.Append(",\"optimizationParameters\":[");
+                bool fo = true;
+                if (e.OptimizationParameters != null)
+                    foreach (NinjaTrader.NinjaScript.Parameter p in e.OptimizationParameters)
+                    {
+                        if (p == null) continue;
+                        if (!fo) sb.Append(",");
+                        fo = false;
+                        sb.Append("{\"name\":").Append(JsonStr(p.Name))
+                          .Append(",\"min\":").Append(JsonStr(Convert.ToString(p.Min, InvCi)))
+                          .Append(",\"max\":").Append(JsonStr(Convert.ToString(p.Max, InvCi)))
+                          .Append(",\"increment\":").Append(Num(p.Increment)).Append("}");
+                    }
+                sb.Append("]");
+                sb.Append(",\"results\":").Append(PerfSummaryJson(e.Results));
+                // The entry's own OptimizationResults - empty on every entry of the
+                // measured walk-forward (the in-sample ranking is in the Optimize
+                // children's Results.performanceValue); kept for the other run types.
+                sb.Append(",\"optimizationResults\":[");
+                bool fr = true;
+                if (e.OptimizationResults != null)
+                    foreach (SystemPerformance r in e.OptimizationResults)
+                    {
+                        if (r == null) continue;
+                        if (!fr) sb.Append(",");
+                        fr = false;
+                        sb.Append("{\"performanceValue\":").Append(Num(r.PerformanceValue))
+                          .Append(",\"parameterValues\":[");
+                        if (r.ParameterValues != null)
+                            for (int i = 0; i < r.ParameterValues.Length; i++)
+                            {
+                                if (i > 0) sb.Append(",");
+                                sb.Append(JsonStr(Convert.ToString(r.ParameterValues[i], InvCi)));
+                            }
+                        sb.Append("],\"totalTrades\":").Append(r.AllTrades != null ? r.AllTrades.Count : 0).Append("}");
+                    }
+                sb.Append("]");
+                sb.Append(",\"children\":").Append(e.Children != null ? e.Children.Count : 0);
+                sb.Append("}");
+            }
+            sb.Append("]");
+            sb.Append(",\"windows\":").Append(windows).Append(",\"rankedWindows\":").Append(ranked);
+            // The CSV files the strategy wrote during the run, in creation order -
+            // the order the headless runner numbers them in. With a prefix set, a
+            // file another writer added to the folder meanwhile is not this run's.
+            List<string> produced = new List<string>();
+            try
+            {
+                if (!string.IsNullOrEmpty(logDir) && Directory.Exists(logDir))
+                    foreach (string f in Directory.GetFiles(logDir, "*.csv"))
+                    {
+                        string name = Path.GetFileName(f);
+                        if (csvBefore.Contains(name)) continue;
+                        if (csvPrefix != null && !name.StartsWith(csvPrefix, StringComparison.OrdinalIgnoreCase)) continue;
+                        produced.Add(f);
+                    }
+                produced.Sort(delegate (string x, string y)
+                    { return File.GetCreationTimeUtc(x).CompareTo(File.GetCreationTimeUtc(y)); });
+            }
+            catch (Exception ex) { LogSafe("analyzerrun: csv scan: " + ex.Message); }
+            sb.Append(",\"csvFiles\":[");
+            for (int i = 0; i < produced.Count; i++)
+            {
+                if (i > 0) sb.Append(",");
+                sb.Append(JsonStr(produced[i]));
+            }
+            sb.Append("]}");
+            return sb.ToString();
+        }
+
+        private static string PerfSummaryJson(SystemPerformance perf)
+        {
+            if (perf == null) return "null";
+            var sb = new StringBuilder("{");
+            TradeCollection all = perf.AllTrades;
+            sb.Append("\"totalTrades\":").Append(all != null ? all.Count : 0);
+            if (all != null && all.TradesPerformance != null)
+            {
+                TradesPerformance tp = all.TradesPerformance;
+                sb.Append(",\"profitFactor\":").Append(Num(tp.ProfitFactor));
+                if (tp.Currency != null)
+                {
+                    sb.Append(",\"netProfit\":").Append(Num(tp.Currency.CumProfit));
+                    sb.Append(",\"maxDrawdown\":").Append(Num(tp.Currency.Drawdown));
+                }
+            }
+            sb.Append(",\"performanceValue\":").Append(Num(perf.PerformanceValue));
+            sb.Append("}");
+            return sb.ToString();
+        }
+
+        // The folder the strategy logs into: the path token of its LogModes
+        // property when it has one, else <MyDocuments>\cAlgo\Logfiles - the rule
+        // the headless runner (Nt8Cli.StrategyLogDir) applies, so both hosts
+        // collect the same files.
+        private static string StrategyLogDir(StrategyBase strat)
+        {
+            string logDir = null;
+            try
+            {
+                PropertyInfo lm = strat.GetType().GetProperty("LogModes", BindingFlags.Public | BindingFlags.Instance);
+                string logModes = lm != null ? (lm.GetValue(strat, null) as string ?? "") : "";
+                foreach (string raw in logModes.Split(','))
+                {
+                    string tok = raw.Trim();
+                    if (tok.IndexOf('\\') >= 0 || tok.IndexOf('/') >= 0 || tok.IndexOf(':') >= 0)
+                        logDir = tok;
+                }
+            }
+            catch (Exception) { }
+            if (logDir == null)
+                logDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "cAlgo", "Logfiles");
+            try { Directory.CreateDirectory(logDir); } catch (Exception) { }
+            return logDir;
+        }
+
+        // The strategy's CSV file prefix, when it has one to set: a public string
+        // property LogFilePrefix with a setter, static (RoadToSuccess declares it
+        // static) or instance. Returns the value written, or null when the strategy
+        // has no such property - then every new file in the folder counts.
+        private static string SetLogFilePrefix(StrategyBase strat, string value)
+        {
+            try
+            {
+                PropertyInfo p = strat.GetType().GetProperty("LogFilePrefix",
+                    BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
+                if (p == null || !p.CanWrite || p.PropertyType != typeof(string)) return null;
+                bool isStatic = p.GetGetMethod(true) != null && p.GetGetMethod(true).IsStatic;
+                p.SetValue(isStatic ? null : strat, value, null);
+                return value;
+            }
+            catch (Exception) { return null; }
+        }
+
+        private static HashSet<string> CsvNames(string dir)
+        {
+            HashSet<string> names = new HashSet<string>();
+            try
+            {
+                if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
+                    foreach (string f in Directory.GetFiles(dir, "*.csv")) names.Add(Path.GetFileName(f));
+            }
+            catch (Exception) { }
+            return names;
+        }
+
+        // Every `reload` leaves the previous NinjaTrader.Custom in the AppDomain
+        // (see ResolveStrategyType), so the LAST hit is the freshest build.
+        private static Type NewestLoadedType(string fullName)
+        {
+            Type newest = null;
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type hit = null;
+                try { hit = asm.GetType(fullName, false); } catch { }
+                if (hit != null) newest = hit;
+            }
+            return newest;
+        }
+
+        private static Type FindFitnessType(string simpleName)
+        {
+            Type newest = null;
+            Type baseType = typeof(NinjaTrader.NinjaScript.OptimizationFitnesses.OptimizationFitness);
+            foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type[] all;
+                try { all = asm.GetTypes(); }
+                catch (ReflectionTypeLoadException rtl) { all = rtl.Types; }
+                catch { continue; }
+                foreach (Type ty in all)
+                    if (ty != null && !ty.IsAbstract && baseType.IsAssignableFrom(ty)
+                        && string.Equals(ty.Name, simpleName, StringComparison.OrdinalIgnoreCase))
+                        newest = ty;
+            }
+            return newest;
+        }
+
+        // ExtractJsonString hands back the raw text between the quotes, escapes and
+        // all: a path the client serialised as "C:\\Users\\..." arrived with its
+        // backslashes doubled (Windows took the path anyway; the answer echoed it
+        // doubled, measured 08.09.2026). This undoes the escapes a JSON writer makes.
+        private static string JsonUnescape(string s)
+        {
+            if (s == null || s.IndexOf('\\') < 0) return s;
+            var sb = new StringBuilder(s.Length);
+            for (int i = 0; i < s.Length; i++)
+            {
+                char c = s[i];
+                if (c != '\\' || i + 1 >= s.Length) { sb.Append(c); continue; }
+                char n = s[++i];
+                switch (n)
+                {
+                    case '\\': sb.Append('\\'); break;
+                    case '"':  sb.Append('"'); break;
+                    case '/':  sb.Append('/'); break;
+                    case 'n':  sb.Append('\n'); break;
+                    case 'r':  sb.Append('\r'); break;
+                    case 't':  sb.Append('\t'); break;
+                    case 'u':
+                        if (i + 4 < s.Length)
+                        {
+                            sb.Append((char)Convert.ToInt32(s.Substring(i + 1, 4), 16));
+                            i += 4;
+                        }
+                        break;
+                    default:   sb.Append('\\').Append(n); break;
+                }
+            }
+            return sb.ToString();
+        }
+
+        private static double JsonNumberField(string json, string key, double dflt)
+        {
+            if (json == null) return dflt;
+            string pat = "\"" + key + "\"";
+            int i = json.IndexOf(pat, StringComparison.Ordinal);
+            if (i < 0) return dflt;
+            int c = json.IndexOf(':', i + pat.Length);
+            if (c < 0) return dflt;
+            int p = c + 1;
+            while (p < json.Length && (char.IsWhiteSpace(json[p]) || json[p] == '"')) p++;
+            int s = p;
+            while (p < json.Length && (char.IsDigit(json[p]) || json[p] == '.' ||
+                                       json[p] == '-' || json[p] == '+' ||
+                                       json[p] == 'e' || json[p] == 'E')) p++;
+            double v;
+            if (p > s && double.TryParse(json.Substring(s, p - s),
+                                         System.Globalization.NumberStyles.Float, InvCi, out v)
+                && v > 0.0)
+                return v;
+            return dflt;
+        }
+
+        // ── satemplate ──────────────────────────────────────────────────────────
+        //  Put one of NinjaTrader's own strategy templates on the Strategy Analyzer
+        //  tab, so a backtest can be asked for by FILE instead of by parameter list.
+        //
+        //  `configure` writes individual properties from a config.json onto the
+        //  tab's strategy, and `backtest` does the same before it runs. That is the
+        //  right shape for a handful of parameters and the wrong one for the files
+        //  NinjaTrader writes itself under templates\Strategy: those carry the
+        //  COMPLETE parameter set, and a test suite is usually one strategy class
+        //  against many of them, identical in everything else. Naming the file beats
+        //  restating hundreds of properties, and it cannot drift from what the GUI
+        //  runs, because it IS what the GUI runs.
+        //
+        //  The template is ASSIGNED, not copied member by member. RestoreTemplate
+        //  hands back the strategy the file describes - a whole instance - and the
+        //  tab's StrategyTemplate takes it. Read off the running NinjaTrader with
+        //  `probe` before this was written, rather than assumed:
+        //      TabStrategyProperties.StrategyTemplate  StrategyBase  canWrite=True
+        //      TabStrategyProperties.Strategy          String        canWrite=True
+        //  Copying onto the instance already sitting there was the alternative, and
+        //  it would mean deciding for each of its 438 properties whether it is
+        //  configuration or runtime state (State, Account, Instrument). Every wrong
+        //  call there is silent, which is why RestoreTemplate returns an instance in
+        //  the first place.
+        //
+        //  ⚠ ORDER: `Strategy` BEFORE the template, never after. Writing the name
+        //  makes NinjaTrader install a FRESH StrategyTemplate, and whatever was put
+        //  on the old one is dropped without an error - upstream's own finding, in
+        //  configure.py's header and its issue #6. So a template for a different
+        //  class selects the class first and assigns second; doing it the other way
+        //  round loses the entire template and says nothing.
+        //
+        //  Switching is not skipped, because a suite is many strategy CLASSES, and
+        //  refusing here would put a manual click between every one of them.
+        private string RunSaTemplate(string id, string text)
+        {
+            string want = ExtractJsonString(text, "template");
+            if (string.IsNullOrWhiteSpace(want))
+                return BtErr(id, "satemplate: no template given");
+
+            Window saWin = FindStrategyAnalyzerWindow();
+            if (saWin == null)
+                return BtErr(id, "satemplate: no Strategy Analyzer window open");
+
+            try
+            {
+                return (string)saWin.Dispatcher.Invoke(new Func<string>(delegate
+                {
+                    try
+                    {
+                        StrategyAnalyzerViewModel vm = saWin.DataContext as StrategyAnalyzerViewModel;
+                        StrategyAnalyzerTabControl tab = vm != null ? vm.SelectedTab : null;
+                        if (tab == null) return BtErr(id, "satemplate: no active SA tab");
+                        StrategyAnalyzerTabProperties tsp = tab.TabStrategyProperties;
+                        if (tsp == null)
+                            return BtErr(id, "satemplate: the tab has no TabStrategyProperties");
+
+                        StrategyBase before = tsp.StrategyTemplate;
+                        string file = TemplatePath(before, want);
+                        if (string.IsNullOrEmpty(file))
+                            return BtErr(id, "satemplate: cannot resolve template " + want
+                                + " - give a full path, or open the strategy so its"
+                                + " template folder is known");
+
+                        string problem;
+                        StrategyBase restored = RestoreTemplate(file, out problem);
+                        if (restored == null)
+                            return BtErr(id, "satemplate: " + problem);
+
+                        string had = before != null ? before.GetType().FullName : "(none)";
+                        string got = restored.GetType().FullName;
+                        bool switched = false;
+                        if (!string.Equals(got, had, StringComparison.Ordinal))
+                        {
+                            // The tab names the strategy the way its own dropdown does,
+                            // by SHORT name, not by full type. Read off a running tab
+                            // with `probe`, where Strategy held the bare class name
+                            // beside a StrategyTemplate whose type was that same name
+                            // under NinjaTrader.NinjaScript.Strategies.
+                            tsp.Strategy = restored.GetType().Name;
+                            switched = true;
+                        }
+
+                        tsp.StrategyTemplate = restored;
+
+                        // ⚠ THE TAB KEEPS ITS OWN INSTRUMENT. It is not taken from the
+                        // template, measured on a running NinjaTrader: after assigning
+                        // a template that names NQ 06-26, the strategy read NQ 06-26
+                        // and the tab still read ES 09-26. A run in that state applies
+                        // the template's parameters to the tab's instrument and says
+                        // nothing about it - a wrong result that looks like a right
+                        // one. So the name travels, when the template carries one.
+                        //
+                        // Written AFTER the template, and read back below together
+                        // with it: if this write were to reinstall the template the
+                        // way `Strategy` does, the reference check would catch it.
+                        string tmplInstrument = restored.InstrumentOrInstrumentList;
+                        if (!string.IsNullOrWhiteSpace(tmplInstrument))
+                            tsp.InstrumentOrInstrumentList = tmplInstrument;
+
+                        // An assignment that does not throw is not evidence that it
+                        // stuck: the property could be handing the value to a binding
+                        // that drops it. So the instance is read back and compared by
+                        // REFERENCE, which is the only comparison that cannot be
+                        // satisfied by a copy that looks similar.
+                        StrategyBase after = tsp.StrategyTemplate;
+                        bool stuck = ReferenceEquals(after, restored);
+
+                        var sb = new StringBuilder("{\"id\":").Append(JsonStr(id));
+                        sb.Append(",\"status\":").Append(JsonStr(stuck ? "ok" : "error"));
+                        sb.Append(",\"template\":").Append(JsonStr(file));
+                        sb.Append(",\"strategy\":").Append(JsonStr(got));
+                        // What the TAB says it holds now, not what was written to it.
+                        sb.Append(",\"tabStrategy\":").Append(JsonStr(tsp.Strategy));
+                        // The three values a run is actually carried out with, read off
+                        // the tab and the template AFTER the writes. The instrument is
+                        // the tab's, because that is the one the Analyzer uses.
+                        sb.Append(",\"instrument\":").Append(JsonStr(tsp.InstrumentOrInstrumentList));
+                        sb.Append(",\"from\":").Append(JsonStr(
+                            after != null ? after.From.ToString("yyyy-MM-dd") : ""));
+                        sb.Append(",\"to\":").Append(JsonStr(
+                            after != null ? after.To.ToString("yyyy-MM-dd") : ""));
+                        sb.Append(",\"switchedFrom\":").Append(JsonStr(switched ? had : ""));
+                        sb.Append(",\"applied\":").Append(stuck ? "true" : "false");
+                        if (stuck)
+                            sb.Append(",\"params\":").Append(ParamReadback(after));
+                        else
+                            sb.Append(",\"error\":").Append(JsonStr(
+                                "the tab kept its previous StrategyTemplate instance"));
+                        sb.Append("}");
+                        LogSafe("satemplate: " + Path.GetFileName(file) + " -> " + got
+                            + (stuck ? " applied" : " NOT applied"));
+                        return sb.ToString();
+                    }
+                    catch (Exception ex) { return BtErr(id, "satemplate: " + Deep(ex)); }
+                }));
+            }
+            catch (Exception ex) { return BtErr(id, "satemplate outer: " + Deep(ex)); }
+        }
+
+
+        // ── playbackrun ──────────────────────────────────────────────────────
+        // Drive Playback, not just read it. `playback` reports the transport's
+        // state; this runs it: connect, set source and range, position the clock,
+        // and get a strategy going — each step reported with what it WROTE and
+        // what it READ BACK.
+        //
+        // Why the read-back on every write: a reflection assignment that does not
+        // throw is not evidence the value stuck. Measured against NinjaTrader
+        // 8.1.8.2: `PlaybackAdapter.FromEst` set before the connection is up reads
+        // back as 01.01.0001, and `PlaybackSpeed` set before connecting is moved
+        // to `oldPlaybackSpeed` while the live field falls back to 1 — a run that
+        // looks configured and replays at 1x instead of max.
+        //
+        // Stages, so a failure is localized rather than global:
+        //   members       reflect the PlaybackAdapter statics (names differ by build)
+        //   connect       simulation mode, source, range, speed, connect
+        //   range         range + speed + Reset — only valid AFTER connect
+        //   uitree        dump a window's visual tree (window: title substring)
+        //   elprobe       dump one named element, its bindings and context menu
+        //   uiset         write the Playback window's own controls
+        //   attach        add a strategy to the grid and configure it from a template
+        //
+        // Why `attach` goes through the grid: adding a strategy to Account.Strategies
+        // is NOT what the Control Center does. Measured 2026-08-18 — the Strategies
+        // grid stayed empty and SetState(DataLoaded) went straight to Finalized
+        // with NinjaTrader's own "All data must first be loaded by the hosting
+        // NinjaScript in its configure state". The grid is bound to its own
+        // ObservableCollection, and it also creates the data series, loads it, and
+        // steps the state machine - so `attach` uses AddStrategyToGrid.
+        private string RunPlaybackRun(string id, string triggerJson)
+        {
+            string stage = ExtractJsonString(triggerJson, "stage");
+            if (string.IsNullOrWhiteSpace(stage)) stage = "connect";
+            string typeName = ExtractJsonString(triggerJson, "strategy");
+            string instName = ExtractJsonString(triggerJson, "instrument");
+            string fromS    = ExtractJsonString(triggerJson, "from");
+            string toS      = ExtractJsonString(triggerJson, "to");
+            string bpS      = ExtractJsonString(triggerJson, "barsPeriod");
+            string trS      = ExtractJsonString(triggerJson, "tickReplay");
+            string srcS     = ExtractJsonString(triggerJson, "source");
+            Dictionary<string, string> prms = ParseParams(triggerJson);
+
+            StringBuilder sb = new StringBuilder("{\"id\":");
+            sb.Append(JsonStr(id)).Append(",\"status\":\"ok\",\"stage\":")
+              .Append(JsonStr(stage)).Append(",\"steps\":[");
+            bool[] first = new bool[] { true };
+            Action<string, bool, string> step = delegate(string what, bool ok, string detail)
+            {
+                if (!first[0]) sb.Append(",");
+                sb.Append("{\"step\":").Append(JsonStr(what))
+                  .Append(",\"ok\":").Append(ok ? "true" : "false")
+                  .Append(",\"detail\":").Append(JsonStr(detail == null ? "" : detail)).Append("}");
+                first[0] = false;
+                // Live progress: the result file only exists once this stage RETURNS.
+                // Measured 2026-08-20 (runs 5 and 8): the UI thread died inside the
+                // enable, the attach result appeared minutes after the driver was gone,
+                // and nothing showed HOW FAR the stage had got while it ran. This file
+                // is appended the moment a sub-step completes, so a frozen NinjaTrader
+                // leaves behind the exact last step that still worked.
+                Progress(id, (ok ? "ok    " : "FAIL  ") + what.Trim()
+                             + (string.IsNullOrEmpty(detail) ? "" : ("  " + detail)));
+            };
+
+            try
+            {
+                Type pb = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                if (pb == null)
+                {
+                    step("locate PlaybackAdapter", false, "type not found");
+                    sb.Append("]}");
+                    return sb.ToString();
+                }
+
+                PbRunCtx ctx = new PbRunCtx();
+                ctx.Id = id;
+                ctx.TriggerJson = triggerJson;
+                ctx.Stage = stage;
+                ctx.TypeName = typeName;
+                ctx.InstName = instName;
+                ctx.FromS = fromS;
+                ctx.ToS = toS;
+                ctx.BpS = bpS;
+                ctx.TrS = trS;
+                ctx.SrcS = srcS;
+                ctx.Prms = prms;
+                ctx.Pb = pb;
+                ctx.Sb = sb;
+                ctx.Step = step;
+
+                if (stage == "members") return Stage_Members(ctx);
+
+                if (stage == "openwindow") return Stage_Openwindow(ctx);
+
+                if (stage == "uitree" || stage == "elprobe") return Stage_Uitree_Elprobe(ctx);
+
+                if (stage == "uiset") return Stage_Uiset(ctx);
+
+                if (stage == "selprobe") return Stage_Selprobe(ctx);
+
+                if (stage == "dialogset") return Stage_Dialogset(ctx);
+                if (stage == "play") return Stage_Play(ctx);
+
+                if (stage == "transport") return Stage_Transport(ctx);
+                if (stage == "cmdprobe" || stage == "invokecmd") return Stage_Cmdprobe_Invokecmd(ctx);
+
+                if (stage == "resname") return Stage_Resname(ctx);
+
+                if (stage == "ntlog") return Stage_Ntlog(ctx);
+
+                if (stage == "stratlive") return Stage_Stratlive(ctx);
+
+                if (stage == "strategystate") return Stage_Strategystate(ctx);
+
+                if (stage == "playbackevents") return Stage_Playbackevents(ctx);
+
+                if (stage == "botout") return Stage_Botout(ctx);
+
+                if (stage == "restore") return Stage_Restore(ctx);
+
+                if (stage == "source") return Stage_Source(ctx);
+
+                if (stage == "panelstate") return Stage_Panelstate(ctx);
+
+                if (stage == "panelflips") return Stage_Panelflips(ctx);
+
+                if (stage == "ready") return Stage_Ready(ctx);
+
+                if (stage == "speed") return Stage_Speed(ctx);
+
+                if (stage == "template") return Stage_Template(ctx);
+
+                if (stage == "findmethod") return Stage_Findmethod(ctx);
+
+                if (stage == "elmembers") return Stage_Elmembers(ctx);
+
+                if (stage == "winmembers") return Stage_Winmembers(ctx);
+
+                if (stage == "setel") return Stage_Setel(ctx);
+
+                if (stage == "hide") return Stage_Hide(ctx);
+
+                if (stage == "unhide") return Stage_Unhide(ctx);
+
+                if (stage == "park") return Stage_Park(ctx);
+
+                if (stage == "closedialogs") return Stage_Closedialogs(ctx);
+
+                if (stage == "baseline") return Stage_Baseline(ctx);
+
+                if (stage == "dialogs") return Stage_Dialogs(ctx);
+
+                if (stage == "enablestrategy") return Stage_Enablestrategy(ctx);
+
+                if (stage == "removestrategy") return Stage_Removestrategy(ctx);
+                if (stage == "uiidle") return Stage_Uiidle(ctx);
+                if (stage == "alloff") return Stage_Alloff(ctx);
+                if (stage == "disconnect") return Stage_Disconnect(ctx);
+
+                if (stage == "recycle") return Stage_Recycle(ctx);
+
+                if (stage == "connect") return Stage_Connect(ctx);
+
+                if (stage == "range") return Stage_Range(ctx);
+
+                if (stage == "stratdump") return Stage_Stratdump(ctx);
+
+                if (stage == "arm") return Stage_Arm(ctx);
+
+                if (stage == "attach") return Stage_Attach(ctx);
+
+                step("stage", false, "unknown stage '" + stage + "'");
+            }
+            catch (Exception ex) { step("exception", false, ex.GetType().Name + ": " + ex.Message); }
+            sb.Append("]}");
+            return sb.ToString();
+        }
+
+        // The state RunPlaybackRun sets up once and every stage below reads. It exists so
+        // each stage can be its own method while its body stays exactly as it was.
+        private sealed class PbRunCtx
+        {
+            public string Id;
+            public string TriggerJson;
+            public string Stage;
+            public string TypeName;
+            public string InstName;
+            public string FromS;
+            public string ToS;
+            public string BpS;
+            public string TrS;
+            public string SrcS;
+            public Dictionary<string, string> Prms;
+            public Type Pb;
+            public StringBuilder Sb;
+            public Action<string, bool, string> Step;
+        }
+
+        private string Stage_Members(PbRunCtx ctx)
+        {
+            Type pb = ctx.Pb;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    foreach (PropertyInfo pi in pb.GetProperties(BFStatic))
+                        step("prop " + pi.Name, pi.CanWrite, pi.PropertyType.Name + " = " + SafeRead(pi, null));
+                    foreach (FieldInfo fi in pb.GetFields(BFStatic))
+                        step("field " + fi.Name, !fi.IsInitOnly, fi.FieldType.Name + " = " + SafeReadField(fi, null));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Uitree_Elprobe(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            string stage = ctx.Stage;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    string wTitle = ExtractJsonString(triggerJson, "window");
+                    Window w = FindWindowByTitle(wTitle);
+                    if (w == null)
+                    {
+                        step("window '" + (wTitle == null ? "Playback" : wTitle) + "'", false,
+                             "not found. Present: " + WindowTitles());
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+                    step("window", true, w.GetType().FullName);
+                    string elName = ExtractJsonString(triggerJson, "element");
+                    // Thread-affine: read on the window's OWN dispatcher. NinjaTrader
+                    // is multi-UI-threaded, so Application.Current.Windows does not
+                    // even list every window — hence Globals.AllWindows above.
+                    w.Dispatcher.Invoke(new Action(delegate
+                    {
+                        if (stage == "uitree") DumpVisualTree(w, 0, step);
+                        else DumpElement(w, elName, step);
+                    }));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Uiset(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            string fromS = ctx.FromS;
+            string toS = ctx.ToS;
+            string srcS = ctx.SrcS;
+            Type pb = ctx.Pb;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    Window w = FindWindowByTitle("Playback");
+                    // ⚠ THIS STAGE SETS THE PANEL, AND A HOST WITHOUT A UI HAS NONE.
+                    //
+                    // Its whole job is keeping the Playback window's controls in step with
+                    // the transport - dtpStart, dtpEnd, the source radios - so the display
+                    // does not contradict the run. Worth doing when a display exists.
+                    //
+                    // The values themselves are set by the NEXT stage, `range`, straight on
+                    // the adapter (FromEst/ToEst), which is the route our GUI-less host
+                    // uses for everything. So headless there is nothing here to do and
+                    // nothing lost by not doing it - but the run died here anyway, because
+                    // a stage that cannot find its window returns a failed step.
+                    if (w == null && NoUiHost())
+                    {
+                        step("Playback window", true,
+                             "no UI in this host - nothing to keep in step. The dates and the"
+                             + " source are set on the adapter by stage 'range', which is the"
+                             + " only place they take effect anyway.");
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+                    if (w == null) { step("Playback window", false, "not found"); sb.Append("]}"); return sb.ToString(); }
+                    step("Playback window", true, w.GetType().FullName);
+                    DateTime uFrom = string.IsNullOrWhiteSpace(fromS) ? DateTime.MinValue : DateTime.Parse(fromS, InvCi);
+                    DateTime uTo   = string.IsNullOrWhiteSpace(toS)   ? DateTime.MinValue : DateTime.Parse(toS, InvCi);
+                    string play = ExtractJsonString(triggerJson, "play");
+                    // Set inside the dispatcher block, ACTED ON after it returns. A one-element
+                    // array because a delegate cannot assign to a local of the enclosing method.
+                    bool[] wantsTransportWait = new bool[] { false };
+                    w.Dispatcher.Invoke(new Action(delegate
+                    {
+                        // The transport statics do not move the panel; the panel is a
+                        // separate set of controls. Leaving them out of sync is worse
+                        // than not setting them at all — the display then contradicts
+                        // the run.
+                        if (uFrom != DateTime.MinValue) SetElementValue(w, "dtpStart", "Value", uFrom, step);
+                        if (uTo   != DateTime.MinValue) SetElementValue(w, "dtpEnd", "Value", uTo.Date.AddDays(1).AddSeconds(-1), step);
+                        if (!string.IsNullOrWhiteSpace(srcS))
+                        {
+                            bool hist = string.Equals(srcS, "historical", StringComparison.OrdinalIgnoreCase);
+                            // ARM THE WATCHER FIRST. Switching TO Historical makes NT8 raise
+                            // a modal (i) notice ("no Level II market depth in this mode"),
+                            // and it does so SYNCHRONOUSLY inside the SetElementValue below -
+                            // that Invoke does not return while the dialog stands. A handler
+                            // called after the write therefore never runs; measured
+                            // 30.08.2026 on a build that had exactly that, the dialog came up
+                            // unchanged. So the watcher runs on its OWN thread, started
+                            // before the write, and confirms through the dispatcher, which
+                            // keeps pumping inside a modal's own frame.
+                            string noticeResult = null;
+                            Thread noticeWatch = null;
+                            if (hist)
+                            {
+                                noticeWatch = new Thread(delegate ()
+                                {
+                                    noticeResult = DismissHistoricalNotice(20000);
+                                });
+                                noticeWatch.IsBackground = true;
+                                noticeWatch.Start();
+                            }
+                            // DISPLAY ONLY - never fatal. The source itself is decided by
+                            // PlaybackAdapter.IsSourceHistoricalData at stage "3 source";
+                            // these radios only keep the panel from contradicting the run.
+                            // Measured 30.08.2026: writing rbHistoricalData.IsChecked while
+                            // the connection is up threw TargetInvocationException and took
+                            // the whole run with it (rc 2). A display defect is reported,
+                            // not paid for with the measurement.
+                            // A SOFT step: same text, same visibility, never a failure
+                            // verdict. SetElementValue catches internally and reports
+                            // through step(..., false, ...), so wrapping the calls in
+                            // try/catch changes nothing - the stage dies on the verdict,
+                            // not on an exception.
+                            //
+                            // Writing the Historical radio makes NinjaTrader re-parse the
+                            // panel's date fields and that parse throws (measured
+                            // 30.08.2026: TargetInvocationException <- FormatException:
+                            // "String was not recognized as a valid DateTime" - the same
+                            // wording as the modal "String was not recognized as a valid
+                            // DateTime. (Panic)" that NinjaTrader raises when Playback is
+                            // connected without a date range, measured 2026-08-24). It is
+                            // NinjaTrader's defect; the run's source is decided by
+                            // PlaybackAdapter.IsSourceHistoricalData at stage "3 source".
+                            // A display that refuses to move is reported, not paid for with
+                            // the measurement.
+                            bool radiosMoved = true;
+                            Action<string, bool, string> softStep = delegate (string sN, bool sOk, string sD)
+                            {
+                                if (!sOk) radiosMoved = false;
+                                step(sN, true, (sOk ? "" : "DISPLAY ONLY, not updated: ") + sD);
+                            };
+                            SetElementValue(w, "rbHistoricalData", "IsChecked", hist, softStep);
+                            SetElementValue(w, "rbRecordedData", "IsChecked", !hist, softStep);
+                            step("source radios", true, radiosMoved
+                                 ? ("panel now shows " + (hist ? "Historical" : "Market Replay"))
+                                 : ("panel keeps the PREVIOUS source - NinjaTrader throws while"
+                                    + " re-parsing the date fields on this write. The RUN uses "
+                                    + (hist ? "Historical" : "Market Replay")
+                                    + ", set on PlaybackAdapter.IsSourceHistoricalData at stage 3,"
+                                    + " which is what decides it."));
+                            if (noticeWatch != null)
+                            {
+                                noticeWatch.Join(21000);
+                                step("historical notice", true, noticeResult ?? "watcher gave no verdict");
+                            }
+                        }
+                        if (!string.IsNullOrWhiteSpace(play))
+                        {
+                            // The transport is driven by PlaybackSpeed, NOT by the button.
+                            // Measured 2026-08-19: writing btnPlay.IsChecked=false read back
+                            // false while the transport kept running - the property changes
+                            // the visual state only. Starting happened to work by writing;
+                            // stopping did not, and that asymmetry is exactly what an
+                            // unverified write hides. Hence: write the speed, then verify the
+                            // EFFECT on the clock (below), never the button.
+                            bool wish = string.Equals(play, "true", StringComparison.OrdinalIgnoreCase);
+
+                            // The speed goes HERE, with the start - see "SPEED IS A
+                            // START COMMAND" in stage "range". Written during setup it
+                            // sent the transport racing through the range before
+                            // anything was attached. The FIELD is written too:
+                            // connecting moves the property value to `oldPlaybackSpeed`
+                            // and leaves the live field at 1 - which is also why the
+                            // panel read "1x" on a clock running at full speed. The
+                            // label further down is refreshed from the ACTUAL value, so
+                            // the panel stops contradicting the run.
+                            if (wish)
+                            {
+                                FieldInfo fiMaxU = pb.GetField("MaxSpeedValue", BFStatic);
+                                object maxU = fiMaxU != null ? fiMaxU.GetValue(null) : (object)int.MaxValue;
+                                SetStatic(pb, "PlaybackSpeed", maxU, step);
+                                try
+                                {
+                                    FieldInfo fiSpU = pb.GetField("playbackSpeed", BFStatic);
+                                    if (fiSpU != null)
+                                    {
+                                        fiSpU.SetValue(null, maxU);
+                                        step("field playbackSpeed",
+                                             fiSpU.GetValue(null).ToString() == maxU.ToString(),
+                                             "wrote=" + maxU + " read=" + fiSpU.GetValue(null));
+                                    }
+                                }
+                                catch (Exception ex) { step("field playbackSpeed", false, ex.Message); }
+
+                                // ⚠ THE WAIT DOES NOT BELONG HERE - THIS IS THE UI THREAD.
+                                //
+                                // Everything in this block runs inside w.Dispatcher.Invoke.
+                                // A wait here is the UI thread waiting for itself, and
+                                // TransportMoving samples NowEst twice 1200 ms apart - so it
+                                // would hold the interface for at least that long, every time,
+                                // while NinjaTrader needs exactly this thread to move the
+                                // transport it is being asked about.
+                                //
+                                // The rule "never wait inside the dispatcher" was written down
+                                // on 2026-08-19 and broken again on 2026-08-20 by this very
+                                // block. So the flag is set here and the WAIT happens after the
+                                // Invoke returns, on the worker thread.
+                                wantsTransportWait[0] = !string.Equals(
+                                    ExtractJsonString(triggerJson, "awaitTransport"),
+                                    "false", StringComparison.OrdinalIgnoreCase);
+                            }
+
+                            // The transport is run by the SPEED, not by a button. A positive
+                            // PlaybackSpeed runs it, 0 parks it - bisected on
+                            // 2026-08-19 and documented independently upstream. Pressing the
+                            // play button needed the window, the right visual state and a real
+                            // Click event; a static property write needs none of that.
+                            if (!wish)
+                            {
+                                int backU;
+                                string probU = SetPlaybackSpeed(0, out backU);
+                                step("transport", probU == null, probU == null
+                                     ? "PlaybackSpeed=0 (parked; verify the EFFECT with stage 'transport')"
+                                     : probU);
+                            }
+                            else
+                            {
+                                DateTime seenU;
+                                bool movingU = TransportMoving(out seenU);
+                                step("transport", true, "moving=" + movingU + " at " + seenU);
+                            }
+                        }
+                        // Speed label derived from the ACTUAL value, never guessed.
+                        PropertyInfo piSp = pb.GetProperty("PlaybackSpeed", BFStatic);
+                        FieldInfo fiMx = pb.GetField("MaxSpeedValue", BFStatic);
+                        object now = piSp != null ? piSp.GetValue(null) : null;
+                        object max = fiMx != null ? fiMx.GetValue(null) : null;
+                        string txt = (now != null && max != null && now.ToString() == max.ToString())
+                                     ? "Max" : (now + "x");
+                        SetElementValue(w, "textBlockSpeed", "Text", txt, step);
+                    }));
+
+                    // ⚠ PHASE 3, ON THE WORKER THREAD - the dispatcher is free again here.
+                    //
+                    // Writing the speed is not the same as the transport running: the
+                    // read-back inside the block came from the same reference in the same
+                    // instant and would report success for a write NinjaTrader ignored.
+                    // NowEst is written by NinjaTrader alone, so its motion is the evidence -
+                    // and TransportMoving samples it twice 1200 ms apart, which is a
+                    // measurement interval and must never sit on the UI thread.
+                    //
+                    // `awaitTransport:"false"` splits trigger and wait for a walkthrough;
+                    // stage `transport` then carries phases 3 and 4.
+                    if (wantsTransportWait[0])
+                    {
+                        DateTime seenU;
+                        string gotU; long msU;
+                        bool runU = WaitUntilChanged(delegate
+                        {
+                            DateTime s4;
+                            return TransportMoving(out s4) ? "moving" : "parked";
+                        }, TransportMoving(out seenU) ? "moving" : "parked", "moving",
+                           RequestTtlSec(triggerJson), out gotU, out msU);
+                        step("transport moving", runU,
+                             (runU ? "running after " : "STILL parked after ")
+                             + msU + " ms   NowEst last seen " + seenU);
+                    }
+                    else
+                        step("transport moving", true,
+                             "NOT waited on request (awaitTransport=false) - "
+                             + "watch it with stage 'transport'");
+
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Selprobe(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Measure the selection BEFORE and AFTER, on the object itself.
+                    // "Remove" stays disabled after setting Records[i].IsSelected, so
+                    // the grid evidently tracks its selection somewhere else - this
+                    // reports where, instead of guessing.
+                    string want2 = ExtractJsonString(triggerJson, "strategy");
+                    Window cc4 = FindWindowByTitle("Control Center");
+                    if (cc4 == null) { step("Control Center", false, "not found"); sb.Append("]}"); return sb.ToString(); }
+                    cc4.Dispatcher.Invoke(new Action(delegate
+                    {
+                        object grid = FindElement(cc4, "grdStrategies");
+                        if (grid == null) { step("grdStrategies", false, "not found"); return; }
+                        step("grid", true, grid.GetType().FullName);
+                        ReportSelection(grid, "before", step);
+
+                        PropertyInfo pRec = grid.GetType().GetProperty("Records");
+                        System.Collections.IEnumerable recs =
+                            pRec == null ? null : pRec.GetValue(grid, null) as System.Collections.IEnumerable;
+                        if (recs == null) { step("Records", false, "not enumerable"); return; }
+                        int n = 0;
+                        object chosen = null;
+                        foreach (object rec in recs)
+                        {
+                            n++;
+                            if (rec == null) continue;
+                            PropertyInfo pdi = rec.GetType().GetProperty("DataItem");
+                            object di = pdi == null ? null : pdi.GetValue(rec, null);
+                            string nm = "";
+                            if (di != null)
+                            {
+                                PropertyInfo pn = di.GetType().GetProperty("Name");
+                                if (pn != null) nm = ("" + pn.GetValue(di, null)).Trim();
+                            }
+                            step("record " + n, true, rec.GetType().Name + "  DataItem.Name='" + nm + "'");
+                            if (chosen == null && (string.IsNullOrWhiteSpace(want2)
+                                || nm.IndexOf(want2, StringComparison.OrdinalIgnoreCase) >= 0))
+                                chosen = rec;
+                        }
+                        if (chosen == null) { step("match", false, "no record for '" + want2 + "'"); return; }
+
+                        foreach (PropertyInfo rp in chosen.GetType().GetProperties(
+                                     BindingFlags.Public | BindingFlags.Instance))
+                        {
+                            if (rp.Name.IndexOf("Select", StringComparison.OrdinalIgnoreCase) < 0
+                                && rp.Name.IndexOf("Active", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                            step("  record." + rp.Name, rp.CanWrite, rp.PropertyType.Name + " = " + SafeReadOn(rp, chosen));
+                        }
+
+                        try
+                        {
+                            PropertyInfo pis = chosen.GetType().GetProperty("IsSelected");
+                            if (pis != null && pis.CanWrite) pis.SetValue(chosen, true, null);
+                            step("set IsSelected", true, "wrote true, read " + SafeReadOn(pis, chosen));
+                        }
+                        catch (Exception ex) { step("set IsSelected", false, ex.Message); }
+
+                        ReportSelection(grid, "after", step);
+
+                        PropertyInfo pcm3 = grid.GetType().GetProperty("ContextMenu");
+                        System.Windows.Controls.ContextMenu cm3 =
+                            pcm3 == null ? null : pcm3.GetValue(grid, null) as System.Windows.Controls.ContextMenu;
+                        if (cm3 != null)
+                        {
+                            // IsEnabled on a context menu that was never opened is stale:
+                            // WPF evaluates CanExecute on ContextMenuOpening. Read it once
+                            // closed, then open the menu, requery, and read it again - the
+                            // difference tells us whether the entry is really unavailable
+                            // or just not evaluated yet.
+                            foreach (object it in cm3.Items)
+                            {
+                                System.Windows.Controls.MenuItem mi = it as System.Windows.Controls.MenuItem;
+                                if (mi == null || mi.Header == null) continue;
+                                string h = ("" + mi.Header).Trim();
+                                if (h == "Remove" || h == "Enable" || h == "Disable")
+                                    step("  closed menu " + h, mi.IsEnabled, mi.IsEnabled ? "enabled" : "disabled");
+                            }
+                            try
+                            {
+                                cm3.PlacementTarget = grid as System.Windows.UIElement;
+                                cm3.IsOpen = true;
+                                System.Windows.Input.CommandManager.InvalidateRequerySuggested();
+                                cm3.Dispatcher.Invoke(new Action(delegate { }),
+                                    System.Windows.Threading.DispatcherPriority.ContextIdle);
+                                foreach (object it in cm3.Items)
+                                {
+                                    System.Windows.Controls.MenuItem mi = it as System.Windows.Controls.MenuItem;
+                                    if (mi == null || mi.Header == null) continue;
+                                    string h = ("" + mi.Header).Trim();
+                                    if (h == "Remove" || h == "Enable" || h == "Disable")
+                                        step("  opened menu " + h, mi.IsEnabled, mi.IsEnabled ? "enabled" : "disabled");
+                                }
+                                cm3.IsOpen = false;
+                            }
+                            catch (Exception ex) { step("open context menu", false, ex.GetType().Name + ": " + ex.Message); }
+                        }
+                    }));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Dialogset(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    Window dw = FindWindowByTitle(
+                        string.IsNullOrWhiteSpace(ExtractJsonString(triggerJson, "window"))
+                        ? "Strategies" : ExtractJsonString(triggerJson, "window"));
+                    if (dw == null || dw.GetType().FullName.IndexOf("Dialog", StringComparison.OrdinalIgnoreCase) < 0)
+                    {
+                        step("dialog", false, "no ObjectDialog found. Windows: " + WindowTitles());
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+                    step("dialog", true, dw.GetType().FullName);
+
+                    string select = ExtractJsonString(triggerJson, "select");
+                    string confirm = ExtractJsonString(triggerJson, "confirm");
+                    Dictionary<string, string> fields = ParseNamedMap(triggerJson, "fields");
+
+                    dw.Dispatcher.Invoke(new Action(delegate
+                    {
+                        if (!string.IsNullOrWhiteSpace(select))
+                        {
+                            // A bot that declares its own namespace shows up as a FOLDER
+                            // with the strategy inside, so "select" may be a path:
+                            // "MyStrategy/MyStrategy". Each level is expanded before
+                            // the next is looked for - collapsed children are virtualized
+                            // and do not exist in the visual tree at all. Measured
+                            // 2026-08-18: selecting the folder alone left the property
+                            // grid on the previous strategy, and every field written
+                            // afterwards belonged to the wrong bot.
+                            string[] parts = select.Split('/');
+                            bool hit = false;
+                            for (int li = 0; li < parts.Length; li++)
+                            {
+                                string part = parts[li].Trim();
+                                if (part.Length == 0) continue;
+                                // Last segment must be a LEAF: a folder and the strategy
+                                // inside it carry the SAME text, and a depth-first walk
+                                // hits the folder first - which is why two selects in a
+                                // row both landed on the folder and the grid never changed.
+                                hit = SelectTreeItem(dw, part, li == parts.Length - 1);
+                                if (!hit) { step("select '" + part + "'", false, "not found in the tree"); break; }
+                                step("select '" + part + "'", true, li < parts.Length - 1 ? "expanded" : "selected");
+                                if (li < parts.Length - 1) ExpandSelected(dw, part);
+                            }
+                        }
+                    }));
+
+                    // Selecting a different strategy rebuilds the property grid, so the
+                    // fields must be written in a SECOND pass, after the UI settled.
+                    if (!string.IsNullOrWhiteSpace(select)) Thread.Sleep(1200);
+
+                    foreach (KeyValuePair<string, string> kv in fields)
+                    {
+                        KeyValuePair<string, string> f = kv;
+                        string outcome = (string)dw.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            return SetByLabel(dw, f.Key, f.Value);
+                        }));
+                        step("field '" + f.Key + "'", outcome.StartsWith("wrote"), outcome);
+                        // Some fields rebuild the grid - changing the bar type swaps the
+                        // whole Data Series section. Let it settle OUTSIDE the dispatcher
+                        // before the next field is looked for, otherwise the walk runs
+                        // through a tree that is being rebuilt and finds nothing.
+                        Thread.Sleep(700);
+                    }
+
+                    if (string.Equals(confirm, "true", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // The OK button used to be invoked through its automation peer.
+                        // That is a click, and clicks are out - so this reports instead of
+                        // pressing. A strategy is set up with stage `attach`, which needs no
+                        // dialog at all.
+                        step("confirm", false,
+                             "confirming a dialog would be a CLICK - use stage 'attach' "
+                             + "(template -> AddStrategyToGrid -> StrategyEnable) instead");
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Play(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Step 8: start (or park) the transport - a property write, not a button
+                    // press, so the value can be read back.
+                    string vP = ExtractJsonString(triggerJson, "value");
+                    int want;
+                    if (string.IsNullOrWhiteSpace(vP) || vP.Equals("max", StringComparison.OrdinalIgnoreCase))
+                        want = MaxSpeedOrOne();
+                    else if (!int.TryParse(vP, out want) || want < 0)
+                    { step("value", false, "expected 'max' or a non-negative integer, got '" + vP + "'"); sb.Append("]}"); return sb.ToString(); }
+
+                    DateTime seenB;
+                    bool movingB = TransportMoving(out seenB);
+                    step("before", true, "moving=" + movingB + " at " + seenB);
+
+                    int got;
+                    string problem = SetPlaybackSpeed(want, out got);
+                    step("PlaybackSpeed", problem == null,
+                         problem == null ? ("wrote " + want + ", reads back " + got) : problem);
+                    if (problem != null) { sb.Append("]}"); return sb.ToString(); }
+
+                    // Phase 3: WAIT FOR THE CLOCK TO MOVE (or to stop), instead of sleeping
+                    // 1.5 s and measuring whatever happens to be true then. Outside the
+                    // dispatcher, because NinjaTrader needs that thread to act at all.
+                    Type pbP = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                    PropertyInfo piNowP = pbP == null ? null : pbP.GetProperty("NowEst", BFStatic);
+                    string beforeP = piNowP == null ? "?" : "" + piNowP.GetValue(null);
+                    string gotP; long msP;
+                    bool changed = WaitUntilChanged(delegate {
+                            return piNowP == null ? "?" : "" + piNowP.GetValue(null); },
+                        beforeP, null, RequestTtlSec(triggerJson), out gotP, out msP);
+                    step("clock moved", changed || want == 0,
+                         changed ? ("moved after " + msP + " ms: " + beforeP + " -> " + gotP)
+                                 : ("did NOT move within this request's budget (" + beforeP + ")"));
+                    DateTime seenA;
+                    bool movingA = TransportMoving(out seenA);
+
+                    // ⚠ THE CLOCK IS THE VERDICT, not the write. A write that resolves is not
+                    // a transport that runs - the same class of mistake as a "set" reported
+                    // into a discarded object.
+                    bool wantMoving = want > 0;
+                    step("after", movingA == wantMoving,
+                         "moving=" + movingA + " at " + seenA + " (wanted " + wantMoving + ")");
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Transport(PbRunCtx ctx)
+        {
+            string id = ctx.Id;
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Report the adapter's own state. Two samples of the tick counter a
+                    // second apart, plus the timer that drives the whole thing.
+                    Type tp2 = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                    if (tp2 == null) { step("PlaybackAdapter", false, "type not found"); sb.Append("]}"); return sb.ToString(); }
+
+                    FieldInfo fiTimer = tp2.GetField("timer", BFStatic);
+                    object tim = fiTimer != null ? fiTimer.GetValue(null) : null;
+                    if (tim == null) step("timer", false, "field 'timer' not found or null");
+                    else
+                    {
+                        string en = "?", iv = "?";
+                        try { PropertyInfo p1 = tim.GetType().GetProperty("Enabled"); if (p1 != null) en = "" + p1.GetValue(tim, null); } catch { }
+                        try { PropertyInfo p2 = tim.GetType().GetProperty("Interval"); if (p2 != null) iv = "" + p2.GetValue(tim, null); } catch { }
+                        step("timer.Enabled", true, en + "   Interval=" + iv + " ms");
+                    }
+
+                    FieldInfo fiTicks = tp2.GetField("RealtimeTickCount", BFStatic);
+                    FieldInfo fiInH = tp2.GetField("inTimerHandler", BFStatic);
+                    PropertyInfo piNowT = tp2.GetProperty("NowEst", BFStatic);
+                    PropertyInfo piSpd = tp2.GetProperty("PlaybackSpeed", BFStatic);
+
+                    // ⚠ NOT a wait - this is the MEASUREMENT WINDOW. A rate needs an interval:
+                    // "how many ticks in how long". It is the caller's parameter, not a constant
+                    // in here, so nothing about NinjaTrader's speed is being assumed.
+                    int sampleMs = 1000;
+                    string smS = ExtractJsonString(triggerJson, "sampleMs");
+                    int smP;
+                    if (!string.IsNullOrWhiteSpace(smS) && int.TryParse(smS, out smP) && smP > 0) sampleMs = smP;
+                    // ⚠ ONE PROGRESS LINE PER READ.
+                    //
+                    // Measured 2026-08-24: after a connect this stage is picked up, writes
+                    // "timer.Enabled True Interval=1000 ms" and never returns - 60 s and
+                    // counting. Before the connect the same stage finishes in 212 ms. The
+                    // last line brackets the blocking call to the four reads below, and a
+                    // bracket is not a name: with a line in front of each, the next run
+                    // says WHICH member does not come back, instead of leaving four
+                    // candidates and an opinion.
+                    Progress(id, "      read RealtimeTickCount ...");
+                    object t1 = fiTicks != null ? fiTicks.GetValue(null) : null;
+                    Progress(id, "      read NowEst ...");
+                    object n1 = piNowT != null ? piNowT.GetValue(null) : null;
+                    Progress(id, "      sampling for " + sampleMs + " ms ...");
+                    Thread.Sleep(sampleMs);
+                    Progress(id, "      read RealtimeTickCount again ...");
+                    object t2 = fiTicks != null ? fiTicks.GetValue(null) : null;
+                    Progress(id, "      read NowEst again ...");
+                    object n2 = piNowT != null ? piNowT.GetValue(null) : null;
+                    Progress(id, "      both reads returned");
+
+                    long d1 = 0, d2 = 0;
+                    try { d1 = Convert.ToInt64(t1); d2 = Convert.ToInt64(t2); } catch { }
+                    // ⚠ RealtimeTickCount CANNOT tell running from parked in playback.
+                    //
+                    // Measured 2026-08-20, one variable changed (the window), everything
+                    // else identical:
+                    //     running, 1500 ms window   29087 -> 29088   delta 1
+                    //     running, 6000 ms window   29089 -> 29095   delta 6
+                    //     PARKED,  6000 ms window   29100 -> 29106   delta 6   <- same
+                    // It advances about once per second of WALL time whatever the
+                    // transport does, so a positive delta is not evidence of motion. It is
+                    // reported because it is bot-free and useful against a DISCONNECTED
+                    // adapter - not as proof that data is flowing.
+                    step("RealtimeTickCount", true, t1 + " -> " + t2 + "   delta=" + (d2 - d1)
+                         + " in " + sampleMs + " ms   (wall-clock driven - does NOT prove motion)");
+                    step("NowEst", true, n1 + " -> " + n2);
+
+                    // The discriminating verdict, from the channel that was PROVEN to
+                    // discriminate: two NowEst samples a known window apart. Measured the
+                    // same day, parked / running / parked again read False / True / False.
+                    bool movedNow = false;
+                    try { movedNow = n1 != null && n2 != null && !n1.ToString().Equals(n2.ToString()); }
+                    catch { }
+                    step("transport moving", true, movedNow
+                         ? "YES - NowEst advanced within " + sampleMs + " ms"
+                         : "no - NowEst stood still for " + sampleMs + " ms");
+                    if (fiInH != null) step("inTimerHandler", true, "" + fiInH.GetValue(null));
+                    if (piSpd != null) step("PlaybackSpeed", true, "" + piSpd.GetValue(null));
+                    // The configured range comes along, so a caller can decide "finished"
+                    // from ONE cheap probe: the run is over when NowEst reaches ToEst.
+                    // Generic - no strategy and no GUI element involved.
+                    PropertyInfo piFrom = tp2.GetProperty("FromEst", BFStatic);
+                    PropertyInfo piTo = tp2.GetProperty("ToEst", BFStatic);
+                    if (piFrom != null) step("FromEst", true, "" + piFrom.GetValue(null));
+                    if (piTo != null) step("ToEst", true, "" + piTo.GetValue(null));
+
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Cmdprobe_Invokecmd(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            string stage = ctx.Stage;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // What does the GUI button actually DO? Toggling it through the
+                    // automation peer six times did not stop the transport (measured
+                    // 2026-08-19), so the control must react to its COMMAND rather than
+                    // to its checked state. Report the command, and optionally execute it.
+                    string wT = ExtractJsonString(triggerJson, "window");
+                    string eN = ExtractJsonString(triggerJson, "element");
+                    Window ws = FindWindowByTitle(string.IsNullOrWhiteSpace(wT) ? "Playback" : wT);
+                    if (ws == null) { step("window", false, "not found: " + wT); sb.Append("]}"); return sb.ToString(); }
+                    bool doExec = (stage == "invokecmd");
+                    string outC = (string)ws.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        object el = FindElement(ws, eN);
+                        if (el == null) return "element '" + eN + "' not found";
+                        PropertyInfo piC = el.GetType().GetProperty("Command");
+                        System.Windows.Input.ICommand cmd =
+                            piC == null ? null : piC.GetValue(el, null) as System.Windows.Input.ICommand;
+                        object par = null;
+                        PropertyInfo piP = el.GetType().GetProperty("CommandParameter");
+                        if (piP != null) { try { par = piP.GetValue(el, null); } catch { } }
+                        if (cmd == null) return el.GetType().Name + " has no Command (parameter=" + par + ")";
+                        bool can = false;
+                        try { can = cmd.CanExecute(par); } catch (Exception ex) { return "CanExecute threw " + ex.Message; }
+                        string info = cmd.GetType().FullName + "  CanExecute=" + can + "  parameter=" + par;
+                        if (!doExec) return info;
+                        if (!can) return "NOT executed - CanExecute=false. " + info;
+                        try { cmd.Execute(par); } catch (Exception ex) { return "Execute threw " + ex.GetType().Name + ": " + ex.Message + ". " + info; }
+                        return "EXECUTED. " + info;
+                    }));
+                    step(stage + " " + eN, outC.IndexOf("not found") < 0 && outC.IndexOf("threw") < 0, outC);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Resname(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Find the RESOURCE NAME behind a piece of NinjaTrader text - read-only, and
+                    // without performing the operation that would produce it.
+                    //
+                    // Log entries carry `Name` (the resource key) next to `Message` (its
+                    // rendering). Matching on the name is what makes a check survive an update
+                    // and a different UI language. But the name of an entry one has never seen
+                    // cannot be guessed - and guessing it is exactly what this stage replaces
+                    // (2026-08-20: I had written "NinjaScriptStrategyDisabl" from thin air).
+                    //
+                    // NinjaTrader exposes its resources as static string properties on NTRes.*
+                    // types, named after the key. So the key for a text is found by asking every
+                    // one of them what it says.
+                    string needleR = ExtractJsonString(triggerJson, "contains");
+                    if (string.IsNullOrWhiteSpace(needleR))
+                    { step("contains", false, "missing"); sb.Append("]}"); return sb.ToString(); }
+
+                    int scanned = 0, found = 0;
+                    foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        string an = null;
+                        try { an = asm.GetName().Name; } catch { }
+                        if (an == null || an.IndexOf("NinjaTrader", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                        Type[] types;
+                        try { types = asm.GetTypes(); }
+                        catch (ReflectionTypeLoadException rex) { types = rex.Types; }
+                        catch { continue; }
+                        foreach (Type ty in types)
+                        {
+                            if (ty == null || ty.FullName == null) continue;
+                            if (!ty.FullName.StartsWith("NTRes", StringComparison.Ordinal)) continue;
+                            PropertyInfo[] props;
+                            try { props = ty.GetProperties(BFStatic); }
+                            catch { continue; }
+                            foreach (PropertyInfo pr in props)
+                            {
+                                if (pr.PropertyType != typeof(string) || !pr.CanRead) continue;
+                                scanned++;
+                                string v = null;
+                                try { v = pr.GetValue(null, null) as string; } catch { continue; }
+                                if (v == null || v.IndexOf(needleR, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                                found++;
+                                step("name", true, pr.Name + "   [" + ty.FullName + "]   = "
+                                     + (v.Length > 70 ? v.Substring(0, 70) + "..." : v));
+                                if (found >= 20) break;
+                            }
+                            if (found >= 20) break;
+                        }
+                        if (found >= 20) break;
+                    }
+                    // The NTRes.* properties are only a generated convenience for SOME
+                    // resources. The log entries carry ResourceType = "Resource", and those
+                    // strings live in an embedded .resources set reached through a
+                    // ResourceManager - so ask that directly. Measured 2026-08-20: the property
+                    // scan found 0 of 2931 for a text that NinjaTrader definitely writes.
+                    if (found == 0)
+                    {
+                        foreach (Assembly asm2 in AppDomain.CurrentDomain.GetAssemblies())
+                        {
+                            string an2 = null;
+                            try { an2 = asm2.GetName().Name; } catch { }
+                            if (an2 == null || an2.IndexOf("NinjaTrader", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                            Type[] tys;
+                            try { tys = asm2.GetTypes(); }
+                            catch (ReflectionTypeLoadException rex2) { tys = rex2.Types; }
+                            catch { continue; }
+                            foreach (Type ty2 in tys)
+                            {
+                                if (ty2 == null || ty2.Name != "Resource") continue;
+                                PropertyInfo rmP = ty2.GetProperty("ResourceManager", BFStatic);
+                                object rm = null;
+                                try { rm = rmP == null ? null : rmP.GetValue(null, null); } catch { }
+                                if (rm == null) continue;
+                                MethodInfo grs = rm.GetType().GetMethod("GetResourceSet",
+                                    new Type[] { typeof(System.Globalization.CultureInfo), typeof(bool), typeof(bool) });
+                                object set = null;
+                                try
+                                {
+                                    set = grs.Invoke(rm, new object[] {
+                                        System.Globalization.CultureInfo.InvariantCulture, true, true });
+                                }
+                                catch { }
+                                System.Collections.IEnumerable en2 = set as System.Collections.IEnumerable;
+                                if (en2 == null) continue;
+                                step("resource set", true, ty2.FullName);
+                                foreach (object o2 in en2)
+                                {
+                                    if (!(o2 is System.Collections.DictionaryEntry)) continue;
+                                    System.Collections.DictionaryEntry de = (System.Collections.DictionaryEntry)o2;
+                                    string val = de.Value as string;
+                                    if (val == null) continue;
+                                    scanned++;
+                                    if (val.IndexOf(needleR, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                                    found++;
+                                    step("name", true, de.Key + "   = "
+                                         + (val.Length > 70 ? val.Substring(0, 70) + "..." : val));
+                                    if (found >= 20) break;
+                                }
+                                if (found >= 20) break;
+                            }
+                            if (found >= 20) break;
+                        }
+                    }
+                    step("scanned", true, scanned + " resource strings");
+                    step("found", found > 0, "" + found);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        // The Playback control window is NOT persisted in any workspace: measured
+        // 2026-08-29 after a NinjaTrader restart - 52 windows loaded across all 7
+        // open workspaces, none titled "Playback", and the only 'playback' hit in
+        // any workspaces\*.xml is a ChartTrader account line. Every stage that
+        // writes the panel (source radios, uiset, speed, play) looks the window up
+        // with FindWindowByTitle("Playback") and fails without it - measured
+        // 2026-09-03: three runs in a row ended rc 2, "3 source check: panel radios
+        // - Playback window not found", each after a healthy connect. So the run
+        // opens the window itself, on the UI thread, by constructing NinjaTrader's
+        // OWN window type - no clicks, no UI automation.
+        //
+        // Type and parameterless constructor proven by reflection 2026-08-29:
+        //   NinjaTrader.Gui.Data.PlaybackControlCenter : NTWindow, .ctor()
+        // Idempotent: an existing window is reported, never duplicated.
+        private string Stage_Openwindow(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+            Window have = FindWindowByTitle("Playback");
+            if (have != null)
+            {
+                string t0 = "";
+                try { t0 = (string)have.Dispatcher.Invoke(new Func<string>(
+                          delegate { return have.Title; })); }
+                catch (Exception) { }
+                step("already open", true, t0);
+                sb.Append("]}");
+                return sb.ToString();
+            }
+            Window ccw = FindWindowByTitle("Control Center");
+            if (ccw == null)
+            {
+                step("control center", false,
+                     "not found - no UI dispatcher to open the window on");
+                sb.Append("]}");
+                return sb.ToString();
+            }
+            string result = null;
+            ccw.Dispatcher.Invoke(new Action(delegate
+            {
+                try
+                {
+                    Type t = typeof(NinjaTrader.Gui.Tools.NTWindow).Assembly
+                        .GetType("NinjaTrader.Gui.Data.PlaybackControlCenter", false);
+                    if (t == null)
+                    {
+                        result = "type NinjaTrader.Gui.Data.PlaybackControlCenter"
+                                 + " not found in NinjaTrader.Gui";
+                        return;
+                    }
+                    Window w = (Window)Activator.CreateInstance(t);
+                    w.Show();
+                    result = "shown: " + w.Title;
+                }
+                catch (Exception ex)
+                {
+                    Exception e2 = ex.InnerException == null ? ex : ex.InnerException;
+                    result = "threw " + e2.GetType().Name + ": " + e2.Message;
+                }
+            }));
+            bool okOpen = result != null && result.StartsWith("shown");
+            step("open PlaybackControlCenter", okOpen,
+                 result == null ? "?" : result);
+            Window now = FindWindowByTitle("Playback");
+            step("window present", now != null,
+                 now == null ? "still not found after Show()" : "found");
+            sb.Append("]}");
+            return sb.ToString();
+        }
+
+        private string Stage_Ntlog(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // NinjaTrader's own entries, from memory. `since` is the index returned by
+                    // the previous call, so a caller sees exactly what happened in between and
+                    // never has to guess when to look.
+                    SubscribeNtLog();
+                    string toFile = ExtractJsonString(triggerJson, "toFile");
+                    if (!string.IsNullOrWhiteSpace(toFile))
+                    {
+                        _ntLogToFile = string.Equals(toFile, "true", StringComparison.OrdinalIgnoreCase);
+                        step("mirror to file", true, _ntLogToFile
+                             ? ("ON - " + Path.Combine(Globals.UserDataDir, "NT8Bridge", "ntlog.txt")
+                                + "   (debugging aid, remember to turn it off)")
+                             : "OFF");
+                    }
+                    string needle = ExtractJsonString(triggerJson, "contains");
+                    int since = 0;
+                    string sinceS = ExtractJsonString(triggerJson, "since");
+                    if (!string.IsNullOrWhiteSpace(sinceS)) int.TryParse(sinceS, out since);
+
+                    List<string> snap; int from;
+                    lock (_ntLogGate)
+                    {
+                        snap = new List<string>(_ntLog);
+                        from = NtLogOffset(since);
+                    }
+                    step("subscribed", _ntLogSubscribed, _ntLogSubscribed ? "yes" : "NO - no entries will arrive");
+                    // THE MARK THE CALLER TAKES AWAY MUST BE THE SEQUENCE NUMBER,
+                    // not the slot count - NtLogOffset() above reads it as one.
+                    // Reporting snap.Count here while the search counted entries
+                    // left the two halves speaking different languages: once the
+                    // buffer sat at its cap the reported mark stopped growing, and
+                    // the next call asked for a window that no longer meant what it
+                    // said. Measured 27.08.2026: the connect check scanned 60
+                    // entries and missed a "Connected" that NinjaTrader had logged
+                    // nine seconds earlier.
+                    step("index", true, "" + NtLogCount());
+                    int shown = 0;
+                    for (int i = from; i < snap.Count; i++)
+                    {
+                        if (!string.IsNullOrWhiteSpace(needle)
+                            && snap[i].IndexOf(needle, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                        step("e" + i, true, snap[i]);
+                        if (++shown >= 60) break;
+                    }
+                    step("matched", shown > 0 || string.IsNullOrWhiteSpace(needle), "" + shown);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Stratlive(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Read-only. Dumps what NINJATRADER maintains for the strategy that is
+                    // actually in the grid - counters no bot has to cooperate with.
+                    //
+                    // The rule (established 2026-08-19): nothing that comes from the bot may serve as
+                    // evidence, because the final test runs an EMPTY bot. Print statements and
+                    // the census file are the bot's; CurrentBar, BarsArray, Bars.Count and the
+                    // adapter's tick counter are NinjaTrader's.
+                    // ⚠ ALL ROWS, not the first one.
+                    //
+                    // Measured 2026-08-22: the grid can hold more than one strategy
+                    // row (it went 0 -> 1 -> 2), but this stage reported "1 row"
+                    // throughout because it returned the FIRST entry only. A reader
+                    // that stops at the first row cannot say what is enabled - so
+                    // every row is listed, and its counters are reported per row.
+                    Window ccL = FindWindowByTitle("Control Center");
+                    if (ccL == null) { step("Control Center", false, "not found"); sb.Append("]}"); return sb.ToString(); }
+                    List<StrategyBase> liveAll = (List<StrategyBase>)ccL.Dispatcher.Invoke(new Func<object>(delegate
+                    {
+                        var found = new List<StrategyBase>();
+                        object g = FindElement(ccL, "grdStrategies");
+                        foreach (var kv in GridRows(g)) if (kv.Value != null) found.Add(kv.Value);
+                        return found;
+                    }));
+                    step("rows", liveAll.Count > 0, liveAll.Count + " strategy row(s) in the grid");
+                    if (liveAll.Count == 0) { step("strategy", false, "no strategy in the grid"); sb.Append("]}"); return sb.ToString(); }
+
+                    // Per-row identity and state; the detail counters below stay on the
+                    // FIRST row (they are the expensive ones and the single-bot chain
+                    // reads them by that name).
+                    for (int r = 0; r < liveAll.Count; r++)
+                    {
+                        StrategyBase sr = liveAll[r];
+                        string acc = "";
+                        try { acc = sr.Account == null ? "?" : sr.Account.Name; } catch { }
+                        string cb = "";
+                        try { cb = "  CurrentBar=" + sr.CurrentBar; } catch { }
+                        step("row[" + r + "]", true, sr.GetType().Name + "  State=" + sr.State
+                             + "  Account=" + acc + cb);
+                    }
+
+                    StrategyBase live = liveAll[0];
+                    step("strategy", true, live.GetType().Name + "  State=" + live.State);
+
+                    // What NinjaTrader counts for this strategy
+                    try { step("CurrentBar", true, "" + live.CurrentBar); } catch (Exception ex) { step("CurrentBar", false, Deep(ex)); }
+                    try
+                    {
+                        Bars[] ba = live.BarsArray;
+                        step("BarsArray", ba != null, ba == null ? "null" : ba.Length + " series");
+                        if (ba != null)
+                            for (int i = 0; i < ba.Length; i++)
+                            {
+                                Bars b0 = ba[i];
+                                if (b0 == null) { step("bars[" + i + "]", false, "null"); continue; }
+                                string fromTo = "";
+                                try { if (b0.Count > 0) fromTo = "  " + b0.GetTime(0) + " .. " + b0.GetTime(b0.Count - 1); }
+                                catch { }
+                                step("bars[" + i + "]", true, b0.Count + " bars  " + b0.BarsPeriod + fromTo);
+                            }
+                    }
+                    catch (Exception ex) { step("BarsArray", false, Deep(ex)); }
+                    try { step("CurrentBars", true, live.CurrentBars == null ? "null" : string.Join(",", Array.ConvertAll(live.CurrentBars, delegate(int v) { return v.ToString(); }))); }
+                    catch (Exception ex) { step("CurrentBars", false, Deep(ex)); }
+                    try { step("Account", true, live.Account == null ? "null" : live.Account.Name); } catch { }
+                    try { step("IsTickReplay", true, "" + live.IsTickReplay); } catch { }
+                    try { step("Instrument", true, live.Instrument == null ? "null" : live.Instrument.FullName); } catch { }
+
+                    // and the adapter's own tick counter, sampled twice
+                    Type pbL = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                    if (pbL != null)
+                    {
+                        FieldInfo fT = pbL.GetField("RealtimeTickCount", BFStatic);
+                        PropertyInfo pN = pbL.GetProperty("NowEst", BFStatic);
+                        object a1 = fT == null ? null : fT.GetValue(null);
+                        object n1 = pN == null ? null : pN.GetValue(null);
+                        Thread.Sleep(1000);
+                        object a2 = fT == null ? null : fT.GetValue(null);
+                        object n2 = pN == null ? null : pN.GetValue(null);
+                        long d1 = 0, d2 = 0;
+                        try { d1 = Convert.ToInt64(a1); d2 = Convert.ToInt64(a2); } catch { }
+                        // See stage `transport`: this counter runs on wall time, not on
+                        // data - measured 2026-08-20, parked and running both gave 6 in a
+                        // 6000 ms window. NowEst below is the channel that discriminates.
+                        step("RealtimeTickCount", true, a1 + " -> " + a2 + "   delta=" + (d2 - d1)
+                             + " in 1000 ms   (wall-clock driven - does NOT prove motion)");
+                        step("NowEst", true, n1 + " -> " + n2);
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Strategystate(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // NinjaTrader's order-rejection notice is the one modal this stage
+                    // confirms itself - see DismissOrderRejectNotices for the measurement
+                    // and the scope. Counted here so the transcript carries every one.
+                    int noticesNow = DismissOrderRejectNotices();
+                    _orderNoticesDismissed += noticesNow;
+                    step("order notices", true, noticesNow + " dismissed this sample, "
+                                                + _orderNoticesDismissed + " in this run ("
+                                                + _orderNoticesScan + ")");
+
+                    // ⚠ THE GENERIC END-OF-RUN SIGNAL: State.Terminated.
+                    //
+                    // Every NinjaScript passes through OnStateChange and ends at
+                    // State.Terminated - no strategy has to cooperate, nothing has to be
+                    // written to disk, and no GUI element is involved. That matters
+                    // because this code is meant to go back upstream.
+                    //
+                    // Rejected earlier, each for a measured reason: the clock standing
+                    // still (a guess about stillness), IsAvailableChanged (subscribed
+                    // 2026-08-19, never fired), the progress slider (falls short of its
+                    // maximum when data is missing), and a strategy's own counter file
+                    // (only some strategies write one).
+                    Window ccs = FindWindowByTitle("Control Center");
+                    if (ccs == null) { step("Control Center", false, "not found"); sb.Append("]}"); return sb.ToString(); }
+                    string outSt = (string)ccs.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        object grid = FindElement(ccs, "grdStrategies");
+                        if (grid == null) return "grdStrategies not found";
+                        PropertyInfo pSrc = grid.GetType().GetProperty("DataSource");
+                        System.Collections.IEnumerable rows =
+                            pSrc == null ? null : pSrc.GetValue(grid, null) as System.Collections.IEnumerable;
+                        if (rows == null) return "no DataSource";
+                        StringBuilder o = new StringBuilder();
+                        int n = 0;
+                        foreach (object row in rows)
+                        {
+                            if (row == null) continue;
+                            n++;
+                            PropertyInfo pn = row.GetType().GetProperty("Name");
+                            string nm = pn == null ? "?" : ("" + pn.GetValue(row, null)).Trim();
+                            // The row is a view; the strategy hangs off it under one of a
+                            // few names depending on the build, so try them in turn.
+                            object strat = null;
+                            foreach (string cand in new string[] { "Strategy", "StrategyBase", "NinjaScript", "Instance" })
+                            {
+                                PropertyInfo ps = row.GetType().GetProperty(cand);
+                                if (ps == null) continue;
+                                try { strat = ps.GetValue(row, null); } catch { }
+                                if (strat != null) break;
+                            }
+                            string st = "?";
+                            if (strat != null)
+                            {
+                                PropertyInfo pst = strat.GetType().GetProperty("State");
+                                if (pst != null) { try { st = "" + pst.GetValue(strat, null); } catch { } }
+                            }
+                            PropertyInfo pe = row.GetType().GetProperty("IsEnabled");
+                            string en = pe == null ? "?" : ("" + pe.GetValue(row, null));
+                            o.Append(nm).Append(" State=").Append(st).Append(" IsEnabled=").Append(en).Append(" | ");
+                        }
+                        if (n == 0) return "no strategy rows";
+                        return o.ToString();
+                    }));
+                    bool terminated = outSt.IndexOf("State=Terminated", StringComparison.Ordinal) >= 0;
+                    step("rows", outSt.IndexOf("not found") < 0, outSt);
+                    // ⚠ `ok` MEANS "THIS STEP DID ITS JOB", NEVER "THE ANSWER IS YES".
+                    //
+                    // This line used to pass `terminated` as the ok flag, so the GOOD case
+                    // - the strategy is still running - was reported as a FAIL. Measured
+                    // 2026-08-20: the driver's hard stop killed a healthy run on it,
+                    // twice. A guard cannot act on FAIL while a step uses the flag as a
+                    // data field, and a guard that cannot act is the same as none.
+                    //
+                    // Reading the state IS the job here, so ok is true when it was read.
+                    // The answer goes where answers belong: into the detail.
+                    step("terminated", true, terminated ? "yes - the strategy has terminated"
+                                                        : "no - the strategy is still running");
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Playbackevents(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    Type pbE = typeof(Connection).Assembly.GetType("NinjaTrader.Adapter.PlaybackAdapter", false);
+                    if (pbE != null)
+                    {
+                        PropertyInfo pa = pbE.GetProperty("IsAvailable", BFStatic);
+                        if (pa != null) step("IsAvailable", true, "" + pa.GetValue(null));
+                        PropertyInfo pn = pbE.GetProperty("NowEst", BFStatic);
+                        if (pn != null) step("NowEst", true, "" + pn.GetValue(null));
+                    }
+                    // Same rule as `terminated` above: this is an answer, not an outcome.
+                    // Whether the playback event channel happens to be subscribed does not
+                    // decide whether THIS step worked - it decides what the event list
+                    // below can contain, and that is said in the text.
+                    step("subscribed", true, _pbSubscribed
+                         ? "yes - playback events are being recorded"
+                         : "no - no playback events will appear below");
+                    lock (_pbEvents)
+                    {
+                        if (_pbEvents.Count == 0) step("events", true, "none recorded yet");
+                        foreach (string s in _pbEvents) step("event", true, s);
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Botout(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Hand out the bot's Print() lines written since index `since`
+                    // and report the new index, so the driver can poll without
+                    // gaps and without repeats - the same contract as `ntlog`.
+                    SubscribeBotOutput();
+                    int sinceB = 0;
+                    string sB = ExtractJsonString(triggerJson, "since");
+                    if (!string.IsNullOrWhiteSpace(sB)) int.TryParse(sB, out sinceB);
+                    List<string> snapB; long droppedB; int seenB; int fromB;
+                    lock (_botOutGate)
+                    {
+                        snapB = new List<string>(_botOut);
+                        droppedB = _botOutDropped;
+                        // THE MARK IS A SEQUENCE NUMBER, NOT A SLOT INDEX. _botOut is a
+                        // ring and drops from the FRONT, so a slot index stops meaning
+                        // anything the moment it wraps: Count pins at BotOutMax, the
+                        // caller hands that back as `since`, and the window below is
+                        // empty from then on. That is exactly what killed every `ntlog`
+                        // wait once THAT buffer saturated (measured, see _ntLogDropped
+                        // above); here the code shape is identical and the only
+                        // difference is a cap ten times larger.
+                        seenB = (int)(droppedB + snapB.Count);
+                        long offB = sinceB - droppedB;
+                        fromB = offB < 0 ? 0 : (offB > snapB.Count ? snapB.Count : (int)offB);
+                    }
+                    // The buffer is a RING: if it dropped lines, the caller's index
+                    // no longer points where it thinks. Say so instead of quietly
+                    // handing over a shifted window.
+                    step("subscribed", _botOutSubscribed,
+                         _botOutSubscribed ? "NinjaTrader.Code.Output.OutputEvent"
+                                           : "NOT subscribed - see bridge.log for the failing step");
+                    step("dropped", droppedB == 0, "" + droppedB
+                         + (droppedB > 0 ? "  (buffer overflowed - poll faster)" : ""));
+                    for (int i = fromB; i < snapB.Count; i++)
+                        step("o" + (droppedB + i), true, snapB[i]);
+                    step("nowIndex", true, "" + seenB);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Restore(PbRunCtx ctx)
+        {
+            string id = ctx.Id;
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // ONE call that puts NinjaTrader back: disconnect, disable and remove
+                    // every strategy row, close every dialog. Server-side, so it costs
+                    // ONE round trip.
+                    //
+                    // Measured 2026-08-19: the client used to do this as ten separate
+                    // stages with 45-60 s budgets each - minutes of waiting whenever
+                    // NinjaTrader was busy, which is exactly when a cleanup is needed. A
+                    // teardown that takes minutes does not get run.
+                    Progress(id, "-> RestoreBaselineNow (disconnect, remove strategies, "
+                                 + "close dialogs - goes through the UI thread)");
+                    RestoreBaselineNow(RequestTtlSec(triggerJson));
+                    // ⚠ THE GRID IS NOT IN THE VISUAL TREE UNTIL ITS TAB HAS BEEN SHOWN.
+                    //
+                    // This looked for an element named "grdStrategies" in the Control
+                    // Center's tree. NinjaTrader virtualizes a tab's content while the tab
+                    // is inactive, so on a profile whose UI.xml has never had the Strategies
+                    // tab selected there is nothing to find - and the step reported -1,
+                    // which the driver treats as a failed mandatory step and ends the run
+                    // before it reaches the connect.
+                    //
+                    // Measured 2026-08-24 on a freshly created UI.xml: "strategy rows -1",
+                    // run aborted; one manual click on the Strategies tab and the same run
+                    // went through to the data end. That click cannot be part of a headless
+                    // procedure, and every user with a new profile meets it.
+                    //
+                    // WithStrategiesGrid is upstream's own answer to exactly this - it
+                    // activates tabs until the grid materializes, reads, and puts the user's
+                    // tab back, on the Control Center's own dispatcher and with a bounded
+                    // Invoke so a busy UI thread cannot wedge the poller. Using it beats a
+                    // second implementation of the same knowledge.
+                    //
+                    // int? on purpose: default(int) is 0, and "could not reach the grid" must
+                    // not read as "no strategies are left".
+                    List<string> gridNotes = new List<string>();
+                    Progress(id, "-> counting strategy rows (materializing the tab if need be)");
+                    // Two counts, and a bounded settle. RestoreBaselineNow waits for the rows
+                    // WITH a strategy object to reach 0 (GridRows); the raw entry count of the
+                    // grid's source (RowCount) can lag behind that by a refresh. Measured
+                    // 2026-09-03 06:32 on a loaded machine (twelve concurrent headless
+                    // NinjaTrader hosts): "restore: strategy
+                    // rows 1 -> 0 after 103 ms" in the log, RowCount still 1 when this verdict
+                    // read it, baselineClean false and rc 2 for a run that
+                    // had reached its data end with no strategy running. So the verdict is the
+                    // removal's own measurement (rows carrying a strategy), the raw count is
+                    // reported next to it, and the grid gets up to ROWS_SETTLE_MS to catch up.
+                    const int ROWS_SETTLE_MS = 10000;
+                    int left = -1, withStrategy = -1;
+                    long settleMs = 0;
+                    System.Diagnostics.Stopwatch swRows = System.Diagnostics.Stopwatch.StartNew();
+                    while (true)
+                    {
+                        int[] counted = WithStrategiesGrid<int[]>(delegate(object g)
+                        {
+                            int raw = RowCount(g);
+                            int live = 0;
+                            try { foreach (var kv in GridRows(g)) if (kv.Value != null) live++; }
+                            catch { live = -1; }
+                            return new int[] { raw, live };
+                        }, gridNotes);
+                        if (counted != null) { left = counted[0]; withStrategy = counted[1]; }
+                        settleMs = swRows.ElapsedMilliseconds;
+                        if (left == 0 || withStrategy == 0 || counted == null || settleMs >= ROWS_SETTLE_MS) break;
+                        Thread.Sleep(250);
+                    }
+                    if (left < 0 && gridNotes.Count > 0)
+                        Progress(id, "   grid unreachable: " + string.Join("; ", gridNotes.ToArray()));
+                    int dlgs = 0;
+                    foreach (Window w in AllWindowsIncludingOwned())
+                    {
+                        try { if (w.GetType().FullName.IndexOf("Dialog", StringComparison.OrdinalIgnoreCase) >= 0) dlgs++; }
+                        catch { }
+                    }
+                    DateTime seenR;
+                    bool movingR = TransportMoving(out seenR);
+                    bool rowsClean = withStrategy >= 0 ? withStrategy == 0 : left == 0;
+                    step("strategy rows", rowsClean,
+                         left + " entries, " + (withStrategy >= 0 ? withStrategy + " with a strategy" : "strategy column unreadable")
+                         + " after " + settleMs + " ms");
+                    step("dialogs", dlgs == 0, "" + dlgs);
+                    step("transport", !movingR, movingR ? ("STILL RUNNING at " + seenR) : ("parked at " + seenR));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Source(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            string srcS = ctx.SrcS;
+            Type pb = ctx.Pb;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Step 3 of the operating sequence: Market Replay or Historical, set
+                    // AFTER the connection is up and the panel is no longer greyed.
+                    //
+                    // Both places are written: the adapter static that governs the run and
+                    // the two radio buttons the user reads. Writing only the static leaves
+                    // the panel showing the other source - the same split that made the
+                    // panel report "1x" on a clock running at full speed.
+                    //
+                    // Caution, measured 2026-08-18: flipping these radios on a CONNECTED
+                    // transport once blocked NinjaTrader's dispatcher for 900 s. That was
+                    // before today's fixes; the caller should use a short timeout so a
+                    // repeat shows up as a finding instead of a wait.
+                    bool histSrc = string.Equals(srcS, "historical", StringComparison.OrdinalIgnoreCase);
+                    bool writeRadios = string.Equals(ExtractJsonString(triggerJson, "radios"),
+                                                     "true", StringComparison.OrdinalIgnoreCase);
+                    SetStatic(pb, "IsSourceHistoricalData", histSrc, step);
+
+                    Window wsrc = FindWindowByTitle("Playback");
+                    // ⚠ THE RADIOS ARE A SECOND OPINION, AND A HOST WITHOUT A UI HAS NONE.
+                    //
+                    // The source itself was already settled one line above, by the object
+                    // model: IsSourceHistoricalData written and read back. These radios only
+                    // confirm that the PANEL agrees - which is worth checking when a panel
+                    // exists and is meaningless when none does.
+                    //
+                    // Failing on their absence stopped a run whose source was correct
+                    // (measured 2026-08-24, headless: "IsSourceHistoricalData wrote=False
+                    // read=False" immediately followed by "panel radios FAIL - Playback
+                    // window not found").
+                    if (wsrc == null && NoUiHost())
+                        step("panel radios", true,
+                             "no UI in this host - the source is settled by"
+                             + " IsSourceHistoricalData above, which read back correctly");
+                    else if (wsrc == null) step("panel radios", false, "Playback window not found");
+                    else
+                    {
+                        Window w2 = wsrc;
+                        bool h2 = histSrc;
+                        string outR = (string)w2.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            System.Windows.Controls.RadioButton rh =
+                                FindElement(w2, "rbHistoricalData") as System.Windows.Controls.RadioButton;
+                            System.Windows.Controls.RadioButton rr =
+                                FindElement(w2, "rbRecordedData") as System.Windows.Controls.RadioButton;
+                            if (rh == null || rr == null) return "radio buttons not found";
+                            if (rh.IsChecked == h2 && rr.IsChecked == !h2)
+                                return "already " + (h2 ? "Historical" : "Market Replay");
+                            // ⚠ The radios are READ, not written.
+                            //
+                            // Measured 2026-08-18 (900 s) and again 2026-08-19 (the stage
+                            // stopped answering within its 10 s budget): assigning
+                            // IsChecked on a CONNECTED Playback panel makes NinjaTrader
+                            // rebuild the transport synchronously on the UI thread - and
+                            // this call sits in that same dispatcher, so it waits on
+                            // itself. The adapter static above already decides the source;
+                            // the panel follows it on the next connect.
+                            if (!writeRadios)
+                                return "panel shows " + (rh.IsChecked == true ? "Historical" : "Market Replay")
+                                     + ", adapter set to " + (h2 ? "Historical" : "Market Replay")
+                                     + " - panel follows on the next connect (radios not written:"
+                                     + " that deadlocks the dispatcher)";
+                            rh.IsChecked = h2;
+                            rr.IsChecked = !h2;
+                            return "Historical=" + rh.IsChecked + " MarketReplay=" + rr.IsChecked;
+                        }));
+                        step("panel radios", outR.IndexOf("not found") < 0, outR);
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Panelstate(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Read-only. Samples every named control of the Playback panel and reports
+                    // when each first became enabled. Every named control is sampled, because
+                    // the controls do not become enabled at the same moment and one of
+                    // them alone does not say the panel is ready.
+                    int waitMs2 = 30000;
+                    string wS2b = ExtractJsonString(triggerJson, "timeoutMs");
+                    int parsed2;
+                    if (!string.IsNullOrWhiteSpace(wS2b) && int.TryParse(wS2b, out parsed2) && parsed2 > 0)
+                        waitMs2 = parsed2;
+
+                    Window wp = FindWindowByTitle("Playback");
+                    if (wp == null) { step("Playback window", false, "not found: " + WindowTitles()); sb.Append("]}"); return sb.ToString(); }
+
+                    string[] names = new string[] {
+                        "slider", "btnPlay", "dtpStart", "dtpEnd",
+                        "rbHistoricalData", "rbRecordedData",
+                        "speedButtonsGrid", "textBlockSpeed" };
+                    Dictionary<string, int> firstOk = new Dictionary<string, int>();
+                    Dictionary<string, string> lastSeen = new Dictionary<string, string>();
+                    foreach (string nm2 in names) { firstOk[nm2] = -1; lastSeen[nm2] = "not found"; }
+                    int winFirst = -1;
+
+                    System.Diagnostics.Stopwatch sw2 = System.Diagnostics.Stopwatch.StartNew();
+                    while (sw2.ElapsedMilliseconds < waitMs2)
+                    {
+                        int ms = (int)sw2.ElapsedMilliseconds;
+                        Window wpp = wp;
+                        string snap = (string)wpp.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            StringBuilder o2 = new StringBuilder();
+                            o2.Append(wpp.IsEnabled ? "1" : "0");
+                            foreach (string nm3 in names)
+                            {
+                                object el = FindElement(wpp, nm3);
+                                System.Windows.UIElement ue2 = el as System.Windows.UIElement;
+                                if (ue2 == null) { o2.Append("|-"); continue; }
+                                o2.Append(ue2.IsEnabled ? "|1" : "|0");
+                            }
+                            return o2.ToString();
+                        }));
+                        string[] parts2 = snap.Split('|');
+                        if (winFirst < 0 && parts2[0] == "1") winFirst = ms;
+                        for (int i2 = 0; i2 < names.Length && i2 + 1 < parts2.Length; i2++)
+                        {
+                            string v2 = parts2[i2 + 1];
+                            lastSeen[names[i2]] = v2 == "1" ? "enabled" : (v2 == "0" ? "disabled" : "not found");
+                            if (firstOk[names[i2]] < 0 && v2 == "1") firstOk[names[i2]] = ms;
+                        }
+                        bool allOk = winFirst >= 0;
+                        foreach (string nm4 in names)
+                            if (firstOk[nm4] < 0 && lastSeen[nm4] != "not found") { allOk = false; break; }
+                        if (allOk) break;
+                        Thread.Sleep(250);
+                    }
+
+                    step("window", winFirst >= 0,
+                         winFirst >= 0 ? ("enabled after " + winFirst + " ms") : "still disabled");
+                    foreach (string nm5 in names)
+                        step(nm5, firstOk[nm5] >= 0,
+                             firstOk[nm5] >= 0 ? ("enabled after " + firstOk[nm5] + " ms")
+                                               : (lastSeen[nm5] + " for the whole " + waitMs2 + " ms"));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Panelflips(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Instant answer, no waiting, no deadline: the recorded transitions of the
+                    // Playback panel since `since`. The caller decides how long to keep asking.
+                    WatchPanelEnabled();
+                    int sinceP = 0;
+                    string sp = ExtractJsonString(triggerJson, "since");
+                    if (!string.IsNullOrWhiteSpace(sp)) int.TryParse(sp, out sinceP);
+                    List<string> snapP; long droppedP; int seenP; int fromP;
+                    lock (_panelGate)
+                    {
+                        snapP = new List<string>(_panelFlips);
+                        droppedP = _panelDropped;
+                        // Sequence number, not slot index - _panelFlips is a ring too.
+                        seenP = (int)(droppedP + snapP.Count);
+                        long offP = sinceP - droppedP;
+                        fromP = offP < 0 ? 0 : (offP > snapP.Count ? snapP.Count : (int)offP);
+                    }
+                    step("watching", _panelWatched, _panelWatched ? "IsEnabledChanged subscribed"
+                                                                 : "NOT subscribed - Playback window missing?");
+                    step("index", true, "" + seenP);
+                    for (int i = fromP; i < snapP.Count; i++)
+                        step("f" + (droppedP + i), true, snapP[i]);
+                    // the value right now, so a caller that arrives late still knows where it stands
+                    Window wpN = FindWindowByTitle("Playback");
+                    if (wpN != null)
+                    {
+                        string nowState = (string)wpN.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            object sl = FindElement(wpN, "slider");
+                            System.Windows.UIElement ue = sl as System.Windows.UIElement;
+                            return ue == null ? "slider not found" : (ue.IsEnabled ? "enabled" : "disabled");
+                        }));
+                        step("now", true, nowState);
+                        // ⚠ WHICH OBJECT are we watching? NinjaTrader REBUILDS this panel, and a
+                        // subscription on the discarded control is silent forever - it would look
+                        // exactly like "the panel never changed". The identity makes the
+                        // difference visible instead of leaving it as a guess.
+                        string ident = (string)wpN.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            object sl2 = FindElement(wpN, "slider");
+                            return sl2 == null ? "-" : (sl2.GetType().Name + "#" + sl2.GetHashCode());
+                        }));
+                        step("watched object", _panelWatchedIdent == ident,
+                             "now=" + ident + "   subscribed=" + (_panelWatchedIdent ?? "-")
+                             + (_panelWatchedIdent == ident ? "" : "   >>> REPLACED, the subscription is dead"));
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Ready(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Step 2 of the operating sequence: wait until the Playback panel is
+                    // no longer greyed out. Right after connecting, NinjaTrader leaves its
+                    // controls disabled while it prepares - the progress slider reported
+                    // "[DISABLED]" in earlier dumps. Anything written into a disabled panel
+                    // is written into a control that is about to be rebuilt.
+                    //
+                    // The readiness signal is the slider: IsEnabled on the control the
+                    // panel uses for the run itself, not on the window.
+                    int waitMs = 15000;
+                    string wS = ExtractJsonString(triggerJson, "timeoutMs");
+                    int parsed;
+                    if (!string.IsNullOrWhiteSpace(wS) && int.TryParse(wS, out parsed) && parsed > 0) waitMs = parsed;
+
+                    Window wr = FindWindowByTitle("Playback");
+                    if (wr == null) { step("Playback window", false, "not found"); sb.Append("]}"); return sb.ToString(); }
+
+                    // ⚠ THE TRANSITION IS THE SIGNAL, NOT THE CURRENT VALUE.
+                    //
+                    // "is it enabled right now" cannot tell "finished preparing" from "has not
+                    // STARTED preparing". Measured 2026-08-19: this stage answered "ready" in
+                    // 1.0 s while an independent sampling run showed the panel stays disabled
+                    // for 11.3 s after the connect. It had read the state from BEFORE the
+                    // connect, and the run then wrote its source, dates and speed into a panel
+                    // NinjaTrader was about to rebuild - the user saw the box still grey while
+                    // the run carried on.
+                    //
+                    // So: the panel must be seen DISABLED first, then ENABLED, and it must STAY
+                    // enabled for a settling period. A check that can pass for the wrong reason
+                    // is not a check.
+                    // The driver sets this; a human stepping through does not.
+                    bool requireTransition = string.Equals(
+                        ExtractJsonString(triggerJson, "requireTransition"), "true",
+                        StringComparison.OrdinalIgnoreCase);
+                    int settleMs = 1500;
+                    string setS = ExtractJsonString(triggerJson, "settleMs");
+                    int settleParsed;
+                    if (!string.IsNullOrWhiteSpace(setS) && int.TryParse(setS, out settleParsed) && settleParsed > 0)
+                        settleMs = settleParsed;
+
+                    bool ready = false;
+                    bool sawDisabled = false;
+                    string last = "?";
+                    int firstDisabledMs = -1, firstEnabledMs = -1;
+                    System.Diagnostics.Stopwatch swR = System.Diagnostics.Stopwatch.StartNew();
+                    long enabledSince = -1;
+                    while (swR.ElapsedMilliseconds < waitMs)
+                    {
+                        Window wrr = wr;
+                        last = (string)wrr.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            // IsEnabled is inherited from the window, so every named control
+                            // reports the same value - measured: all eight flip in the same
+                            // sample. The slider is read as the panel's own signal.
+                            object sl = FindElement(wrr, "slider");
+                            System.Windows.UIElement ue = sl as System.Windows.UIElement;
+                            if (ue == null) return "slider not found";
+                            return ue.IsEnabled ? "enabled" : "disabled";
+                        }));
+                        long now = swR.ElapsedMilliseconds;
+                        if (last == "disabled")
+                        {
+                            if (!sawDisabled) { sawDisabled = true; firstDisabledMs = (int)now; }
+                            enabledSince = -1;          // the streak restarts after every grey phase
+                        }
+                        else if (last == "enabled")
+                        {
+                            if (enabledSince < 0) { enabledSince = now; if (firstEnabledMs < 0 && sawDisabled) firstEnabledMs = (int)now; }
+                            if (sawDisabled && now - enabledSince >= settleMs) { ready = true; break; }
+                            // no transition demanded and it has been free long enough: stop early
+                            // instead of burning the whole budget on a panel that is fine.
+                            if (!requireTransition && !sawDisabled && now - enabledSince >= settleMs) break;
+                        }
+                        Thread.Sleep(250);
+                    }
+                    // ⚠ SEEING THE TRANSITION IS THE STRONG CASE, NOT THE ONLY ONE.
+                    //
+                    // "grey seen -> free seen -> stable" proves the panel was rebuilt AFTER the
+                    // connect. But the grey phase lasts about 12 s and then it is over: a check
+                    // that runs two minutes later never sees it and would report a failure for a
+                    // panel that is perfectly ready. That happened on 2026-08-20 during a
+                    // single-step session, and it is a false alarm, not a finding.
+                    //
+                    // So both outcomes are reported for what they are, and the CALLER decides:
+                    // a driver that connects and checks back to back passes requireTransition
+                    // (the connect must have had an effect), a human stepping through does not.
+                    bool stableFree = last == "enabled" && enabledSince >= 0
+                                      && swR.ElapsedMilliseconds - enabledSince >= settleMs;
+                    if (!ready && !sawDisabled && stableFree && !requireTransition)
+                    {
+                        step("panel ready", true,
+                             "already free and stable for " + settleMs + " ms - no grey phase seen, "
+                             + "so this does NOT prove the connect took effect (pass "
+                             + "requireTransition=true where that matters)");
+                    }
+                    else
+                    {
+                        step("panel ready", ready,
+                             ready ? ("grey from " + firstDisabledMs + " ms, free from " + firstEnabledMs
+                                      + " ms, then " + settleMs + " ms stable")
+                                   : (!sawDisabled
+                                      ? ("never went grey within " + waitMs + " ms - with "
+                                         + "requireTransition the connect must show its effect here")
+                                      : ("still " + last + " after " + waitMs + " ms")));
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Speed(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            Type pb = ctx.Pb;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Four places hold the playback speed, and each one alone is a lie
+                    // (measured 2026-08-19). By default this stage writes the PANEL's
+                    // two; `apply:"now"` adds the adapter's. Every one written is read
+                    // back:
+                    //
+                    //   PlaybackAdapter.PlaybackSpeed  the property. Writing it STARTS the
+                    //                                  transport (bisected, see stage "range").
+                    //   PlaybackAdapter.playbackSpeed  the live field. Connecting moves the
+                    //                                  property to `oldPlaybackSpeed` and
+                    //                                  leaves this at 1.
+                    //   PlaybackControlCenter.oldReplaySpeed  the PANEL's own memory. It sat
+                    //                                  at 1 while the adapter said Max, which
+                    //                                  is why the panel kept reading "1x".
+                    //   textBlockSpeed.Text            the label. Writing only this makes the
+                    //                                  display agree with itself and nothing else.
+                    //
+                    // No clicking: everything here is a field or property write.
+                    string vS2 = ExtractJsonString(triggerJson, "value");
+                    Window ws2 = FindWindowByTitle("Playback");
+                    FieldInfo fiMaxS = pb.GetField("MaxSpeedValue", BFStatic);
+                    object maxS = fiMaxS != null ? fiMaxS.GetValue(null) : (object)int.MaxValue;
+                    object want = maxS;
+                    if (!string.IsNullOrWhiteSpace(vS2) && !string.Equals(vS2, "max", StringComparison.OrdinalIgnoreCase))
+                    {
+                        int iv;
+                        if (int.TryParse(vS2, System.Globalization.NumberStyles.Integer, InvCi, out iv)) want = iv;
+                    }
+
+                    // ⚠ NOT ONE TICK MAY PASS DURING SETUP.
+                    //
+                    // Writing PlaybackAdapter.PlaybackSpeed starts the transport (bisected
+                    // 2026-08-19). Parking it again afterwards is NOT good enough: the data
+                    // consumed in between is gone, and a strategy attached later starts
+                    // mid-stream. So the adapter is left alone here.
+                    //
+                    // What is written instead is the PANEL's paused memory,
+                    // `oldReplaySpeed`. Measured the same day: pausing sets
+                    // PlaybackAdapter.PlaybackSpeed to 0 while the panel keeps the real
+                    // value in oldReplaySpeed, and pressing play restores it - one click on
+                    // btnPlay took PlaybackSpeed 0 -> 2147483647 and the clock went
+                    // +3.7 h in 8 s, with nothing having written the speed.
+                    //
+                    // `apply:"now"` writes the adapter too - for a caller that deliberately
+                    // wants the change to take effect on a running transport.
+                    bool applyNow = string.Equals(ExtractJsonString(triggerJson, "apply"),
+                                                  "now", StringComparison.OrdinalIgnoreCase);
+                    if (!applyNow)
+                        step("adapter untouched", true,
+                             "PlaybackSpeed not written - that would start the transport and "
+                             + "cost the strategy the ticks in between");
+                    else
+                    {
+                        // 1. STATE BEFORE - and it is the EFFECT that is read, not the
+                        //    property. SetStatic writes and reads the value back from the
+                        //    same reference in the same instant: that proves the value
+                        //    landed, never that the transport reacted to it. NowEst is
+                        //    written by NinjaTrader and by no bot, so it is evidence.
+                        DateTime seenB2;
+                        bool movingB2 = TransportMoving(out seenB2);
+                        step("transport before", true,
+                             (movingB2 ? "moving" : "parked") + " at " + seenB2);
+
+                        SetStatic(pb, "PlaybackSpeed", want, step);
+                        try
+                        {
+                            FieldInfo fiSp = pb.GetField("playbackSpeed", BFStatic);
+                            if (fiSp == null) step("field playbackSpeed", false, "not found");
+                            else
+                            {
+                                fiSp.SetValue(null, want);
+                                step("field playbackSpeed", ("" + fiSp.GetValue(null)) == ("" + want),
+                                     "wrote=" + want + " read=" + fiSp.GetValue(null));
+                            }
+                        }
+                        catch (Exception ex) { step("field playbackSpeed", false, ex.Message); }
+
+                        // 3. WAIT FOR THE CHANGE the write is supposed to cause: a speed
+                        //    above zero starts the transport, zero parks it. Bound only by
+                        //    the caller's own ttlSec - no constant in this file decides how
+                        //    long NinjaTrader may take. TransportMoving's 1200 ms is the
+                        //    sampling interval of the measurement, not a wait: a rate needs
+                        //    two readings a known gap apart.
+                        long wantN = 0;
+                        try { wantN = Convert.ToInt64(want); } catch { }
+                        string wantMotion = wantN > 0 ? "moving" : "parked";
+                        string gotMotion; long msMotion;
+                        bool reacted = WaitUntilChanged(delegate
+                        {
+                            DateTime s3;
+                            return TransportMoving(out s3) ? "moving" : "parked";
+                        }, movingB2 ? "moving" : "parked", wantMotion,
+                           RequestTtlSec(triggerJson), out gotMotion, out msMotion);
+                        step("transport reacted", reacted,
+                             (movingB2 ? "moving" : "parked") + " -> " + gotMotion
+                             + " after " + msMotion + " ms (wanted " + wantMotion
+                             + " for PlaybackSpeed=" + want + ")");
+                    }
+
+                    if (ws2 == null) step("panel", false, "Playback window not found");
+                    else
+                    {
+                        Window wsp = ws2;
+                        object wantP = want;
+                        string outSp = (string)wsp.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            StringBuilder o = new StringBuilder();
+                            FieldInfo fiOld = wsp.GetType().GetField("oldReplaySpeed",
+                                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                            if (fiOld == null) o.Append("oldReplaySpeed not found; ");
+                            else
+                            {
+                                try
+                                {
+                                    fiOld.SetValue(wsp, Convert.ToInt32(wantP));
+                                    o.Append("oldReplaySpeed=").Append(fiOld.GetValue(wsp)).Append("; ");
+                                }
+                                catch (Exception ex) { o.Append("oldReplaySpeed threw ").Append(ex.Message).Append("; "); }
+                            }
+                            object tbEl = FindElement(wsp, "textBlockSpeed");
+                            System.Windows.Controls.TextBlock tb2 = tbEl as System.Windows.Controls.TextBlock;
+                            if (tb2 == null) o.Append("textBlockSpeed not found");
+                            else
+                            {
+                                tb2.Text = ("" + wantP) == ("" + maxS) ? "Max" : (wantP + "x");
+                                o.Append("label=").Append(tb2.Text);
+                            }
+                            return o.ToString();
+                        }));
+                        step("panel", outSp.IndexOf("not found") < 0, outSp);
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Template(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            string typeName = ctx.TypeName;
+            string fromS = ctx.FromS;
+            string toS = ctx.ToS;
+            string bpS = ctx.BpS;
+            string trS = ctx.TrS;
+            Dictionary<string, string> prms = ctx.Prms;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Dialog-free on purpose. The first attempt read the strategy out of the
+                    // open Strategies dialog and picked the wrong object (the first entry of
+                    // viewModel.ListAvailable). Nothing here needs a window.
+                    string act = ExtractJsonString(triggerJson, "action");
+                    if (string.IsNullOrWhiteSpace(act)) act = "list";
+                    string tname = ExtractJsonString(triggerJson, "name");
+
+                    string why;
+                    Type stT = ResolveStrategyType(typeName, out why);
+                    if (stT == null) { step("strategy type", false, why); sb.Append("]}"); return sb.ToString(); }
+                    step("strategy type", true, stT.FullName);
+
+                    StrategyBase probe;
+                    try
+                    {
+                        probe = (StrategyBase)Activator.CreateInstance(stT);
+                        probe.SetState(State.SetDefaults);
+                    }
+                    catch (Exception ex)
+                    { step("instance", false, Deep(ex)); sb.Append("]}"); return sb.ToString(); }
+
+                    string folder = TemplateFolder(probe);
+                    step("folder", !string.IsNullOrEmpty(folder),
+                         string.IsNullOrEmpty(folder) ? "GetTemplateFolder returned nothing" : folder);
+                    if (string.IsNullOrEmpty(folder)) { sb.Append("]}"); return sb.ToString(); }
+
+                    if (act == "list")
+                    {
+                        if (!Directory.Exists(folder)) step("templates", true, "folder does not exist yet");
+                        else
+                        {
+                            string[] fs = Directory.GetFiles(folder, "*.xml");
+                            if (fs.Length == 0) step("templates", true, "none");
+                            foreach (string f in fs) step("template", true, Path.GetFileNameWithoutExtension(f));
+                        }
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+
+                    string tfile = TemplatePath(probe, tname);
+                    if (string.IsNullOrEmpty(tfile)) { step("name", false, "missing"); sb.Append("]}"); return sb.ToString(); }
+
+                    if (act == "save")
+                    {
+                        // Saved from a fresh instance plus the request's params, so the whole
+                        // template set for a test matrix can be produced from the CLI.
+                        Type tt2 = TemplateType();
+                        MethodInfo miSave = tt2 == null ? null : tt2.GetMethod("SaveFullStrategyTemplate",
+                            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+                        if (miSave == null) { step("save", false, "SaveFullStrategyTemplate not found"); sb.Append("]}"); return sb.ToString(); }
+
+                        try
+                        {
+                            if (!string.IsNullOrWhiteSpace(bpS))
+                                probe.BarsPeriod = (BarsPeriod)ConvertConfigToken(bpS, typeof(BarsPeriod));
+                            if (!string.IsNullOrWhiteSpace(trS))
+                                probe.IsTickReplay = string.Equals(trS, "true", StringComparison.OrdinalIgnoreCase);
+                            if (!string.IsNullOrWhiteSpace(fromS)) probe.From = DateTime.Parse(fromS, InvCi);
+                            if (!string.IsNullOrWhiteSpace(toS))
+                                probe.To = DateTime.Parse(toS, InvCi).Date.AddDays(1).AddSeconds(-1);
+                            InjectParams(probe, prms);
+
+                            // Do not write a range into a file that could never be run. A
+                            // fresh instance carries From 2099 / To 1800; saved unchanged,
+                            // that template stays a loaded gun for every later `attach`.
+                            string saveBad = RangeProblem(probe.From, probe.To);
+                            if (saveBad != null)
+                            {
+                                step("save", false, "template not written - " + saveBad
+                                     + ". Pass 'from' and 'to' with the save request.");
+                                sb.Append("]}");
+                                return sb.ToString();
+                            }
+                            Directory.CreateDirectory(Path.GetDirectoryName(tfile));
+                            // The container is the ROOT ELEMENT, not the document.
+                            // SaveFullStrategyTemplate FILLS the container - it writes
+                            // <StrategyType> and <Strategy> side by side - so a document
+                            // handed in directly would end up with two top-level elements
+                            // ("This operation would create an incorrectly structured
+                            // document"). The element name matches the files NinjaTrader
+                            // itself writes: root <StrategyTemplate>.
+                            System.Xml.Linq.XElement root =
+                                new System.Xml.Linq.XElement("StrategyTemplate");
+                            miSave.Invoke(null, new object[] { root, probe });
+                            new System.Xml.Linq.XDocument(root).Save(tfile);
+                            step("save", File.Exists(tfile),
+                                 tfile + "  (" + new FileInfo(tfile).Length + " Bytes)");
+                        }
+                        catch (Exception ex) { step("save", false, Deep(ex)); }
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+
+                    if (act == "load")
+                    {
+                        // Read-back check: proves the file restores into a usable strategy
+                        // BEFORE a run depends on it. `attach` does the same restore.
+                        string p2;
+                        StrategyBase got = RestoreTemplate(tfile, out p2);
+                        if (got == null) { step("load", false, p2); sb.Append("]}"); return sb.ToString(); }
+                        step("load", true, Path.GetFileName(tfile) + " -> " + got.GetType().Name
+                             + ", State " + got.State
+                             + ", BarsPeriod " + (got.BarsPeriod == null ? "null" : got.BarsPeriod.ToString())
+                             + ", IsTickReplay " + got.IsTickReplay);
+                        step("params", true, ParamReadback(got));
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+
+                    step("action", false, "unknown: " + act);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Findmethod(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Search the loaded NinjaTrader assemblies for methods by name.
+                    //
+                    // This is the tool for the standing task (established 2026-08-19): every
+                    // place the bridge still presses a button has to be replaced by the
+                    // call that button makes. Finding that call means searching the object
+                    // model, not the visual tree.
+                    string need = ExtractJsonString(triggerJson, "name");
+                    string inType = ExtractJsonString(triggerJson, "type");
+                    if (string.IsNullOrWhiteSpace(need)) { step("name", false, "missing"); sb.Append("]}"); return sb.ToString(); }
+                    int hits = 0;
+                    foreach (System.Reflection.Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
+                    {
+                        string an = null;
+                        try { an = asm.GetName().Name; } catch { }
+                        if (an == null || an.IndexOf("NinjaTrader", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                        Type[] types;
+                        try { types = asm.GetTypes(); }
+                        catch (ReflectionTypeLoadException ex) { types = ex.Types; }
+                        catch { continue; }
+                        foreach (Type ty in types)
+                        {
+                            if (ty == null) continue;
+                            if (!string.IsNullOrWhiteSpace(inType)
+                                && (ty.FullName == null || ty.FullName.IndexOf(inType, StringComparison.OrdinalIgnoreCase) < 0))
+                                continue;
+                            MethodInfo[] ms;
+                            try { ms = ty.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly); }
+                            catch { continue; }
+                            foreach (MethodInfo mi in ms)
+                            {
+                                if (mi.Name.IndexOf(need, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                                if (hits++ > 120) break;
+                                StringBuilder ps = new StringBuilder();
+                                foreach (ParameterInfo pi3 in mi.GetParameters())
+                                {
+                                    if (ps.Length > 0) ps.Append(", ");
+                                    ps.Append(pi3.ParameterType.Name).Append(" ").Append(pi3.Name);
+                                }
+                                step("m", true, (mi.IsStatic ? "static " : "") + ty.FullName + "." + mi.Name
+                                                + "(" + ps + ") : " + mi.ReturnType.Name);
+                            }
+                            if (hits > 120) break;
+                        }
+                        if (hits > 120) break;
+                    }
+                    step("hits", true, "" + hits);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Elmembers(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Reflect over a named ELEMENT's type - methods included.
+                    //
+                    // This is the tool that made the AddOn click-free: for every button the
+                    // bridge used to press, it showed the method behind it, and that method
+                    // is what is called now (StrategiesGrid.StrategyEnable/Disable/Remove,
+                    // PlaybackAdapter.PlaybackSpeed). It stays, because the next control
+                    // that has to be driven is found the same way.
+                    string wT2 = ExtractJsonString(triggerJson, "window");
+                    string eN2 = ExtractJsonString(triggerJson, "element");
+                    string filt2 = ExtractJsonString(triggerJson, "filter");
+                    Window wq = FindWindowByTitle(string.IsNullOrWhiteSpace(wT2) ? "Strategies" : wT2);
+                    if (wq == null) { step("window", false, "not found: " + wT2); sb.Append("]}"); return sb.ToString(); }
+                    string outQ = (string)wq.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        object el = FindElement(wq, eN2);
+                        if (el == null) return "element '" + eN2 + "' not found";
+                        Type et = el.GetType();
+                        StringBuilder o = new StringBuilder();
+                        o.Append("TYPE ").Append(et.FullName).Append(Environment.NewLine);
+                        foreach (MethodInfo mi in et.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                        {
+                            if (IsAccessor(mi)) continue;
+                            if (!string.IsNullOrWhiteSpace(filt2) && mi.Name.IndexOf(filt2, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                            StringBuilder ps = new StringBuilder();
+                            foreach (ParameterInfo pi2 in mi.GetParameters())
+                            {
+                                if (ps.Length > 0) ps.Append(", ");
+                                ps.Append(pi2.ParameterType.Name).Append(" ").Append(pi2.Name);
+                            }
+                            o.Append("method ").Append(mi.Name).Append("(").Append(ps).Append(") : ")
+                             .Append(mi.ReturnType.Name).Append(Environment.NewLine);
+                        }
+                        foreach (FieldInfo fi in et.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                        {
+                            if (!string.IsNullOrWhiteSpace(filt2) && fi.Name.IndexOf(filt2, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                            string v = "?";
+                            try { v = "" + fi.GetValue(el); } catch { }
+                            o.Append("field ").Append(fi.Name).Append(" : ").Append(fi.FieldType.Name)
+                             .Append(" = ").Append(v.Length > 60 ? v.Substring(0, 60) : v).Append(Environment.NewLine);
+                        }
+                        foreach (PropertyInfo pr in et.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                        {
+                            if (!string.IsNullOrWhiteSpace(filt2) && pr.Name.IndexOf(filt2, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                            string v = "?";
+                            try { v = pr.CanRead ? ("" + pr.GetValue(el, null)) : "(write-only)"; } catch { }
+                            o.Append("prop ").Append(pr.Name).Append(" : ").Append(pr.PropertyType.Name)
+                             .Append(" = ").Append(v.Length > 60 ? v.Substring(0, 60) : v)
+                             .Append(pr.CanWrite ? "  [writable]" : "").Append(Environment.NewLine);
+                        }
+                        return o.ToString();
+                    }));
+                    foreach (string line in outQ.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
+                        step("m", true, line.Trim());
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Winmembers(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Reflect over the WINDOW's own type. The panel's speed is not the
+                    // TextBlock that displays it - writing that text only makes the label
+                    // agree with itself. What is needed is whatever the two arrows in
+                    // `speedButtonsGrid` actually change.
+                    string wT = ExtractJsonString(triggerJson, "window");
+                    string filt = ExtractJsonString(triggerJson, "filter");
+                    Window wm = FindWindowByTitle(string.IsNullOrWhiteSpace(wT) ? "Playback" : wT);
+                    if (wm == null) { step("window", false, "not found: " + wT); sb.Append("]}"); return sb.ToString(); }
+                    Type wt = wm.GetType();
+                    step("type", true, wt.FullName);
+                    string res = (string)wm.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        StringBuilder o = new StringBuilder();
+                        foreach (PropertyInfo pi in wt.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                        {
+                            if (!string.IsNullOrWhiteSpace(filt) && pi.Name.IndexOf(filt, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                            string val = "?";
+                            try { val = pi.CanRead ? ("" + pi.GetValue(wm, null)) : "(write-only)"; } catch (Exception ex) { val = ex.GetType().Name; }
+                            o.Append("prop ").Append(pi.Name).Append(" : ").Append(pi.PropertyType.Name)
+                             .Append(" = ").Append(val).Append(pi.CanWrite ? "  [writable]" : "").Append(Environment.NewLine);
+                        }
+                        foreach (FieldInfo fi in wt.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                        {
+                            if (!string.IsNullOrWhiteSpace(filt) && fi.Name.IndexOf(filt, StringComparison.OrdinalIgnoreCase) < 0) continue;
+                            string val = "?";
+                            try { val = "" + fi.GetValue(wm); } catch (Exception ex) { val = ex.GetType().Name; }
+                            o.Append("field ").Append(fi.Name).Append(" : ").Append(fi.FieldType.Name)
+                             .Append(" = ").Append(val).Append(Environment.NewLine);
+                        }
+                        return o.ToString();
+                    }));
+                    foreach (string line in res.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))
+                        if (!string.IsNullOrWhiteSpace(line)) step("m", true, line.Trim());
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Setel(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Set one property on one named element, and read it back. Needed to
+                    // test a control before wiring it into a chain - here the Playback
+                    // progression slider, which an operator reports stops a run when dragged
+                    // fully left. Testing beats assuming: the play BUTTON was assumed to
+                    // stop the transport and does not.
+                    string wT = ExtractJsonString(triggerJson, "window");
+                    string eN = ExtractJsonString(triggerJson, "element");
+                    string pN = ExtractJsonString(triggerJson, "property");
+                    string vS = ExtractJsonString(triggerJson, "value");
+                    Window ws = FindWindowByTitle(string.IsNullOrWhiteSpace(wT) ? "Playback" : wT);
+                    if (ws == null) { step("window", false, "not found: " + wT); sb.Append("]}"); return sb.ToString(); }
+                    string outS = (string)ws.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        object el = FindElement(ws, eN);
+                        if (el == null) return "element '" + eN + "' not found";
+                        PropertyInfo pi = el.GetType().GetProperty(pN);
+                        if (pi == null) return "no property '" + pN + "' on " + el.GetType().Name;
+                        object before = null;
+                        try { before = pi.GetValue(el, null); } catch { }
+                        if (!pi.CanWrite) return "read-only, value=" + before;
+                        try
+                        {
+                            // Nullable<T> needs the UNDERLYING type: ToggleButton.IsChecked is
+                            // bool?, and Convert.ChangeType to bool? throws InvalidCastException
+                            // (measured 2026-08-19 while trying to open the template slideout).
+                            Type pt = pi.PropertyType;
+                            Type under = Nullable.GetUnderlyingType(pt);
+                            object conv = string.IsNullOrEmpty(vS) && under != null
+                                          ? null
+                                          : Convert.ChangeType(vS, under ?? pt, InvCi);
+                            pi.SetValue(el, conv, null);
+                        }
+                        catch (Exception ex) { return "set threw " + ex.GetType().Name + ": " + ex.Message; }
+                        object after = null;
+                        try { after = pi.GetValue(el, null); } catch { }
+                        return el.GetType().Name + "." + pN + ": " + before + " -> " + after;
+                    }));
+                    step("set " + eN + "." + pN, outS.IndexOf(" -> ", StringComparison.Ordinal) > 0, outS);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Hide(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    HideDialogs(step);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Unhide(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    UnhideDialogs(step);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Park(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Stopping the transport as its own step, so a caller can make sure
+                    // nothing moves before it touches a dialog.
+                    int tries = 6;
+                    ParkTransport(step, tries);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Closedialogs(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    int closed = 0;
+                    foreach (Window w in AllWindowsIncludingOwned())
+                    {
+                        string ty = null;
+                        try { ty = w.GetType().FullName; } catch { }
+                        if (ty == null || ty.IndexOf("Dialog", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                        Window ww = w;
+                        try
+                        {
+                            ww.Dispatcher.Invoke(new Action(delegate { ww.Close(); }));
+                            closed++;
+                            step("closed", true, ty);
+                        }
+                        catch (Exception ex) { step("close failed", false, ty + ": " + ex.Message); }
+                    }
+                    step("dialogs closed", true, closed + " closed");
+                    Thread.Sleep(800);
+                    step("windows now", true, WindowTitles());
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Baseline(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            Type pb = ctx.Pb;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Verify the starting state and, unless checkOnly, restore it.
+                    // A run must begin from a state we established, not from whatever
+                    // the last attempt left behind.
+                    bool checkOnly = string.Equals(ExtractJsonString(triggerJson, "checkOnly"),
+                                                   "true", StringComparison.OrdinalIgnoreCase);
+
+                    // a) dialogs
+                    List<Window> dlgs = new List<Window>();
+                    foreach (Window w in AllWindowsIncludingOwned())
+                    {
+                        try { if (w.GetType().FullName.IndexOf("Dialog", StringComparison.OrdinalIgnoreCase) >= 0) dlgs.Add(w); }
+                        catch { }
+                    }
+                    if (dlgs.Count == 0) step("no open dialog", true, "ok");
+                    else if (checkOnly) step("no open dialog", false, dlgs.Count + " open");
+                    else
+                    {
+                        foreach (Window w in dlgs)
+                        {
+                            Window ww = w;
+                            try { ww.Dispatcher.Invoke(new Action(delegate { ww.Close(); })); } catch { }
+                        }
+                        Thread.Sleep(800);
+                        int left = 0;
+                        foreach (Window w in AllWindowsIncludingOwned())
+                        {
+                            try { if (w.GetType().FullName.IndexOf("Dialog", StringComparison.OrdinalIgnoreCase) >= 0) left++; }
+                            catch { }
+                        }
+                        step("no open dialog", left == 0, "closed " + dlgs.Count + ", left " + left);
+                    }
+
+                    // b) strategy rows
+                    Window cc3 = FindWindowByTitle("Control Center");
+                    if (cc3 == null) step("strategy rows", false, "Control Center not found");
+                    else
+                    {
+                        string r = (string)cc3.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            object grid = FindElement(cc3, "grdStrategies");
+                            if (grid == null) return "grdStrategies not found";
+                            PropertyInfo pSrc = grid.GetType().GetProperty("DataSource");
+                            System.Collections.IEnumerable rows =
+                                pSrc == null ? null : pSrc.GetValue(grid, null) as System.Collections.IEnumerable;
+                            if (rows == null) return "no DataSource";
+                            List<object> list = new List<object>();
+                            foreach (object o in rows) if (o != null) list.Add(o);
+                            if (list.Count == 0) return "none";
+                            if (checkOnly) return list.Count + " row(s) present";
+                            // One removal per dispatcher trip - waiting in here would block
+                            // the thread that performs it.
+                            int start = RowCount(grid);
+                            foreach (var kv in GridRows(grid))
+                                if (kv.Value != null) FireDisableRemove(cc3, kv.Value);
+                            return "rows before=" + start;
+                        }));
+                        // Outside the dispatcher: wait, count, and repeat while rows remain.
+                        int left2 = -1;
+                        for (int round = 0; round < 20; round++)
+                        {
+                            Thread.Sleep(700);
+                            Window ccx = cc3;
+                            left2 = (int)ccx.Dispatcher.Invoke(new Func<int>(delegate
+                            {
+                                object g3 = FindElement(ccx, "grdStrategies");
+                                return g3 == null ? -1 : RowCount(g3);
+                            }));
+                            if (left2 <= 0) break;
+                            ccx.Dispatcher.Invoke(new Action(delegate
+                            {
+                                object g3 = FindElement(ccx, "grdStrategies");
+                                if (g3 == null) return;
+                                PropertyInfo ps3 = g3.GetType().GetProperty("DataSource");
+                                System.Collections.IEnumerable rs =
+                                    ps3 == null ? null : ps3.GetValue(g3, null) as System.Collections.IEnumerable;
+                                if (rs == null) return;
+                                foreach (var kv in GridRows(g3))
+                                    if (kv.Value != null) FireDisableRemove(ccx, kv.Value);
+                            }));
+                        }
+                        step("strategy rows", r == "none" || left2 == 0, r + "  rows now=" + left2);
+                    }
+
+                    // c) a running transport saturates the UI thread. Measured
+                    // 2026-08-19: with the player at Max speed the strategy dialog
+                    // disappeared between two bridge calls and "Enable" came back
+                    // greyed. A moving clock is not a baseline.
+                    if (checkOnly)
+                    {
+                        DateTime seenB;
+                        bool movingB = TransportMoving(out seenB);
+                        step("transport parked", !movingB,
+                             movingB ? ("STILL RUNNING at " + seenB) : ("parked at " + seenB));
+                    }
+                    else ParkTransport(step, 6);
+
+                    // d) connections. The Control Center can be found in any of three
+                    //    states - Playback up, nothing connected, or connected to some
+                    //    other provider - and each needs a different repair. `require`
+                    //    says which one the caller needs: "playback" (default) or "none".
+                    string require = ExtractJsonString(triggerJson, "require");
+                    if (string.IsNullOrWhiteSpace(require)) require = "playback";
+                    List<string> live = new List<string>();
+                    foreach (Connection c in Connection.Connections)
+                        if (c != null && c.Options != null && c.Options.Provider != Provider.Playback
+                            && c.Status != ConnectionStatus.Disconnected)
+                            live.Add(c.Options.Name + "=" + c.Status);
+                    step("other connections", live.Count == 0,
+                         live.Count == 0 ? "none" : string.Join(", ", live.ToArray()));
+
+                    PropertyInfo piC2 = typeof(Connection).GetProperty("PlaybackConnection", BFStatic);
+                    Connection pc2 = piC2 != null ? piC2.GetValue(null) as Connection : null;
+                    bool pbUp = pc2 != null && pc2.Status == ConnectionStatus.Connected;
+
+                    if (!checkOnly && string.Equals(require, "playback", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Playback refuses to connect while anything else is up, and says
+                        // so in a modal dialog that also blocks the dispatcher.
+                        if (live.Count > 0)
+                        {
+                            foreach (Connection c in Connection.Connections)
+                                if (c != null && c.Options != null && c.Options.Provider != Provider.Playback
+                                    && c.Status != ConnectionStatus.Disconnected)
+                                    try { c.Disconnect(); } catch { }
+                            for (int i = 0; i < 60; i++)
+                            {
+                                Thread.Sleep(500);
+                                bool any = false;
+                                foreach (Connection c in Connection.Connections)
+                                    if (c != null && c.Options != null && c.Options.Provider != Provider.Playback
+                                        && c.Status != ConnectionStatus.Disconnected) any = true;
+                                if (!any) break;
+                            }
+                            // Counted, not assumed: "requested" described the call.
+                        int stillOn = 0;
+                        foreach (Connection cx in Connection.Connections)
+                            if (cx != null && cx.Status == ConnectionStatus.Connected) stillOn++;
+                        step("other connections closed", true, stillOn + " still connected");
+                        }
+                        if (!pbUp)
+                        {
+                            try { NinjaTrader.Core.Globals.TradingOptions.IsGlobalSimulationMode = true; } catch { }
+                            ConnectOptions po2 = null;
+                            foreach (ConnectOptions o in NinjaTrader.Core.Globals.ConnectOptions)
+                                if (o.Provider == Provider.Playback) { po2 = o; break; }
+                            if (po2 == null) step("connect playback", false, "no Playback ConnectOptions");
+                            else
+                            {
+                                Connection.Connect(po2);
+                                string s3 = "?";
+                                for (int i = 0; i < 600; i++)
+                                {
+                                    Thread.Sleep(500);
+                                    Connection c = piC2 != null ? piC2.GetValue(null) as Connection : null;
+                                    s3 = c == null ? "null" : c.Status.ToString();
+                                    if (c != null && c.Status == ConnectionStatus.Connected) break;
+                                }
+                                pbUp = s3 == "Connected";
+                                step("connect playback", pbUp, "Status=" + s3);
+                            }
+                        }
+                    }
+                    step("playback connected", pbUp,
+                         pc2 == null ? "no connection object" : ("Status=" + (piC2.GetValue(null) as Connection == null
+                             ? "null" : ((Connection)piC2.GetValue(null)).Status.ToString())));
+                    PropertyInfo piNow3 = pb.GetProperty("NowEst", BFStatic);
+                    if (piNow3 != null) step("NowEst", true, "" + piNow3.GetValue(null));
+
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Dialogs(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // What is already open? Never guess the starting state.
+                    step("windows", true, WindowTitles());
+                    foreach (Window w in AllWindowsIncludingOwned())
+                    {
+                        string ti = null, ty = null;
+                        try
+                        {
+                            Window ww = w;
+                            ti = (string)ww.Dispatcher.Invoke(new Func<string>(delegate { return ww.Title; }));
+                            ty = ww.GetType().FullName;
+                        }
+                        catch { }
+                        if (ty != null && ty.IndexOf("Dialog", StringComparison.OrdinalIgnoreCase) >= 0)
+                            step("open dialog", false, ty + "  title='" + ti + "'");
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Enablestrategy(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Calls NinjaTrader's own StrategyEnable / StrategyDisable statics - the
+                    // calls behind the menu entries, no menu and no selection involved.
+                    // Setting StrategiesGridEntry.IsEnabled would flip a display value
+                    // without starting anything, which is why the property is not used.
+                    string wantE = ExtractJsonString(triggerJson, "strategy");
+                    // Direction. A teardown must be able to switch a strategy OFF; the
+                    // stage used to be hardwired to "Enable".
+                    string enableFlag = ExtractJsonString(triggerJson, "enable");
+                    bool wantEnabled = string.IsNullOrWhiteSpace(enableFlag)
+                                       || string.Equals(enableFlag, "true", StringComparison.OrdinalIgnoreCase);
+                    string entryE = wantEnabled ? "Enable" : "Disable";
+                    Window cce = FindWindowByTitle("Control Center");
+                    if (cce == null) { step("Control Center", false, "not found"); sb.Append("]}"); return sb.ToString(); }
+                    string resE = (string)cce.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        object grid = FindElement(cce, "grdStrategies");
+                        if (grid == null) return "grdStrategies not found";
+                        PropertyInfo pSrc = grid.GetType().GetProperty("DataSource");
+                        System.Collections.IEnumerable rows =
+                            pSrc == null ? null : pSrc.GetValue(grid, null) as System.Collections.IEnumerable;
+                        if (rows == null) return "no DataSource";
+                        object hit = null;
+                        foreach (object row in rows)
+                        {
+                            if (row == null) continue;
+                            PropertyInfo pn = row.GetType().GetProperty("Name");
+                            string nm = pn == null ? null : ("" + pn.GetValue(row, null)).Trim();
+                            if (string.IsNullOrWhiteSpace(wantE) || (nm != null
+                                && nm.IndexOf(wantE, StringComparison.OrdinalIgnoreCase) >= 0))
+                            { hit = row; break; }
+                        }
+                        if (hit == null) return "no row matching '" + wantE + "'";
+
+                        // Already there? NinjaTrader greys out the entry that would be a
+                        // no-op, so invoking it would report a failure for exactly the
+                        // state the caller asked for.
+                        PropertyInfo piE = hit.GetType().GetProperty("IsEnabled");
+                        if (piE != null)
+                        {
+                            object cur = null;
+                            try { cur = piE.GetValue(hit, null); } catch { }
+                            if (cur is bool && ((bool)cur) == wantEnabled)
+                                return "already " + (wantEnabled ? "enabled" : "disabled");
+                        }
+
+                        // The call behind the menu entry, fired not awaited. Enable takes the
+                        // row; Disable does not.
+                        StrategyBase sHit = RowStrategy(hit);
+                        if (sHit == null) return "row carries no StrategyBase";
+                        MethodInfo mEn = wantEnabled ? StrategiesGridStatic("StrategyEnable", 3)
+                                                     : StrategiesGridStatic("StrategyDisable", 1);
+                        if (mEn == null) return (wantEnabled ? "StrategyEnable" : "StrategyDisable")
+                                              + " not found on StrategiesGrid";
+                        object[] argsEn = wantEnabled ? new object[] { sHit, cce, hit }
+                                                      : new object[] { sHit };
+                        MethodInfo mEn2 = mEn;
+                        cce.Dispatcher.BeginInvoke(new Action(delegate
+                        {
+                            try { mEn2.Invoke(null, argsEn); } catch { }
+                        }));
+                        return "fired " + mEn.Name;
+                    }));
+                    Thread.Sleep(2000);
+                    string stateE = (string)cce.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        object grid = FindElement(cce, "grdStrategies");
+                        if (grid == null) return "grid gone";
+                        PropertyInfo pSrc = grid.GetType().GetProperty("DataSource");
+                        System.Collections.IEnumerable rows =
+                            pSrc == null ? null : pSrc.GetValue(grid, null) as System.Collections.IEnumerable;
+                        if (rows == null) return "no DataSource";
+                        foreach (object row in rows)
+                        {
+                            if (row == null) continue;
+                            PropertyInfo pe = row.GetType().GetProperty("IsEnabled");
+                            PropertyInfo pn = row.GetType().GetProperty("Name");
+                            return ("" + (pn == null ? "?" : pn.GetValue(row, null))).Trim()
+                                   + " IsEnabled=" + (pe == null ? "?" : "" + pe.GetValue(row, null));
+                        }
+                        return "no rows";
+                    }));
+                    string wantMark = wantEnabled ? "IsEnabled=True" : "IsEnabled=False";
+                    step(wantEnabled ? "enable" : "disable",
+                         stateE.IndexOf(wantMark, StringComparison.OrdinalIgnoreCase) >= 0,
+                         resE + "  ->  " + stateE);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Removestrategy(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Select by name, then let NinjaTrader remove the row. Removing it
+                    // from the bound collection directly would leave the strategy on the
+                    // account - the grid is a view, not the owner.
+                    string want = ExtractJsonString(triggerJson, "strategy");
+                    Window cc2 = FindWindowByTitle("Control Center");
+                    if (cc2 == null) { step("Control Center", false, "not found"); sb.Append("]}"); return sb.ToString(); }
+                    // Counted OUTSIDE the dispatcher, before anything is fired: the verdict
+                    // below compares against this, so it rests on the row count and not on
+                    // the fact that a call was made.
+                    int before3 = (int)cc2.Dispatcher.Invoke(new Func<int>(delegate
+                    {
+                        object g0 = FindElement(cc2, "grdStrategies");
+                        return g0 == null ? -1 : RowCount(g0);
+                    }));
+                    string res = (string)cc2.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        object grid = FindElement(cc2, "grdStrategies");
+                        if (grid == null) return "grdStrategies not found";
+                        PropertyInfo pSrc = grid.GetType().GetProperty("DataSource");
+                        System.Collections.IEnumerable rows =
+                            pSrc == null ? null : pSrc.GetValue(grid, null) as System.Collections.IEnumerable;
+                        if (rows == null) return "grid has no DataSource";
+                        object hit = null;
+                        int seen = 0;
+                        foreach (object row in rows)
+                        {
+                            seen++;
+                            if (row == null) continue;
+                            PropertyInfo pn = row.GetType().GetProperty("Name");
+                            string nm = pn == null ? null : ("" + pn.GetValue(row, null)).Trim();
+                            if (string.IsNullOrWhiteSpace(want) || (nm != null
+                                && nm.IndexOf(want, StringComparison.OrdinalIgnoreCase) >= 0))
+                            { hit = row; break; }
+                        }
+                        if (hit == null) return "no row matching '" + want + "' among " + seen;
+                        // NEVER wait inside the dispatcher: sleeping here blocks the very
+                        // UI thread that has to carry out the removal, so the count can
+                        // only ever come back unchanged. Measured 2026-08-18 - the row was
+                        // in fact gone while this reported "rows 1 -> 1". Count before,
+                        // fire, return; the caller waits and counts again outside.
+                        //
+                        // Disable FIRST. NinjaTrader only asks "are you sure" when the
+                        // strategy is still enabled, and that modal blocks every following
+                        // command. Disabling an already-disabled strategy is a no-op, so
+                        // the order costs nothing and removes the dialog instead of
+                        // answering it - answering would be a click.
+                        int before2 = RowCount(grid);
+                        StrategyBase sHit2 = RowStrategy(hit);
+                        if (sHit2 == null) return "row carries no StrategyBase";
+                        FireDisableRemove(cc2, sHit2);
+                        return "fired StrategyDisable + StrategyRemove  rows before=" + before2;
+                    }));
+                    // Outside the dispatcher now: give NinjaTrader time to act, then
+                    // count again in a fresh Invoke. The count is the evidence.
+                    Thread.Sleep(1500);
+                    int after3 = (int)cc2.Dispatcher.Invoke(new Func<int>(delegate
+                    {
+                        object g2 = FindElement(cc2, "grdStrategies");
+                        return g2 == null ? -1 : RowCount(g2);
+                    }));
+                    // The EVIDENCE is the count dropping, never "the call returned".
+                    step("remove", after3 >= 0 && after3 < before3,
+                         res + "  rows " + before3 + " -> " + after3);
+                    step("windows now", true, WindowTitles());
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Uiidle(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Wait until NinjaTrader has drained its UI queue - the handshake that
+                    // was missing between every pair of stages. Both windows are asked,
+                    // because they live on different UI threads: measured 2026-08-19,
+                    // Application.Current.Windows does not even list all of them.
+                    //
+                    // `window` picks one by title; without it, Control Center and Playback
+                    // are both checked. A window that does not exist is reported as such,
+                    // never silently skipped.
+                    string wantW = ExtractJsonString(triggerJson, "window");
+                    string[] titles = string.IsNullOrWhiteSpace(wantW)
+                        ? new string[] { "Control Center", "Playback" }
+                        : new string[] { wantW };
+                    bool allIdle = true;
+                    foreach (string ti in titles)
+                    {
+                        Window wi = FindWindowByTitle(ti);
+                        if (wi == null) { step("idle " + ti, true, "window not present"); continue; }
+                        long msI; string stI;
+                        bool idle = WaitForUiIdle(wi, RequestTtlSec(triggerJson), out msI, out stI);
+                        if (!idle) allIdle = false;
+                        step("idle " + ti, idle,
+                             idle ? ("queue drained after " + msI + " ms")
+                                  : ("STILL busy after " + msI + " ms - operation " + stI));
+                    }
+                    step("ui idle", allIdle,
+                         allIdle ? "every window reported its queue drained"
+                                 : "at least one window is still working - do not send the next step");
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Alloff(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // ⚠ THE BASELINE STEP MUST COPE WITH ANY STARTING SITUATION:
+                    // nothing connected, one live feed, several at once. It turns
+                    // everything off and proves it, by name.
+                    //
+                    // ⚠ MODE WARNING: Playback wants every other connection DOWN, the
+                    // Strategy Analyzer wants a LIVE one UP and no Playback. Called
+                    // bare, this stage serves the first and destroys the second. Pass
+                    // `keep` with the connection names that must survive.
+                    //
+                    // Neither existing stage does that: `disconnect` touches only
+                    // Connection.PlaybackConnection, and `connect` disconnects the others
+                    // but then connects Playback. A baseline built from those two is a
+                    // baseline nobody measured.
+                    //
+                    // It enumerates Connection.Connections - the LIVE list. The
+                    // configuration is the wrong source and hid a running connection on
+                    // 2026-08-20: NinjaTrader's menu showed "Live" connected while a
+                    // report built from Globals.ConnectOptions listed six rows without
+                    // it (see RunConnections in NT8BridgeServer.cs).
+                    List<Connection> all = new List<Connection>();
+                    try { foreach (Connection c in Connection.Connections) if (c != null) all.Add(c); }
+                    catch (Exception ex) { step("enumerate", false, Deep(ex)); }
+
+                    // ⚠ `keep` EXISTS BECAUSE THE OPERATING MODES NEED OPPOSITE THINGS.
+                    //
+                    // Playback needs every other connection DOWN. The Strategy Analyzer
+                    // needs a LIVE connection up and must not have Playback at all - the
+                    // wrong one gives 262,379 callbacks instead of 1,968,635, or every
+                    // counter at zero, and the backtest still reports status: ok.
+                    //
+                    // Without this parameter the stage is a blunt instrument that any
+                    // future caller could fire before an Analyzer run, killing the very
+                    // connection that run depends on. `keep` names the connections that
+                    // stay up, comma separated; they are reported, so what survived is a
+                    // measurement and not an assumption. Empty = everything off.
+                    string keepS = ExtractJsonString(triggerJson, "keep");
+                    List<string> keepList = new List<string>();
+                    if (!string.IsNullOrWhiteSpace(keepS))
+                        foreach (string k in keepS.Split(','))
+                            if (k.Trim().Length > 0) keepList.Add(k.Trim());
+
+                    // 1. STATE BEFORE - names and status, so "it changed" is answerable
+                    List<string> names = new List<string>();
+                    List<Connection> open = new List<Connection>();
+                    List<string> kept = new List<string>();
+                    foreach (Connection c in all)
+                    {
+                        string nm = "?", st = "?";
+                        try { nm = c.Options == null ? "<no options>" : c.Options.Name; } catch { }
+                        try { st = c.Status.ToString(); } catch { }
+                        names.Add(nm + "=" + st);
+                        bool spare = false;
+                        foreach (string k in keepList)
+                            if (string.Equals(k, nm, StringComparison.OrdinalIgnoreCase)) spare = true;
+                        if (spare) { kept.Add(nm + "=" + st); continue; }
+                        if (st != ConnectionStatus.Disconnected.ToString()) open.Add(c);
+                    }
+                    step("before", true, all.Count + " connection(s): "
+                         + (names.Count == 0 ? "none" : string.Join(", ", names.ToArray())));
+                    if (keepList.Count > 0)
+                        step("kept up on request", true,
+                             kept.Count == 0
+                             ? ("keep=" + string.Join(",", keepList.ToArray())
+                                + " matched no connection - NOTHING was spared")
+                             : string.Join(", ", kept.ToArray()));
+
+                    if (open.Count == 0)
+                    {
+                        step("all disconnected", true, keepList.Count > 0
+                             ? "nothing left to disconnect beside the kept one(s)"
+                             : "nothing was connected - nothing to do");
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+
+                    // 2. TRIGGER on every one that is not already down
+                    int markOff = NtLogCount();
+                    List<string> hit = new List<string>();
+                    foreach (Connection c in open)
+                    {
+                        string nm = "?";
+                        try { nm = c.Options == null ? "<no options>" : c.Options.Name; } catch { }
+                        hit.Add(nm);
+                        try { c.Disconnect(); }
+                        catch (Exception ex) { step("disconnect " + nm, false, Deep(ex)); }
+                    }
+                    step("triggered", true, "Disconnect() on " + string.Join(", ", hit.ToArray()));
+
+                    // 3. WAIT FOR THE CHANGE - NinjaTrader's own entry, matched on the
+                    //    resource NAME so it holds in any UI language. Proven to
+                    //    discriminate on 2026-08-20: silent while nothing happened,
+                    //    5 entries on connect, 2 on disconnect.
+                    string hitLine; int nowIdx;
+                    bool sawIt = WaitForLogName(markOff, "CbiConnectionProcessConnectionStatusUpdate",
+                                                null, RequestTtlSec(triggerJson), out hitLine, out nowIdx);
+                    step("change seen", sawIt, sawIt ? hitLine : "NinjaTrader logged no status change");
+
+                    // 4. WAIT FOR THE END - every connection reports Disconnected. The
+                    //    250 ms is the SAMPLING RATE of the measurement, never a
+                    //    deadline: the only bound is the caller's own ttlSec.
+                    System.Diagnostics.Stopwatch swOff = System.Diagnostics.Stopwatch.StartNew();
+                    double ttlOff = RequestTtlSec(triggerJson);
+                    List<string> left = new List<string>();
+                    while (swOff.Elapsed.TotalSeconds < ttlOff)
+                    {
+                        left.Clear();
+                        foreach (Connection c in open)
+                        {
+                            string st = "?", nm = "?";
+                            try { nm = c.Options == null ? "<no options>" : c.Options.Name; } catch { }
+                            try { st = c.Status.ToString(); } catch { }
+                            if (st != ConnectionStatus.Disconnected.ToString()) left.Add(nm + "=" + st);
+                        }
+                        if (left.Count == 0) break;
+                        Thread.Sleep(250);
+                    }
+                    step("all disconnected", left.Count == 0,
+                         left.Count == 0
+                         ? ("every connection reports Disconnected after "
+                            + swOff.ElapsedMilliseconds + " ms: " + string.Join(", ", hit.ToArray()))
+                         : ("STILL UP after " + swOff.ElapsedMilliseconds + " ms: "
+                            + string.Join(", ", left.ToArray())));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Disconnect(PbRunCtx ctx)
+        {
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Only disconnect - no reconnect. Recycling re-indexes the replay
+                    // store and locks the whole panel again; sometimes all that is
+                    // wanted is a transport that stops.
+                    PropertyInfo piD = typeof(Connection).GetProperty("PlaybackConnection", BFStatic);
+                    Connection pd = piD != null ? piD.GetValue(null) as Connection : null;
+                    if (pd == null || pd.Status == ConnectionStatus.Disconnected)
+                        step("disconnect playback", true, "was not connected");
+                    else
+                    {
+                        pd.Disconnect();
+                        string sd = "?";
+                        for (int i = 0; i < 120; i++)
+                        {
+                            Thread.Sleep(500);
+                            Connection c = piD.GetValue(null) as Connection;
+                            sd = c == null ? "null" : c.Status.ToString();
+                            if (c == null || c.Status == ConnectionStatus.Disconnected) break;
+                        }
+                        step("disconnect playback", sd == "Disconnected" || sd == "null", "Status=" + sd);
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Recycle(PbRunCtx ctx)
+        {
+            Type pb = ctx.Pb;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Disconnect Playback and connect it again. A transport left at the
+                    // end of a finished range keeps its clock there, and anything started
+                    // afterwards has no data ahead of it. Recycling is what the
+                    // Connections menu does by hand.
+                    PropertyInfo piC = typeof(Connection).GetProperty("PlaybackConnection", BFStatic);
+                    Connection pc = piC != null ? piC.GetValue(null) as Connection : null;
+                    if (pc != null && pc.Status != ConnectionStatus.Disconnected)
+                    {
+                        pc.Disconnect();
+                        string s1 = "?";
+                        for (int i = 0; i < 120; i++)
+                        {
+                            Thread.Sleep(500);
+                            Connection c = piC.GetValue(null) as Connection;
+                            s1 = c == null ? "null" : c.Status.ToString();
+                            if (c == null || c.Status == ConnectionStatus.Disconnected) break;
+                        }
+                        step("disconnect playback", s1 == "Disconnected" || s1 == "null", "Status=" + s1);
+                    }
+                    else step("disconnect playback", true, "was not connected");
+
+                    ConnectOptions po = null;
+                    foreach (ConnectOptions o in NinjaTrader.Core.Globals.ConnectOptions)
+                        if (o.Provider == Provider.Playback) { po = o; break; }
+                    if (po == null) { step("connect playback", false, "no Playback ConnectOptions"); sb.Append("]}"); return sb.ToString(); }
+                    Connection.Connect(po);
+                    string s2 = "?";
+                    for (int i = 0; i < 600; i++)
+                    {
+                        Thread.Sleep(500);
+                        Connection c = piC != null ? piC.GetValue(null) as Connection : null;
+                        s2 = c == null ? "null" : c.Status.ToString();
+                        if (c != null && c.Status == ConnectionStatus.Connected) break;
+                    }
+                    step("connect playback", s2 == "Connected", "Status=" + s2);
+                    PropertyInfo piNow2 = pb.GetProperty("NowEst", BFStatic);
+                    if (piNow2 != null) step("NowEst", true, "" + piNow2.GetValue(null));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Connect(PbRunCtx ctx)
+        {
+            _orderNoticesDismissed = 0;     // a run starts with its connect - see DismissOrderRejectNotices
+            string triggerJson = ctx.TriggerJson;
+            string fromS = ctx.FromS;
+            string toS = ctx.ToS;
+            string srcS = ctx.SrcS;
+            Type pb = ctx.Pb;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // One clock for the whole stage: every wait below draws from the
+                    // caller's single ttlSec instead of each taking it in full.
+                    System.Diagnostics.Stopwatch stageClock = System.Diagnostics.Stopwatch.StartNew();
+                    // What the range was MEANT to be; confirmed once the connection is up.
+                    DateTime? wantFrom = null, wantTo = null;
+                    // The unpadded request - see the note where these are filled.
+                    DateTime? reqFrom = null, reqTo = null;
+                    ArmPanelWatch();   // before anything connects, so no event is missed
+                    // Global simulation mode FIRST. Connecting Playback without it
+                    // puts NinjaTrader on its restart-in-simulation path.
+                    // Skippable so it can be tested as a single variable. It is the one
+                    // thing this stage did on EVERY connect that a person connecting from
+                    // the Playback dialog never does - and an operator reports their manual
+                    // connect leaves the transport standing while ours starts by itself.
+                    bool skipGlobalSim = string.Equals(ExtractJsonString(triggerJson, "skipGlobalSim"),
+                                                       "true", StringComparison.OrdinalIgnoreCase);
+                    if (skipGlobalSim) step("global simulation mode", true, "SKIPPED on request");
+                    else
+                    {
+                        try
+                        {
+                            NinjaTrader.Core.Globals.TradingOptions.IsGlobalSimulationMode = true;
+                            step("global simulation mode", true, "IsGlobalSimulationMode=true");
+                        }
+                        catch (Exception ex) { step("global simulation mode", false, ex.GetType().Name + ": " + ex.Message); }
+                    }
+
+                    // `statics:"false"` connects WITHOUT touching the adapter - the
+                    // instrument for finding out which of these writes makes the
+                    // transport start on its own. A human connecting from the GUI writes
+                    // none of them, and an operator reports the transport then stays put.
+                    // Each write is also individually skippable, so the culprit can be
+                    // isolated by changing ONE thing against a working run.
+                    bool writeStatics = !string.Equals(ExtractJsonString(triggerJson, "statics"),
+                                                       "false", StringComparison.OrdinalIgnoreCase);
+                    bool skipMode = string.Equals(ExtractJsonString(triggerJson, "skipFromMode"),
+                                                  "true", StringComparison.OrdinalIgnoreCase);
+                    bool skipSpeed = string.Equals(ExtractJsonString(triggerJson, "skipSpeed"),
+                                                   "true", StringComparison.OrdinalIgnoreCase);
+                    bool hist = string.Equals(srcS, "historical", StringComparison.OrdinalIgnoreCase);
+                    if (!writeStatics) step("statics", true, "SKIPPED on request");
+                    else
+                    {
+                        SetStatic(pb, "IsSourceHistoricalData", hist, step);
+                        if (skipMode) step("PlaybackFromMode", true, "SKIPPED on request");
+                        else SetStatic(pb, "PlaybackFromMode", Enum.Parse(typeof(PlaybackFromMode), "SelectedTime"), step);
+                        // ⚠ WRITE NOW, VERIFY AFTER THE CONNECT.
+                        //
+                        // The adapter reads these while connecting, so they have to be
+                        // written here. But its getter does not report the pending value
+                        // yet: measured, both read straight back as DateTime.MinValue,
+                        // and the run died on a read-back of a state that does not exist
+                        // before the connection is up. Our own host writes the same
+                        // statics and reads FromEst=10.08.2026 back AFTER connecting.
+                        //
+                        // So the confirming read is the step further down. Nothing is
+                        // accepted silently - it is checked where a check can mean
+                        // something.
+                        // ⚠ TWO PAIRS, AND THEY ARE NOT INTERCHANGEABLE.
+                        //
+                        //   reqFrom/reqTo    the days the CALLER asked for
+                        //   wantFrom/wantTo  those days padded by one on each side, which is
+                        //                    what gets WRITTEN, so the clock can be parked
+                        //                    before the first bar and run past the last one
+                        //
+                        // The coverage check further down must use the REQUESTED pair. It used
+                        // the padded one until 25.08.2026, and then a request for exactly the
+                        // days that exist could never pass it: measured coverage
+                        // "FromEst=10.08.2026 00:00:00 ToEst=10.08.2026 23:59:59" against a
+                        // --from/--to of 10.08.2026 reported "requested window inside it: False",
+                        // because it was comparing 09.08. against 10.08. Two of three cells died
+                        // on that, after connecting perfectly.
+                        if (!string.IsNullOrWhiteSpace(fromS))
+                        {
+                            reqFrom = DateTime.Parse(fromS, InvCi).Date;
+                            wantFrom = reqFrom.Value.AddDays(-1);
+                            SetStaticQuiet(pb, "FromEst", wantFrom.Value, step);
+                        }
+                        if (!string.IsNullOrWhiteSpace(toS))
+                        {
+                            reqTo = DateTime.Parse(toS, InvCi).Date;
+                            wantTo = reqTo.Value.AddDays(1);
+                            SetStaticQuiet(pb, "ToEst", wantTo.Value, step);
+                        }
+                        // ⚠ PlaybackSpeed is NOT written here. Writing it BEFORE connecting
+                        // starts the transport on its own - and it does not even take
+                        // effect: the value is moved to `oldPlaybackSpeed` and the live
+                        // field falls back to 1, which is why the panel then showed "1x"
+                        // while the clock advanced by itself.
+                        //
+                        // Bisected 2026-08-19 against an operator watching the panel, one
+                        // variable per run, disconnect + connect each time:
+                        //
+                        //   nothing written .................... stands
+                        //   + IsSourceHistoricalData ........... stands
+                        //   + FromEst / ToEst .................. stands
+                        //   + PlaybackFromMode ................. stands
+                        //   + PlaybackSpeed .................... RUNS
+                        //
+                        // It was written here for one afternoon on 2026-08-24, on the theory
+                        // that our GUI-less host does it and connects. That theory did not
+                        // hold - the connect kept failing with the write in place, and what
+                        // actually fixed it was watching the Connection that Connect RETURNS
+                        // instead of a static that stays null. So the write is gone again and
+                        // the bisect above stands.
+                        //
+                        // The speed belongs after the connection is up, where stage
+                        // "range" sets it together with Reset and reads it back as Max.
+                        if (skipSpeed) step("PlaybackSpeed", true, "SKIPPED on request");
+                        else step("PlaybackSpeed", true,
+                                  "not set before connecting - that starts the transport; stage 'range' sets it");
+                    }
+
+                    // Playback refuses to connect while anything else is connected and
+                    // says so in a MODAL dialog — which also blocks the dispatcher, so
+                    // the bridge stops answering entirely. Disconnect first, and prove
+                    // it by status rather than by the call returning.
+                    try
+                    {
+                        List<Connection> others = new List<Connection>();
+                        foreach (Connection c in Connection.Connections)
+                            if (c != null && c.Options != null && c.Options.Provider != Provider.Playback
+                                && c.Status != ConnectionStatus.Disconnected)
+                                others.Add(c);
+                        if (others.Count == 0) step("disconnect others", true, "nothing connected");
+                        else
+                        {
+                            List<string> names = new List<string>();
+                            foreach (Connection c in others) { names.Add(c.Options.Name); c.Disconnect(); }
+                            bool allGone = false;
+                            for (int i = 0; i < 60 && !allGone; i++)
+                            {
+                                Thread.Sleep(500);
+                                allGone = true;
+                                foreach (Connection c in others)
+                                    if (c.Status != ConnectionStatus.Disconnected) allGone = false;
+                            }
+                            step("disconnect others", allGone,
+                                 string.Join(", ", names.ToArray()) + " -> " + (allGone ? "Disconnected" : "still connected"));
+                            if (!allGone) { sb.Append("]}"); return sb.ToString(); }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        step("disconnect others", false, ex.GetType().Name + ": " + ex.Message);
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+
+                    ConnectOptions opts = null;
+                    foreach (ConnectOptions o in NinjaTrader.Core.Globals.ConnectOptions)
+                        if (o.Provider == Provider.Playback) { opts = o; break; }
+                    if (opts == null) step("playback connection", false, "no Playback ConnectOptions configured");
+                    else
+                    {
+                        PropertyInfo piConn = typeof(Connection).GetProperty("PlaybackConnection", BFStatic);
+                        Connection existing = piConn != null ? piConn.GetValue(null) as Connection : null;
+                        if (existing != null && existing.Status == ConnectionStatus.Connected)
+                            step("playback connection", true, "already Connected");
+                        else
+                        {
+                            // ⚠ WATCH THE CONNECTION Connect RETURNS.
+                            //
+                            // This polled the static Connection.PlaybackConnection and read
+                            // "Status=null" for the whole budget, every single run - null is
+                            // not a status, it is this code looking where the connection was
+                            // never put. Our own host, which connects reliably on the same
+                            // machine, watches the RETURN VALUE and nothing else.
+                            Connection conn = Connection.Connect(opts);
+                            if (conn == null)
+                            {
+                                step("playback connection", false,
+                                     "Connection.Connect returned null");
+                                sb.Append("]}");
+                                return sb.ToString();
+                            }
+                            // First connect indexes every replay file of the instrument
+                            // and can take minutes — measured on an MNQ ##-## store of
+                            // 2,355 files. Poll rather than assume.
+                            //
+                            // ⚠ THE BOUND IS THE CALLER'S ttlSec, NOT A NUMBER FROM HERE.
+                            // A fixed 300 s held this single-threaded poller for five
+                            // minutes after a connect that had already panicked (measured
+                            // 2026-08-24: panic at 15:01:15, queue free at 15:06:42), and
+                            // four queued requests expired unexecuted meanwhile. The caller
+                            // states what it is willing to wait; spending more of everyone
+                            // else's time than that is not this stage's to decide.
+                            string last = "?";
+                            System.Diagnostics.Stopwatch swPc = System.Diagnostics.Stopwatch.StartNew();
+                            // What is left of the request budget once the earlier steps
+                            // have had their share. ONE request, ONE budget.
+                            double ttlPc = RequestTtlSec(triggerJson) - stageClock.Elapsed.TotalSeconds;
+                            if (ttlPc < 1.0) ttlPc = 1.0;
+                            while (swPc.Elapsed.TotalSeconds < ttlPc)
+                            {
+                                Thread.Sleep(100);      // sampling rate from the reference host
+                                last = conn.Status.ToString();
+                                if (conn.Status == ConnectionStatus.Connected) break;
+                                // A connect that FAILED reports its own end state; waiting out
+                                // the rest of the budget on it only delays the report.
+                                if (conn.Status == ConnectionStatus.Disconnected
+                                    && swPc.Elapsed.TotalSeconds > 2.0) break;
+                            }
+                            // Connected is not usable: measured in a GUI-less host, every
+                            // account carried Connection=null while the connection itself read
+                            // Connected, and NinjaTrader then takes a strategy to Finalized
+                            // instead of Realtime without a word. So the count is reported.
+                            int acctsOn = 0;
+                            try
+                            {
+                                foreach (Account a2 in Account.All)
+                                    if (a2 != null && a2.Connection == conn) acctsOn++;
+                            }
+                            catch (Exception ex) { last += " (accounts: " + ex.GetType().Name + ")"; }
+                            step("playback connection", last == "Connected",
+                                 "Status=" + last + " after " + swPc.ElapsedMilliseconds
+                                 + " ms (caller allowed " + ((int)ttlPc) + " s), accounts on it: "
+                                 + acctsOn);
+
+                            // ⚠ WHAT THE CONNECT LEFT IS THE STORE'S COVERAGE, NOT OUR RANGE.
+                            //
+                            // Measured right after Connected, having written 09.08.2026 and
+                            // 11.08.2026:
+                            //     FromEst read=12.03.2013   ToEst read=18.08.2026 23:59:59
+                            // which is the span of everything in the replay store. Connecting
+                            // replaces the requested window with the available one - our own
+                            // host knows this and positions AGAIN afterwards, and stage
+                            // `range` in this file carries the same note: "AFTER connect -
+                            // before it the adapter discards these".
+                            //
+                            // So the COVERAGE is a measurement; the verdict below is narrow on
+                            // purpose. It fails on one thing only: a requested day that is not
+                            // in the store at all, which can never play. Everything else about
+                            // the window is set and verified in stage `range`.
+                            //
+                            // The comment used to say "a MEASUREMENT, not a verdict" while the
+                            // line below emitted a pass/fail step that the driver turns into a
+                            // hard stop (25.08.2026). Code and prose now say the same thing.
+                            if (last == "Connected")
+                            {
+                                // ⚠ RE-ASSERT THE SOURCE AFTER THE CONNECT.
+                                //
+                                // Connect overwrites the playback statics from the SAVED
+                                // configuration - the GUI-less host in the sibling project
+                                // states this in as many words and re-applies its statics
+                                // after every connect for exactly that reason. The proof is
+                                // one line below in this very stage: FromEst/ToEst read back
+                                // as the replay store's whole span (12.03.2013..18.08.2026),
+                                // not as the values written seconds earlier.
+                                //
+                                // Written BEFORE the connect it decides how NinjaTrader
+                                // connects; written again AFTER it, it decides what the rest
+                                // of the run - and the value NinjaTrader later persists -
+                                // actually is. Both writes are needed, and neither replaces
+                                // the other.
+                                try
+                                {
+                                    object srcBefore = null, srcAfter = null;
+                                    PropertyInfo piS = pb.GetProperty("IsSourceHistoricalData", BFStatic);
+                                    if (piS != null)
+                                    {
+                                        srcBefore = piS.GetValue(null);
+                                        piS.SetValue(null, hist, null);
+                                        srcAfter = piS.GetValue(null);
+                                    }
+                                    step("source after connect",
+                                         piS != null && srcAfter != null
+                                             && srcAfter.Equals(hist),
+                                         piS == null
+                                             ? "IsSourceHistoricalData not reachable"
+                                             : ("was " + srcBefore + " after Connect, re-applied "
+                                                + hist + ", reads " + srcAfter));
+                                }
+                                catch (Exception ex)
+                                {
+                                    step("source after connect", false, ex.GetType().Name + ": " + ex.Message);
+                                }
+
+                                string covDetail = "";
+                                foreach (string nm in new string[] { "FromEst", "ToEst" })
+                                {
+                                    object got = null;
+                                    try
+                                    {
+                                        PropertyInfo pr = pb.GetProperty(nm, BFStatic);
+                                        if (pr != null) got = pr.GetValue(null);
+                                    }
+                                    catch (Exception ex) { got = ex.GetType().Name; }
+                                    covDetail += nm + "=" + got + "   ";
+                                }
+                                bool inside = true;
+                                if (reqFrom.HasValue || reqTo.HasValue)
+                                {
+                                    try
+                                    {
+                                        // ⚠ THE STORE, NOT THE PANEL. FromEst/ToEst are the range the
+                                        // Playback panel is SET TO, and Connect restores that from the
+                                        // saved configuration - so right here they say what the last
+                                        // session used, not what data exists.
+                                        //
+                                        // Measured 26.08.2026: the step failed with
+                                        //     FromEst=11.08.2026 ToEst=18.08.2026
+                                        //     requested 07.07.2026..14.07.2026 inside it: False
+                                        // while `playback` scanning the SAME instrument's files
+                                        // reported 2,523 of 2,523 readable, 17.12.2018..17.08.2026.
+                                        // The day was in the store all along; the panel simply had
+                                        // not been set yet, which stage 4 does a few steps later.
+                                        //
+                                        // A guard that reads a value the run is about to change
+                                        // cannot answer the question it was written for - its own
+                                        // comment says "not in the store at all".
+                                        DateTime lo, hi;
+                                        int nread;
+                                        string covInstr = ExtractJsonString(triggerJson, "instrument");
+                                        // ASK ABOUT THE STORE THIS RUN READS. Playback/Historical
+                                        // is served from db\tick (NCD); only Market Replay reads
+                                        // db\replay (NRD). Measured 30.08.2026: a Historical run
+                                        // on MNQ 09-26 was refused here with "store scan
+                                        // unavailable, panel range used / requested
+                                        // 28.08.2026..28.08.2026 inside it: False", while that day
+                                        // held 24 Ask / 24 Bid / 23 Last NCD files. It has no .nrd
+                                        // at all - the recordings live under the continuous name
+                                        // (MNQ ##-##) - so scanning db\replay could only ever
+                                        // return nothing, and the fallback then judged the request
+                                        // against the PREVIOUS run's panel range (27.08.).
+                                        string covSrc = ExtractJsonString(triggerJson, "source");
+                                        bool covFromNcd = string.Equals(
+                                            (covSrc ?? "").Trim(), "historical",
+                                            StringComparison.OrdinalIgnoreCase);
+                                        bool covOk = covFromNcd
+                                            ? TickCoverage(covInstr, out lo, out hi, out nread)
+                                            : ReplayCoverage(covInstr, out lo, out hi, out nread);
+                                        if (covOk)
+                                            covDetail += "store " + nread
+                                                       + (covFromNcd ? " NCD files " : " files readable ")
+                                                       + lo.ToString("dd.MM.yyyy") + ".."
+                                                       + hi.ToString("dd.MM.yyyy") + "   ";
+                                        else
+                                        {
+                                            lo = (DateTime)pb.GetProperty("FromEst", BFStatic).GetValue(null);
+                                            hi = (DateTime)pb.GetProperty("ToEst", BFStatic).GetValue(null);
+                                            covDetail += "store scan unavailable, panel range used   ";
+                                        }
+                                        // ⚠ COMPARE WHOLE DAYS, and compare the REQUESTED window.
+                                        // Coverage is reported as 00:00:00 on the first day and
+                                        // 23:59:59 on the last, so a same-day request is inside
+                                        // only when the comparison is done on .Date - otherwise
+                                        // the end 23:59:59 vs a midnight request decides it.
+                                        if (reqFrom.HasValue && reqFrom.Value.Date < lo.Date) inside = false;
+                                        if (reqTo.HasValue && reqTo.Value.Date > hi.Date) inside = false;
+                                        covDetail += "requested " + (reqFrom.HasValue ? reqFrom.Value.ToString("dd.MM.yyyy") : "-")
+                                                   + ".." + (reqTo.HasValue ? reqTo.Value.ToString("dd.MM.yyyy") : "-")
+                                                   + " inside it: " + inside;
+                                    }
+                                    catch (Exception ex) { covDetail += "range check: " + ex.GetType().Name; }
+                                }
+                                // FAILS only when the day we were asked for is not in the
+                                // store at all - that cannot play, and finding out here beats
+                                // finding out from an empty result.
+                                step("coverage after connect", inside, covDetail);
+                            }
+                        }
+                    }
+
+                    // ⚠ TRIGGERING AND WAITING BELONG TOGETHER (established 2026-08-20).
+                    //
+                    // "Connected" is not "usable". NinjaTrader rebuilds the Playback panel after
+                    // the connect, and anything written while that runs goes into a control it is
+                    // about to discard. Measured 2026-08-19: about 11 s - but that is not a
+                    // constant to rely on, the user says it can take minutes. So the step WAITS
+                    // and REPORTS the duration it measured instead of assuming one. The bound
+                    // below is a backstop against waiting forever, not a verdict: reaching it is
+                    // reported as "still not usable", never quietly as success.
+                    // ⚠ WAIT ON THE EVENT, NEVER ON A CLOCK (established 2026-08-20, shouted).
+                    //
+                    // Everything that used to stand here was a number I invented: 40 s for the
+                    // panel, 1500 ms "stable", a 10-minute bound. The user is right that these
+                    // are guesses about NinjaTrader's workload - loading a cold cache can take
+                    // minutes - and a guess is either a false alarm or a stall.
+                    //
+                    // So the end of this action is marked by NinjaTrader, not by me:
+                    //     Window.LoadedEvent (class handler)  the Playback window exists
+                    //     slider.IsEnabledChanged             its controls became usable
+                    // ArmPanelWatch() was called BEFORE connecting, so no event can slip through
+                    // in between. The wait below has exactly one bound: the caller's own ttlSec,
+                    // which is the caller's decision and not a constant in this file.
+                    // ⚠ TRIGGER AND WAIT ARE ONE STEP - BUT A WALKTHROUGH MUST BE ABLE TO SPLIT
+                    // THEM.
+                    //
+                    // In a run this stage triggers AND waits, because a step that returns before
+                    // its effect exists is useless. When a human steps through it phase by phase
+                    // (state before / trigger / change / end), the trigger has to come back at
+                    // once so the change can be watched separately - `awaitPanel:"false"` does
+                    // that. Then stage `panelflips` carries phases 3 and 4.
+                    bool doWait = !string.Equals(ExtractJsonString(triggerJson, "awaitPanel"),
+                                                 "false", StringComparison.OrdinalIgnoreCase);
+                    if (!doWait)
+                    {
+                        step("panel usable", true,
+                             "NOT waited on request (awaitPanel=false) - watch it with stage 'panelflips'");
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+                    // ⚠ The window does not exist yet when the watch is armed - measured
+                    // 2026-08-20, the trace read [noPlaybackWindow;] and the class handler
+                    // never fired, so the wait sat out the full ttl twice while reading
+                    // the same controls directly said enabled after 12236 ms.
+                    //
+                    // So discovery no longer depends on the event: it keeps LOOKING, on the
+                    // path that demonstrably finds the window (stage `panelstate` uses the
+                    // same one). The 250 ms is a SAMPLING RATE, not a deadline - how often
+                    // it looks, never how long NinjaTrader may take. The only bound stays
+                    // the caller's own ttlSec. Once hooked, the enable TRANSITION is still
+                    // observed through the event, which is what an event is good for.
+                    // ⚠ THE PANEL IS A GUI CONCEPT. Waiting for it in a host that has
+                    // no windows would sit out the caller's whole ttl and then report
+                    // failure for something that cannot happen here.
+                    //
+                    // The hazard this wait guards against is stated above: NinjaTrader
+                    // rebuilds the Playback PANEL after connecting and writes land in a
+                    // control it is about to discard. With no window nothing is rebuilt
+                    // and nothing is discarded.
+                    //
+                    // The readiness that matters was already established WITHOUT the UI,
+                    // by the step above: PlaybackConnection.Status polled until
+                    // Connected. And stage `range` reads every value it writes back, so
+                    // a write that was too early still cannot pass silently.
+                    if (NoUiHost())
+                    {
+                        step("panel usable", true,
+                             "no UI in this host - no panel is rebuilt, so no write can"
+                             + " land in a discarded control   [" + _panelTrace + "]");
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+
+                    System.Diagnostics.Stopwatch swC = System.Diagnostics.Stopwatch.StartNew();
+                    // The REMAINDER of the caller's budget. Taking a fresh ttlSec here
+                    // made the stage cost twice what the caller allowed, and the answer
+                    // then arrived after the caller had given up - measured as
+                    // "(no answer) - stage returned nothing" on a stage that did answer.
+                    double ttlC = RequestTtlSec(triggerJson) - stageClock.Elapsed.TotalSeconds;
+                    bool usable = false;
+                    if (ttlC <= 0.5)
+                        step("panel usable", false,
+                             "not waited - the request budget was already spent by the"
+                             + " steps above   [" + _panelTrace + "]");
+                    while (ttlC > 0.5 && swC.Elapsed.TotalSeconds < ttlC)
+                    {
+                        if (_panelTrace.IndexOf("hooked;") < 0) HookPlaybackSlider();
+                        if (_panelUsable.Wait(TimeSpan.FromMilliseconds(250))) { usable = true; break; }
+                    }
+                    if (ttlC > 0.5)
+                        step("panel usable", usable,
+                             (usable ? "usable after " : "STILL not usable after ")
+                             + swC.ElapsedMilliseconds + " ms of the "
+                             + ((int)ttlC) + " s left   [" + _panelTrace + "]"
+                             + (usable ? "" : "  - waited as long as this request allowed"));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Range(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            string fromS = ctx.FromS;
+            string toS = ctx.ToS;
+            Type pb = ctx.Pb;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // AFTER connect — before it the adapter discards these.
+                    if (!string.IsNullOrWhiteSpace(fromS))
+                        SetStatic(pb, "FromEst", DateTime.Parse(fromS, InvCi), step);
+                    if (!string.IsNullOrWhiteSpace(toS))
+                        SetStatic(pb, "ToEst", DateTime.Parse(toS, InvCi).Date.AddDays(1).AddSeconds(-1), step);
+
+                    // Speed on the FIELD as well: connecting moves the property value
+                    // to `oldPlaybackSpeed` and leaves the live field at 1.
+                    //
+                    // `skipReset` exists to separate the two things this stage does.
+                    // Writing PlaybackSpeed BEFORE connecting was bisected on 2026-08-19
+                    // as the cause of the transport starting by itself; the same write
+                    // happens here, after connecting, and the transport starts here too.
+                    // Which of the two - the speed or the Reset - is the trigger is
+                    // decided by a run with one of them switched off.
+                    // ⚠ SPEED IS A START COMMAND.
+                    //
+                    // Bisected 2026-08-19, one variable per run, confirmed by the
+                    // adapter clock, by the panel's progress slider and by an operator:
+                    //
+                    //   connect without PlaybackSpeed .......... stands
+                    //   connect with    PlaybackSpeed .......... RUNS
+                    //   range   without PlaybackSpeed .......... stands (also after 10 s)
+                    //   range   with    PlaybackSpeed .......... RUNS
+                    //
+                    // Writing PlaybackAdapter.PlaybackSpeed starts the transport,
+                    // whenever it happens. So the speed is not part of setting things
+                    // up: stage "uiset" writes it together with pressing play, the one
+                    // moment a run is meant to begin. `speed:"true"` restores the old
+                    // behaviour for anyone who needs it.
+                    bool rangeSkipSpeed = !string.Equals(ExtractJsonString(triggerJson, "speed"),
+                                                         "true", StringComparison.OrdinalIgnoreCase);
+                    bool rangeSkipReset = string.Equals(ExtractJsonString(triggerJson, "skipReset"),
+                                                        "true", StringComparison.OrdinalIgnoreCase);
+                    FieldInfo fiMax = pb.GetField("MaxSpeedValue", BFStatic);
+                    object max = fiMax != null ? fiMax.GetValue(null) : (object)int.MaxValue;
+                    if (rangeSkipSpeed) step("PlaybackSpeed", true, "SKIPPED on request");
+                    else SetStatic(pb, "PlaybackSpeed", max, step);
+                    if (rangeSkipSpeed) step("field playbackSpeed", true, "SKIPPED on request");
+                    else
+                    try
+                    {
+                        FieldInfo fiSpeed = pb.GetField("playbackSpeed", BFStatic);
+                        if (fiSpeed == null) step("field playbackSpeed", false, "not found");
+                        else
+                        {
+                            fiSpeed.SetValue(null, max);
+                            step("field playbackSpeed", fiSpeed.GetValue(null).ToString() == max.ToString(),
+                                 "wrote=" + max + " read=" + fiSpeed.GetValue(null));
+                        }
+                    }
+                    catch (Exception ex) { step("field playbackSpeed", false, ex.GetType().Name + ": " + ex.Message); }
+
+                    // Park the clock at the range start. After a completed range it
+                    // sits at the END, and a strategy activated there has nothing
+                    // ahead of it.
+                    if (rangeSkipReset) step("Reset", true, "SKIPPED on request");
+                    else if (!string.IsNullOrWhiteSpace(fromS))
+                    {
+                        try
+                        {
+                            MethodInfo reset = null;
+                            foreach (MethodInfo mi in pb.GetMethods(BFStatic))
+                                if (mi.Name == "Reset" && mi.GetParameters().Length == 2) { reset = mi; break; }
+                            if (reset == null) step("Reset", false, "method not found");
+                            else
+                            {
+                                DateTime wantClock = DateTime.Parse(fromS, InvCi);
+                                // Phase 3: WAIT FOR THE CLOCK TO ARRIVE, do not sleep 3 s and
+                                // hope. Reset is asynchronous and walks the clock toward the
+                                // target; three seconds is a guess about how far it gets.
+                                reset.Invoke(null, new object[] { wantClock, null });
+                                PropertyInfo piNowW = pb.GetProperty("NowEst", BFStatic);
+                                string beforeClock = piNowW == null ? "?" : "" + piNowW.GetValue(null);
+                                string gotClock; long msClock;
+                                WaitUntilChanged(delegate {
+                                        return piNowW == null ? "?" : "" + piNowW.GetValue(null); },
+                                    beforeClock, wantClock.ToString("dd.MM.yyyy HH:mm:ss"),
+                                    RequestTtlSec(triggerJson), out gotClock, out msClock);
+                                // The verdict is the CLOCK, not the call. "invoked" says only
+                                // that nothing threw.
+                                step("Reset", gotClock == wantClock.ToString("dd.MM.yyyy HH:mm:ss"),
+                                     "clock " + beforeClock + " -> " + gotClock + " after " + msClock
+                                     + " ms (wanted " + wantClock.ToString("dd.MM.yyyy HH:mm:ss") + ")");
+                            }
+                        }
+                        catch (Exception ex) { step("Reset", false, ex.GetType().Name + ": " + ex.Message); }
+                    }
+                    PropertyInfo piNow = pb.GetProperty("NowEst", BFStatic);
+                    if (piNow != null) step("NowEst", true, "" + piNow.GetValue(null));
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Stratdump(PbRunCtx ctx)
+        {
+            string triggerJson = ctx.TriggerJson;
+            string typeName = ctx.TypeName;
+            string instName = ctx.InstName;
+            string fromS = ctx.FromS;
+            string toS = ctx.ToS;
+            string bpS = ctx.BpS;
+            string trS = ctx.TrS;
+            Dictionary<string, string> prms = ctx.Prms;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // Read-only twin of `attach`: builds the SAME object and stops before
+                    // AddStrategyToGrid, so the object it would have added can be inspected
+                    // without the run starting.
+                    Instrument instD = Instrument.GetInstrument(instName);
+                    if (instD == null) { step("instrument", false, instName + " not found"); sb.Append("]}"); return sb.ToString(); }
+                    step("instrument", true, instD.FullName);
+
+                    string whyD;
+                    Type stD = ResolveStrategyType(typeName, out whyD);
+                    if (stD == null) { step("strategy type", false, whyD); sb.Append("]}"); return sb.ToString(); }
+                    step("strategy type", true, stD.FullName + (whyD == null ? "" : "   " + whyD));
+
+                    string tmplD = ExtractJsonString(triggerJson, "template");
+                    StrategyBase sd;
+                    if (string.IsNullOrWhiteSpace(tmplD))
+                    {
+                        sd = (StrategyBase)Activator.CreateInstance(stD);
+                        sd.SetState(State.SetDefaults);
+                        step("template", true, "none - defaults");
+                    }
+                    else
+                    {
+                        StrategyBase probeD = (StrategyBase)Activator.CreateInstance(stD);
+                        probeD.SetState(State.SetDefaults);
+                        string fileD = TemplatePath(probeD, tmplD);
+                        if (fileD == null) { step("template", false, "no folder for " + stD.Name); sb.Append("]}"); return sb.ToString(); }
+                        string pD;
+                        sd = RestoreTemplate(fileD, out pD);
+                        if (sd == null) { step("template", false, fileD + ": " + pD); sb.Append("]}"); return sb.ToString(); }
+                        step("template", true, Path.GetFileName(fileD) + " -> State " + sd.State);
+                    }
+
+                    // the same property writes as `attach`, without the account and
+                    // without its trading-hours override
+                    sd.Instrument = instD;
+                    sd.InstrumentOrInstrumentList = instD.FullName;
+                    if (!string.IsNullOrWhiteSpace(bpS))
+                        sd.BarsPeriod = (BarsPeriod)ConvertConfigToken(bpS, typeof(BarsPeriod));
+                    if (!string.IsNullOrWhiteSpace(fromS)) sd.From = DateTime.Parse(fromS, InvCi);
+                    if (!string.IsNullOrWhiteSpace(toS))   sd.To = DateTime.Parse(toS, InvCi).Date.AddDays(1).AddSeconds(-1);
+                    if (!string.IsNullOrWhiteSpace(trS))
+                        sd.IsTickReplay = string.Equals(trS, "true", StringComparison.OrdinalIgnoreCase);
+                    TradingHours thD = instD.MasterInstrument.TradingHours;
+                    if (thD != null) { sd.TradingHoursInstance = thD; sd.TradingHoursSerializable = thD.Name; sd.TradingHours = thD; }
+                    InjectParams(sd, prms);
+
+                    step("state", true, "" + sd.State + "   (NOT added to the grid, NOT enabled)");
+
+                    // ⚠ ASK NINJATRADER, do not guess. `IsStrategyConfigurationValid` is its
+                    // OWN verdict on a set of strategies and it RETURNS A REASON - so the
+                    // question "is this object fit to be armed" has an answer that costs
+                    // nothing and arms nothing. It was never asked before; three times today
+                    // the answer was found out the expensive way instead.
+                    MethodInfo miValid = StrategiesGridStatic("IsStrategyConfigurationValid", 1);
+                    if (miValid == null) step("IsStrategyConfigurationValid", false, "not found");
+                    else
+                    {
+                        try
+                        {
+                            List<StrategyBase> one = new List<StrategyBase>();
+                            one.Add(sd);
+                            object verdict = miValid.Invoke(null, new object[] { one });
+                            string vs = verdict == null ? null : verdict.ToString();
+                            step("IsStrategyConfigurationValid", string.IsNullOrEmpty(vs),
+                                 string.IsNullOrEmpty(vs) ? "valid (returned nothing)" : vs);
+                        }
+                        catch (Exception ex) { step("IsStrategyConfigurationValid", false, Deep(ex)); }
+                    }
+
+                    // Everything readable, so the diff against NinjaTrader's own object is
+                    // complete rather than a selection of what seemed relevant.
+                    int shown = 0;
+                    foreach (PropertyInfo pd in sd.GetType().GetProperties(
+                                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                    {
+                        if (pd.GetIndexParameters().Length > 0 || !pd.CanRead) continue;
+                        object v;
+                        try { v = pd.GetValue(sd, null); }
+                        catch (Exception ex) { step("p " + pd.Name, true, "<" + ex.GetType().Name + ">"); continue; }
+                        string s = v == null ? "null" : v.ToString();
+                        if (s.Length > 90) s = s.Substring(0, 90) + "...";
+                        step("p " + pd.Name, true, s);
+                        shown++;
+                    }
+                    foreach (FieldInfo fd in sd.GetType().GetFields(
+                                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                    {
+                        object v;
+                        try { v = fd.GetValue(sd); }
+                        catch (Exception ex) { step("f " + fd.Name, true, "<" + ex.GetType().Name + ">"); continue; }
+                        string s = v == null ? "null" : v.ToString();
+                        if (s.Length > 90) s = s.Substring(0, 90) + "...";
+                        step("f " + fd.Name, true, s);
+                        shown++;
+                    }
+                    step("members", true, "" + shown);
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Arm(PbRunCtx ctx)
+        {
+            string id = ctx.Id;
+            string triggerJson = ctx.TriggerJson;
+            string typeName = ctx.TypeName;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    // The SECOND HALF of `attach`, split off 2026-08-20. Measured that
+                    // evening: the enable fired in the same breath as the load stuck
+                    // inside StrategyEnable twice (runs 9/10, operation Executing, no
+                    // 'Enabling' log line, Control Center frozen) - while the user
+                    // enabling the SAME loaded row by hand worked (log 20:56:36).
+                    // This stage arms an ALREADY LOADED row in its own request, so the
+                    // gap between load and enable becomes the variable under test.
+                    Window ccA = FindWindowByTitle("Control Center");
+                    if (ccA == null)
+                    { step("Control Center", false, "not found: " + WindowTitles()); sb.Append("]}"); return sb.ToString(); }
+
+                    // Find the row by the TYPE NAME of the strategy it carries - the
+                    // loading request's object is gone, so identity cannot anchor it.
+                    object[] armBox = new object[3];   // [0]=StrategiesGridEntry [1]=StrategyBase [2]=DispatcherOperation
+                    // NinjaTrader virtualizes a Control Center tab's content while the tab is
+                    // inactive, so on a profile whose Strategies tab has never been shown the
+                    // named element `grdStrategies` is simply absent (measured 2026-08-24 on a
+                    // UI.xml NinjaTrader had just written itself). WithStrategiesGrid activates
+                    // tabs until the grid materializes, hands it over, and restores the user's
+                    // tab afterwards - so the lookup has to happen INSIDE its callback, not
+                    // before it. It marshals onto the Control Center's dispatcher itself, which
+                    // is why the Dispatcher.Invoke that used to wrap this block is gone.
+                    List<string> rowNotes = new List<string>();
+                    Progress(id, "-> locating the loaded strategy row (materializing the tab if need be)");
+                    string rowFind = WithStrategiesGrid<string>(delegate(object realizedA)
+                    {
+                        // Prefer the inner NTGrid by name; fall back to what the helper realized.
+                        object gridA = FindElement(ccA, "grdStrategies") ?? realizedA;
+                        if (gridA == null) return "grdStrategies not in the visual tree";
+                        // The rows live under a different member on the NTGrid than on the
+                        // StrategiesGrid control, so ask for all of them - same set SnapshotGrid uses.
+                        System.Collections.IEnumerable rowsA = FirstMember(gridA,
+                            new[] { "DataSource", "source", "Entries", "ItemsSource" }) as System.Collections.IEnumerable;
+                        if (rowsA == null) return "no row source on " + gridA.GetType().Name;
+                        int nA = 0;
+                        foreach (object row in rowsA)
+                        {
+                            if (row == null) continue;
+                            nA++;
+                            StrategyBase sA = RowStrategy(row);
+                            if (sA != null && sA.GetType().Name == typeName)
+                            { armBox[0] = row; armBox[1] = sA; }
+                        }
+                        return armBox[0] != null
+                            ? "ok:row of " + typeName + " among " + nA + " row(s)"
+                            : "no row carries a " + typeName + " (rows: " + nA + ")";
+                    }, rowNotes);
+                    // WithStrategiesGrid returns default(T) - null here - when it cannot reach
+                    // the grid at all; its reason is in the notes.
+                    if (rowFind == null)
+                        rowFind = "grid not reachable" + (rowNotes.Count > 0 ? ": " + string.Join("; ", rowNotes.ToArray()) : "");
+                    step("row found", rowFind.StartsWith("ok:"), rowFind);
+                    if (!rowFind.StartsWith("ok:")) { sb.Append("]}"); return sb.ToString(); }
+                    StrategyBase stratA = (StrategyBase)armBox[1];
+                    step("state before enable", true, "" + stratA.State);
+
+                    int markA = NtLogCount();
+                    Progress(id, "-> posting StrategyEnable via Dispatcher.Invoke (UI thread)");
+                    string armPost = (string)ccA.Dispatcher.Invoke(new Func<string>(delegate
+                    {
+                        MethodInfo enA = StrategiesGridStatic("StrategyEnable", 3);
+                        if (enA == null) return "StrategyEnable(StrategyBase, Window, StrategiesGridEntry) not found";
+                        System.Windows.Threading.DispatcherOperation opA =
+                            ccA.Dispatcher.BeginInvoke(new Action(delegate
+                            {
+                                try { enA.Invoke(null, new object[] { stratA, ccA, armBox[0] }); }
+                                catch (Exception exA) { LogSafe("arm: StrategyEnable threw " + Deep(exA)); }
+                            }));
+                        armBox[2] = opA;
+                        return "ok:posted, op=" + opA.Status;
+                    }));
+                    step("StrategyEnable posted", armPost.StartsWith("ok:"), armPost);
+                    if (!armPost.StartsWith("ok:")) { sb.Append("]}"); return sb.ToString(); }
+
+                    Progress(id, "-> waiting for NinjaTrader's own 'Enabling' log line, budget "
+                                 + RequestTtlSec(triggerJson).ToString("0") + "s (worker thread, "
+                                 + "log-file channel - touches no dispatcher)");
+                    string hitA; int idxA;
+                    bool startedA = WaitForLogName(markA, "NinjaScriptStrategyBaseEnabling",
+                                                   null, RequestTtlSec(triggerJson),
+                                                   out hitA, out idxA);
+                    System.Windows.Threading.DispatcherOperation opLateA =
+                        armBox[2] as System.Windows.Threading.DispatcherOperation;
+                    step("enable operation status", true,
+                         opLateA == null ? "operation not captured"
+                                         : opLateA.Status + " (read after the log wait)");
+                    step("NinjaTrader started arming", startedA,
+                         startedA ? hitA.Substring(0, Math.Min(96, hitA.Length))
+                                  : "NinjaTrader never reported NinjaScriptStrategyBaseEnabling "
+                                    + "within this request's budget - it did not begin");
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+
+        private string Stage_Attach(PbRunCtx ctx)
+        {
+            string id = ctx.Id;
+            string triggerJson = ctx.TriggerJson;
+            string typeName = ctx.TypeName;
+            string instName = ctx.InstName;
+            string fromS = ctx.FromS;
+            string toS = ctx.ToS;
+            string bpS = ctx.BpS;
+            string trS = ctx.TrS;
+            Dictionary<string, string> prms = ctx.Prms;
+            StringBuilder sb = ctx.Sb;
+            Action<string, bool, string> step = ctx.Step;
+
+                    Instrument inst = Instrument.GetInstrument(instName);
+                    if (inst == null) { step("instrument", false, instName + " not found"); sb.Append("]}"); return sb.ToString(); }
+                    step("instrument", true, inst.FullName);
+
+                    // One resolver for every stage: it prefers the FRESHEST loaded copy of the
+                    // class (each `reload` leaves the previous NinjaTrader.Custom behind) and
+                    // reports ambiguity instead of picking silently.
+                    string whyT;
+                    Type st = ResolveStrategyType(typeName, out whyT);
+                    if (st == null) { step("strategy type", false, whyT); sb.Append("]}"); return sb.ToString(); }
+                    step("strategy type", true, st.FullName + (whyT == null ? "" : "   " + whyT));
+
+                    // With a template, the strategy IS the restored object - NinjaTrader
+                    // built it from the XML exactly as the dialog's `load` button would.
+                    // The request's own fields are applied afterwards and therefore win, so
+                    // one template can serve a whole matrix of ranges and bar types.
+                    string tmplName = ExtractJsonString(triggerJson, "template");
+                    // ⚠ CREATE THE STRATEGY ON THE CONTROL CENTER'S DISPATCHER - NEVER
+                    // ON THIS POLLER THREAD.
+                    //
+                    // Proven 2026-08-20 by a full-memory dump of the frozen
+                    // process, read with dotnet-dump:
+                    //   EmptyStrategy.<Dispatcher>k__BackingField == 0x1734c7b3278,
+                    //   whose _dispatcherThread is managed id 83 = OS thread 0x9ec0,
+                    //   an MTA THREADPOOL worker - the timer thread this poller ran
+                    //   CreateInstance on. NinjaTrader's StrategyEnable internally does
+                    //   strategy.Dispatcher.Invoke(StrategiesGrid+<>c__DisplayClass110_0)
+                    //   - a thread-pool thread never pumps messages, the operation never
+                    //   runs, the grid thread (0x4f44) waits forever and the Control
+                    //   Center freezes. Same freeze whether OUR call or the user's own
+                    //   checkbox fired the enable: the poisoned binding sits in the
+                    //   OBJECT, not in the caller.
+                    // Creating the instance on the Control Center window's dispatcher
+                    // binds strategy.Dispatcher to the SAME thread StrategyEnable later
+                    // runs on, so its inner Invoke executes directly - exactly what the
+                    // GUI dialog path produces.
+                    Window ccMake = FindWindowByTitle("Control Center");
+                    if (ccMake == null)
+                    { step("Control Center", false, "not found: " + WindowTitles()); sb.Append("]}"); return sb.ToString(); }
+                    StrategyBase strat;
+                    if (string.IsNullOrWhiteSpace(tmplName))
+                    {
+                        strat = (StrategyBase)ccMake.Dispatcher.Invoke(new Func<object>(delegate
+                        {
+                            StrategyBase s0 = (StrategyBase)Activator.CreateInstance(st);
+                            s0.SetState(State.SetDefaults);
+                            return s0;
+                        }));
+                        step("template", true, "none given - defaults   (created on the grid dispatcher, "
+                             + "thread of " + ccMake.GetType().Name + ")");
+                    }
+                    else
+                    {
+                        // [0] = restored strategy or null, [1] = failure text
+                        object[] mk = new object[2];
+                        ccMake.Dispatcher.Invoke(new Action(delegate
+                        {
+                            StrategyBase probe2 = (StrategyBase)Activator.CreateInstance(st);
+                            probe2.SetState(State.SetDefaults);
+                            string tfile2i = TemplatePath(probe2, tmplName);
+                            if (tfile2i == null) { mk[1] = "no template folder for " + st.Name; return; }
+                            string why2i;
+                            StrategyBase r2 = RestoreTemplate(tfile2i, out why2i);
+                            mk[0] = r2;
+                            mk[1] = r2 == null ? (tfile2i + ": " + why2i) : tfile2i;
+                        }));
+                        strat = mk[0] as StrategyBase;
+                        string tfile2 = strat == null ? null : (string)mk[1];
+                        if (strat == null)
+                        { step("template", false, (string)mk[1]); sb.Append("]}"); return sb.ToString(); }
+                        // Compare by NAME, not by Type identity: after a reload the same class
+                        // is loaded twice (old + new NinjaTrader.Custom), and IsInstanceOfType
+                        // then reports a mismatch between two types with the SAME FullName -
+                        // measured 2026-08-19, it aborted this very run. The restored object is
+                        // the authoritative one; NinjaTrader built it itself.
+                        if (strat.GetType().FullName != st.FullName)
+                        {
+                            step("template", false, "template holds " + strat.GetType().FullName
+                                 + " but " + st.FullName + " was requested");
+                            sb.Append("]}");
+                            return sb.ToString();
+                        }
+                        if (!ReferenceEquals(strat.GetType(), st))
+                            step("assembly", true, "template instance comes from "
+                                 + strat.GetType().Assembly.FullName
+                                 + " - resolved type sits in " + st.Assembly.FullName);
+                        step("template", true, Path.GetFileName(tfile2) + " -> State " + strat.State);
+                    }
+                    strat.Instrument = inst;
+                    strat.InstrumentOrInstrumentList = inst.FullName;
+                    if (!string.IsNullOrWhiteSpace(bpS))
+                        strat.BarsPeriod = (BarsPeriod)ConvertConfigToken(bpS, typeof(BarsPeriod));
+                    if (!string.IsNullOrWhiteSpace(fromS)) strat.From = DateTime.Parse(fromS, InvCi);
+                    if (!string.IsNullOrWhiteSpace(toS))   strat.To = DateTime.Parse(toS, InvCi).Date.AddDays(1).AddSeconds(-1);
+                    if (!string.IsNullOrWhiteSpace(trS))
+                        strat.IsTickReplay = string.Equals(trS, "true", StringComparison.OrdinalIgnoreCase);
+
+                    // ⚠ CHECK THE RANGE BEFORE ARMING - whether we set it or the template did.
+                    // Whichever wrote it, this object is about to be handed to NinjaTrader,
+                    // and an absurd range there is not a bad measurement, it is a dead process.
+                    string rangeBad = RangeProblem(strat.From, strat.To);
+                    step("range", rangeBad == null,
+                         strat.From.ToString("yyyy-MM-dd") + " .. " + strat.To.ToString("yyyy-MM-dd")
+                         + (rangeBad == null ? "" : "   REFUSED: " + rangeBad));
+                    if (rangeBad != null) { sb.Append("]}"); return sb.ToString(); }
+
+                    // Trading hours on all three members: NinjaScriptBase.Setup asserts
+                    // on TradingHoursList[0] == null if any of them is missing.
+                    // Optional override via the request's `tradingHours` field (e.g. a
+                    // 24/7 template for coverage experiments). The name must match an
+                    // installed template EXACTLY - on a miss the step fails and lists
+                    // every available name, so the caller never has to guess one.
+                    TradingHours th = inst.MasterInstrument.TradingHours;
+                    string thWanted = ExtractJsonString(triggerJson, "tradingHours");
+                    if (!string.IsNullOrWhiteSpace(thWanted))
+                    {
+                        TradingHours thHit = null;
+                        var thNames = new StringBuilder();
+                        foreach (TradingHours cand in TradingHours.All)
+                        {
+                            if (thNames.Length > 0) thNames.Append(" | ");
+                            thNames.Append(cand.Name);
+                            if (cand.Name == thWanted) thHit = cand;
+                        }
+                        if (thHit == null)
+                        {
+                            step("trading hours", false, "no template named '" + thWanted
+                                 + "'. Installed: " + thNames);
+                            sb.Append("]}"); return sb.ToString();
+                        }
+                        th = thHit;
+                    }
+                    if (th == null) { step("trading hours", false, "MasterInstrument has none"); sb.Append("]}"); return sb.ToString(); }
+                    strat.TradingHoursInstance = th;
+                    strat.TradingHoursSerializable = th.Name;
+                    strat.TradingHours = th;
+                    step("trading hours", true, th.Name);
+
+                    InjectParams(strat, prms);
+
+                    // Which playback account this strategy trades on. Empty falls
+                    // back to the one NinjaTrader names itself
+                    // (Account.PlaybackAccountName); a name that does not exist
+                    // stops the run rather than being swapped for another.
+                    string accName = ExtractJsonString(triggerJson, "account");
+                    if (string.IsNullOrWhiteSpace(accName)) accName = Account.PlaybackAccountName;
+                    Account acc = null;
+                    foreach (Account a in Account.All)
+                        if (string.Equals(a.Name, accName, StringComparison.OrdinalIgnoreCase)) { acc = a; break; }
+                    if (acc == null)
+                    {
+                        List<string> names = new List<string>();
+                        foreach (Account a in Account.All) names.Add(a.Name);
+                        step("account", false, accName + " missing; present: " + string.Join(", ", names.ToArray()));
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+                    strat.Account = acc;
+                    step("account chosen", true, acc.Name
+                         + (string.IsNullOrWhiteSpace(ExtractJsonString(triggerJson, "account"))
+                            ? "  (default)" : "  (requested)"));
+
+                    // ⚠ THE COMPARISON VALUE FOR THE HEADLESS REFUSAL (2026-08-22).
+                    //
+                    // In the headless host NinjaTrader accepts StrategyEnable and then
+                    // takes the strategy to Finalized instead of Realtime, writing no
+                    // reason to its log. The forensics dump there showed
+                    // `account.Connection = null`. This step prints the same field from
+                    // the GUI process, where the enable is known to succeed - so the
+                    // two can be compared instead of guessed about.
+                    try
+                    {
+                        step("account.Connection", acc.Connection != null,
+                             acc.Connection == null ? "null"
+                             : (acc.Connection.Options == null ? "?" : acc.Connection.Options.Name)
+                               + " / " + acc.Connection.Status);
+                    }
+                    catch (Exception exCon) { step("account.Connection", false, Deep(exCon)); }
+
+                    // ⚠ ASK NINJATRADER BEFORE ARMING. `IsStrategyConfigurationValid` is its
+                    // OWN verdict and it returns a REASON. It costs nothing, arms nothing, and
+                    // it is the check that was never made while the enable froze the process
+                    // three times on 2026-08-19.
+                    MethodInfo miOk = StrategiesGridStatic("IsStrategyConfigurationValid", 1);
+                    if (miOk == null) step("configuration valid", true, "check not available on this build");
+                    else
+                    {
+                        string verdictS;
+                        try
+                        {
+                            List<StrategyBase> oneS = new List<StrategyBase>();
+                            oneS.Add(strat);
+                            object vv = miOk.Invoke(null, new object[] { oneS });
+                            verdictS = vv == null ? null : vv.ToString();
+                        }
+                        catch (Exception ex) { verdictS = "check threw " + Deep(ex); }
+                        bool okS = string.IsNullOrEmpty(verdictS);
+                        step("configuration valid", okS, okS ? "NinjaTrader raised no objection" : verdictS);
+                        if (!okS) { sb.Append("]}"); return sb.ToString(); }
+                    }
+
+                    // `via` decides who drives. Default is the grid, because that is what the
+                    // Control Center itself does; the account variant is kept so the two can
+                    // be compared rather than believed.
+                    string via = ExtractJsonString(triggerJson, "via");
+                    if (string.IsNullOrWhiteSpace(via)) via = "grid";
+
+                    if (string.Equals(via, "grid", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // [0] = StrategiesGrid (owns AddStrategyToGrid), [1] = inner NTGrid
+                        // (owns DataSource, where the rows actually live - the same place the
+                        // teardown counts them).
+                        object[] gridCtl = new object[2];
+                        Window cc2 = FindWindowByTitle("Control Center");
+                        if (cc2 == null)
+                        { step("Control Center", false, "not found: " + WindowTitles()); sb.Append("]}"); return sb.ToString(); }
+
+                        // "->" lines mark what is ABOUT TO run on the dispatcher. If the UI
+                        // thread never comes back, the progress file ends on the marker that
+                        // names the exact call it died in - the step() line never happens.
+                        // Same virtualization as in `restore`: while the Strategies tab has never
+                        // been shown, `grdStrategies` is not in the tree and this step died with
+                        // "not in the visual tree" (measured 2026-08-24, GUI Historical run).
+                        // WithStrategiesGrid activates tabs until the grid exists and restores the
+                        // user's tab afterwards, so the work happens inside its callback. It
+                        // marshals onto the Control Center's dispatcher itself - hence no
+                        // Dispatcher.Invoke around this any more.
+                        List<string> addNotes = new List<string>();
+                        Progress(id, "-> AddStrategyToGrid (materializing the tab if need be, UI thread)");
+                        string outcome2 = WithStrategiesGrid<string>(delegate(object realized2)
+                        {
+                            // `grdStrategies` is the inner NTGrid; AddStrategyToGrid sits on the
+                            // StrategiesGrid CONTROL that contains it. Walk up until the type
+                            // that owns the method appears, instead of assuming the named
+                            // element is the right object (measured: it is an NTGrid).
+                            // The helper already hands over a StrategiesGrid, so it is also the
+                            // fallback when the inner element cannot be resolved by name.
+                            object grid2 = FindElement(cc2, "grdStrategies") ?? realized2;
+                            if (grid2 == null) return "grdStrategies not in the visual tree";
+                            gridCtl[1] = grid2;
+                            System.Windows.DependencyObject up = grid2 as System.Windows.DependencyObject;
+                            List<string> climbed = new List<string>();
+                            while (up != null)
+                            {
+                                if (up.GetType().Name == "StrategiesGrid") { grid2 = up; break; }
+                                climbed.Add(up.GetType().Name);
+                                System.Windows.DependencyObject nx = null;
+                                try { nx = System.Windows.Media.VisualTreeHelper.GetParent(up); } catch { }
+                                if (nx == null)
+                                {
+                                    System.Windows.FrameworkElement fe = up as System.Windows.FrameworkElement;
+                                    nx = fe == null ? null : fe.Parent as System.Windows.DependencyObject;
+                                }
+                                up = nx;
+                            }
+                            if (grid2.GetType().Name != "StrategiesGrid")
+                                return "no StrategiesGrid above grdStrategies; climbed: "
+                                       + string.Join(" > ", climbed.ToArray());
+                            MethodInfo add2 = null;
+                            foreach (MethodInfo mi2 in grid2.GetType().GetMethods(
+                                         BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                            {
+                                if (mi2.Name != "AddStrategyToGrid") continue;
+                                ParameterInfo[] ps2 = mi2.GetParameters();
+                                if (ps2.Length == 1 && ps2[0].ParameterType.IsAssignableFrom(typeof(StrategyBase)))
+                                { add2 = mi2; break; }
+                            }
+                            gridCtl[0] = grid2;   // the enable step looks its row up in this control
+
+                            // ⚠ AddStrategyToGrid, NOT StrategyAdd - and the reason is evidence,
+                            // not taste. Both runs that completed (2026-08-19, 21:49 and 22:37)
+                            // used AddStrategyToGrid and fired the enable while the strategy was
+                            // still at State.SetDefaults, and the enable worked. Switching to
+                            // StrategyAdd advanced it to Configure - which LOOKS better and was
+                            // never shown to work. The working path is the one with the track
+                            // record; the other one is a hypothesis.
+                            if (add2 == null) return "AddStrategyToGrid(StrategyBase) not found";
+                            try { add2.Invoke(grid2, new object[] { strat }); }
+                            catch (Exception ex2) { return "AddStrategyToGrid threw " + Deep(ex2); }
+                            return "ok:AddStrategyToGrid";
+                        }, addNotes);
+                        // null means the helper never reached a grid; its reason is in the notes.
+                        if (outcome2 == null)
+                            outcome2 = "grid not reachable" + (addNotes.Count > 0 ? ": " + string.Join("; ", addNotes.ToArray()) : "");
+                        step("AddStrategyToGrid", outcome2 != null && outcome2.StartsWith("ok:"),
+                             outcome2 + "   -> state " + strat.State);
+                        if (outcome2 == null || !outcome2.StartsWith("ok:")) { sb.Append("]}"); return sb.ToString(); }
+
+                        // Adding is not arming: measured, the strategy sat in SetDefaults after
+                        // the row appeared. `StrategyEnable` is the static behind the Enable menu
+                        // item - the call itself, not the click.
+                        // ⚠ THE ROW HAS TO EXIST BEFORE ANYTHING IS ARMED.
+                        // Without this the enable was fired at a strategy the Strategies window
+                        // did not show, and waited forever. A missing row is a FINDING, not a
+                        // reason to carry on.
+                        // Phase 3 for the add: wait until the collection actually GAINS the row.
+                        // The previous version ran 20 rounds of 250 ms - a five-second deadline
+                        // dressed up as a loop. How long NinjaTrader needs is its business; the
+                        // only bound is this request's own budget.
+                        string rowsGot; long rowsMs;
+                        Progress(id, "-> waiting for the grid row to appear (polls the UI thread)");
+                        WaitUntilChanged(delegate
+                        {
+                            return "" + (int)cc2.Dispatcher.Invoke(new Func<int>(delegate
+                            {
+                                object g5 = gridCtl[1];
+                                if (g5 == null) return 0;
+                                PropertyInfo ps5 = g5.GetType().GetProperty("DataSource");
+                                System.Collections.IEnumerable rs5 = ps5 == null ? null
+                                    : ps5.GetValue(g5, null) as System.Collections.IEnumerable;
+                                if (rs5 == null) return 0;
+                                int n5 = 0;
+                                foreach (object o5 in rs5) if (o5 != null) n5++;
+                                return n5;
+                            }));
+                        }, "0", null, RequestTtlSec(triggerJson), out rowsGot, out rowsMs);
+                        step("row appeared", rowsGot != "0",
+                             "rows 0 -> " + rowsGot + " after " + rowsMs + " ms");
+
+                        // ⚠ IS THE STRATEGY ACTUALLY LOADED? Three checks, none of which
+                        // reads our own side of the fence. Counting rows in the bound
+                        // collection was exactly that mistake: it reported "1 row(s)" while
+                        // the Strategies window showed none (2026-08-19).
+                        //
+                        // 1) the ACCOUNT holds it - the domain truth, not a view
+                        bool inAccount = false;
+                        foreach (StrategyBase sx in acc.Strategies)
+                            if (ReferenceEquals(sx, strat)) { inAccount = true; break; }
+                        // Reported, not gated: neither completed run was ever checked this way,
+                        // so making it a hard gate would risk blocking a path that works for a
+                        // reason I have not measured.
+                        step("strategy on the account", true,
+                             inAccount ? (acc.Name + " holds it, " + acc.Strategies.Count + " total")
+                                       : (acc.Name + " does NOT hold it"));
+
+                        // The STATE is reported, never gated on. A gate at DataLoaded would
+                        // have blocked both runs that completed on 2026-08-19: they fired the
+                        // enable from State.SetDefaults and it worked. Whatever loads the series
+                        // happens inside the enable, not before it - so a state below DataLoaded
+                        // here is information, not a fault.
+                        step("state before enable", true, "" + strat.State);
+
+                        // 3) and only now the row, as a secondary sign
+                        Progress(id, "-> reading the row count via Dispatcher.Invoke (UI thread)");
+                        int rowsNow = (int)cc2.Dispatcher.Invoke(new Func<int>(delegate
+                        {
+                            object g7 = gridCtl[1];
+                            return g7 == null ? -1 : RowCount(g7);
+                        }));
+                        step("row in the grid", true, rowsNow + " row(s)   (secondary - the account "
+                             + "and the state are the evidence)");
+
+                        // enable=false: load the strategy row and STOP - do not arm it.
+                        // Built 2026-08-20 after runs 9 and 10 both stuck inside NinjaTrader's
+                        // StrategyEnable (operation dequeued, 'Enabling' log line never written).
+                        // Loading up to the grid row worked in EVERY run today; this switch cuts
+                        // the chain exactly at the measured boundary so the loaded-but-disarmed
+                        // state can be inspected.
+                        string enableS = ExtractJsonString(triggerJson, "enable");
+                        if (string.Equals(enableS, "false", StringComparison.OrdinalIgnoreCase))
+                        {
+                            step("enable", true, "SKIPPED on request (enable=false) - the strategy "
+                                 + "row is loaded and stays disarmed, state " + strat.State);
+                            sb.Append("]}");
+                            return sb.ToString();
+                        }
+
+                        // Phase 1 for the enable: where NinjaTrader's log stands BEFORE it is
+                        // triggered, so phase 3 can tell a new entry from an old one.
+                        int markEnable = NtLogCount();
+                        string[] enableStatus = new string[] { "?" };
+                        // The DispatcherOperation is created inside the delegate below (on the
+                        // UI thread); this box carries it out so its status can be read AGAIN
+                        // after the log wait - see "enable operation status" further down.
+                        object[] opBox = new object[1];
+                        Progress(id, "-> posting StrategyEnable via Dispatcher.Invoke (UI thread)");
+                        string outcome3 = (string)cc2.Dispatcher.Invoke(new Func<string>(delegate
+                        {
+                            Type sgT = null;
+                            foreach (Assembly asm3 in AppDomain.CurrentDomain.GetAssemblies())
+                            {
+                                try { sgT = asm3.GetType("NinjaTrader.Gui.NinjaScript.StrategiesGrid", false); }
+                                catch { }
+                                if (sgT != null) break;
+                            }
+                            if (sgT == null) return "StrategiesGrid type not found";
+                            MethodInfo en = null;
+                            foreach (MethodInfo mi3 in sgT.GetMethods(BFStatic))
+                                if (mi3.Name == "StrategyEnable" && mi3.GetParameters().Length == 3) { en = mi3; break; }
+                            if (en == null) return "StrategyEnable(StrategyBase, Window, StrategiesGridEntry) not found";
+
+                            // The row object the GUI would hand in. Found by identity against
+                            // OUR strategy, so it can never be somebody else's row.
+                            object sge = null;
+                            string rowNote = "";
+                            PropertyInfo pSrc4 = gridCtl[1] == null ? null
+                                : gridCtl[1].GetType().GetProperty("DataSource");
+                            System.Collections.IEnumerable rows4 = pSrc4 == null ? null
+                                : pSrc4.GetValue(gridCtl[1], null) as System.Collections.IEnumerable;
+                            if (rows4 == null) return "grdStrategies has no DataSource";
+                            int nrows = 0;
+                            foreach (object row in rows4)
+                            {
+                                if (row == null) continue;
+                                nrows++;
+                                foreach (PropertyInfo pr4 in row.GetType().GetProperties(
+                                             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+                                {
+                                    if (pr4.GetIndexParameters().Length > 0) continue;
+                                    object v4 = null;
+                                    try { v4 = pr4.GetValue(row, null); } catch { continue; }
+                                    if (ReferenceEquals(v4, strat)) { sge = row; rowNote = row.GetType().Name + "." + pr4.Name; break; }
+                                }
+                                if (sge != null) break;
+                            }
+                            if (sge == null)
+                                return "none of the " + nrows + " row(s) in DataSource holds this strategy";
+                            // ⚠ FIRE, THEN READ WHAT BECAME OF IT - WITHOUT WAITING.
+                            //
+                            // ⚠ THIS CODE RUNS ON THE UI THREAD. Everything from the enclosing
+                            // cc2.Dispatcher.Invoke onwards executes on the dispatcher, so any
+                            // wait here is the UI thread waiting for itself. The earlier
+                            // version of this comment claimed the opposite and sent the search
+                            // for the freeze somewhere else for hours.
+                            //
+                            // BeginInvoke returns a DispatcherOperation. Its status is read as
+                            // it stands, never waited on, and it still separates three cases
+                            // that looked identical all evening:
+                            //
+                            //   Completed  the enable ran and finished
+                            //   Executing  it started and is stuck inside
+                            //   Pending    it NEVER STARTED - the UI thread never picked it up
+                            //
+                            // Until now all three produced the same picture: no log line, no
+                            // error, an empty Strategies list, and a NinjaTrader that had to be
+                            // killed. Whatever comes back here, it is a finding instead of a
+                            // freeze.
+                            System.Windows.Threading.DispatcherOperation opEn =
+                                cc2.Dispatcher.BeginInvoke(new Action(delegate
+                                {
+                                    try { en.Invoke(null, new object[] { strat, cc2, sge }); }
+                                    catch (Exception exq) { LogSafe("StrategyEnable threw " + Deep(exq)); }
+                                }));
+                            opBox[0] = opEn;   // carried out for the late status re-read
+                            // ⚠ DO NOT WAIT HERE. THIS CODE RUNS ON THE UI THREAD.
+                            //
+                            // Everything from the enclosing cc2.Dispatcher.Invoke onwards
+                            // executes ON the dispatcher. Waiting here for an operation that
+                            // only the dispatcher can run means the UI thread waits for
+                            // itself: DispatcherOperation.Wait then pumps a nested frame, and
+                            // whether that ever returns depends on what the enable does.
+                            //
+                            // Measured 2026-08-20: with a template it came back in 1.9 s
+                            // (op=Completed); with an EMPTY strategy and no template it did
+                            // not come back at all - NinjaTrader stopped answering the bridge
+                            // AND the user could no longer operate the Playback or Control
+                            // Center windows. The comment that used to sit above this line
+                            // asserted the wait stayed clear of the UI thread; the nesting
+                            // says otherwise, and the nesting is the code.
+                            //
+                            // The 25 s were wrong twice over: a guessed deadline, and an
+                            // unnecessary one. The PROOF that arming started comes right
+                            // after this, on the WORKER thread, from NinjaTrader's own log
+                            // entry (NinjaScriptStrategyBaseEnabling) - a handshake, bounded
+                            // only by the caller's ttlSec.
+                            //
+                            // The status is still read, because Pending / Executing /
+                            // Completed separates "never picked up" from "started" - but it
+                            // is read as it stands RIGHT NOW, without waiting for it.
+                            enableStatus[0] = opEn.Status.ToString() + " (read, not waited on)";
+                            return "ok:" + rowNote + "  op=" + enableStatus[0];
+                        }));
+                        // ── Phase 3: DID NINJATRADER REACT AT ALL? ──────────────────────────
+                        //
+                        // The enable is posted asynchronously, so "the call returned" says
+                        // nothing. NinjaTrader writes its own entry when it starts arming, and
+                        // the resource key for it is MEASURED, not guessed (stage `resname`
+                        // over NinjaTrader.Resource):
+                        //     NinjaScriptStrategyBaseEnabling1 / ...Enabling2
+                        // Waiting for that entry is the difference between "it has begun" and
+                        // "nothing happened yet" - the distinction that was missing every time
+                        // this step froze NinjaTrader.
+                        string hitEn; int idxEn;
+                        Progress(id, "-> enable posted (op=" + enableStatus[0].Split(' ')[0]
+                                     + "); waiting for NinjaTrader's own 'Enabling' log line, budget "
+                                     + RequestTtlSec(triggerJson).ToString("0") + "s (worker thread, "
+                                     + "log-file channel - touches no dispatcher)");
+                        bool started = WaitForLogName(markEnable, "NinjaScriptStrategyBaseEnabling",
+                                                      null, RequestTtlSec(triggerJson),
+                                                      out hitEn, out idxEn);
+                        step("NinjaTrader started arming", started,
+                             started ? hitEn.Substring(0, Math.Min(96, hitEn.Length))
+                                     : "NinjaTrader never reported NinjaScriptStrategyBaseEnabling "
+                                       + "within this request's budget - it did not begin");
+
+                        // ⚠ THE DISPATCHER STATUS IS NOT THE VERDICT ANY MORE.
+                        //
+                        // It used to demand Completed - which was reachable only because the
+                        // code waited for it, on the UI thread, and that wait is what froze
+                        // NinjaTrader. Since the wait is gone, the status is read microseconds
+                        // after BeginInvoke, so Pending is the NORMAL reading, not a failure.
+                        // Measured 2026-08-20 with the empty strategy: op=Pending while
+                        // NinjaTrader had ALREADY written NinjaScriptStrategyBaseEnabling1 -
+                        // the two say different things, and only the second one is evidence.
+                        //
+                        // So the verdict rests on what NinjaTrader itself reported (`started`)
+                        // plus the call having been posted at all. The status stays in the
+                        // text, because Pending / Executing / Completed still tells a reader
+                        // how far the operation had got when it was looked at.
+                        // Re-read the operation status AFTER the log wait. At post time
+                        // Pending is the normal reading; HERE it separates two different
+                        // freezes: Pending after the full budget = the dispatcher never
+                        // dequeued the operation; Executing = StrategyEnable started and is
+                        // stuck inside it. Run A 2026-08-20: the account reset ran and no
+                        // 'Enabling' line followed - only this late read can say which of
+                        // the two that was.
+                        System.Windows.Threading.DispatcherOperation opLate =
+                            opBox[0] as System.Windows.Threading.DispatcherOperation;
+                        step("enable operation status", true,
+                             opLate == null
+                               ? "operation not captured (posting path did not run)"
+                               : opLate.Status + " (read after the log wait; at post time it was "
+                                 + enableStatus[0].Split(' ')[0] + ")");
+                        bool enablePosted = outcome3 != null && outcome3.StartsWith("ok:");
+                        step("StrategyEnable", enablePosted && started,
+                             outcome3 + (started
+                               ? "   >>> posted, and NinjaTrader reported it started arming"
+                               : "   >>> NinjaTrader never reported that it began - see the step above"));
+                        if (!(enablePosted && started)) { sb.Append("]}"); return sb.ToString(); }
+
+                        // TRIGGER AND RETURN. Do not watch from in here.
+                        //
+                        // Two ways of waiting were tried on 2026-08-19 and both froze the
+                        // bridge, each for its own reason:
+                        //   - calling StrategyEnable synchronously inside the dispatcher never
+                        //     came back; three requests queued behind it for seven minutes
+                        //     while the heartbeat kept ticking, so the UI was alive and only
+                        //     this worker was stuck.
+                        //   - firing it and then polling the row through Dispatcher.Invoke in
+                        //     a loop queued every poll BEHIND the enable's own dispatcher work
+                        //     and froze just the same.
+                        // Enabling is heavy: NinjaTrader loads the series and steps the state
+                        // machine. Watching it therefore belongs in SEPARATE requests, each with
+                        // its own budget - which is the trigger/wait/continue discipline every
+                        // other stage follows. Use stage `strategystate` to watch.
+                        // NOT a result: BeginInvoke only posted it. The proof is NinjaTrader's
+                        // own log line, which the caller waits for - a step that cannot measure
+                        // its effect must not claim one.
+                        step("enable requested (NOT proof)", true,
+                             "proof = NinjaTrader's log line \"Enabling NinjaScript strategy\"; "
+                             + "our own object stays at " + strat.State + " because NinjaTrader "
+                             + "runs its own instance");
+                        sb.Append("]}");
+                        return sb.ToString();
+                    }
+
+                    acc.Strategies.Add(strat);
+                    step("added to account", true, acc.Name + ", state " + strat.State);
+
+                    // `Active` is not part of the chain NinjaTrader walks.
+                    State[] chain = new State[] { State.Configure, State.DataLoaded,
+                                                  State.Historical, State.Transition, State.Realtime };
+                    foreach (State target in chain)
+                    {
+                        State before = strat.State;
+                        if ((int)before >= (int)target) { step("SetState(" + target + ")", true, "already " + before); continue; }
+                        try
+                        {
+                            strat.SetState(target);
+                            step("SetState(" + target + ")", strat.State == target, before + " -> " + strat.State);
+                        }
+                        catch (Exception ex)
+                        {
+                            step("SetState(" + target + ")", false,
+                                 "threw " + ex.GetType().Name + ": " + ex.Message + " -> " + strat.State);
+                        }
+                        if (strat.State == State.Terminated || strat.State == State.Finalized) break;
+                    }
+                    sb.Append("]}");
+                    return sb.ToString();
+        }
+        // One appended line per event, written the instant it happens - worker or UI
+        // thread alike, plain file IO, no dispatcher. This is the channel that stays
+        // readable while NinjaTrader's UI thread is stuck: the result JSON only exists
+        // once a stage returns, but this file grows WHILE it runs. The driver tails it.
+        // No clock TIME here (protocol rule: data-stream time or none) - but every
+        // line now carries the milliseconds ELAPSED since this request was first
+        // written to, which is a measurement rather than a clock and is the one
+        // thing the file was missing.
+        //
+        // ⚠ WHY IT WAS NEEDED. A full run showed `ui idle` taking 31.2 s and then
+        // 81.6 s and `ntlog` 16.1 s and then 36.3 s - each exactly its budget, so
+        // each a timeout. The same stages answered in 2 s when sent on their own.
+        // Timeless step lines cannot tell "this step is slow" from "this step
+        // waited for the one before it", and that is precisely the question.
+        private static readonly Dictionary<string, System.Diagnostics.Stopwatch> _progClocks
+            = new Dictionary<string, System.Diagnostics.Stopwatch>();
+
+        private void Progress(string id, string text)
+        {
+            try
+            {
+                if (_resultDir == null || id == null) return;
+                System.Diagnostics.Stopwatch sw;
+                lock (_progClocks)
+                {
+                    if (!_progClocks.TryGetValue(id, out sw))
+                    {
+                        sw = System.Diagnostics.Stopwatch.StartNew();
+                        // Bounded: ids are unique per request, so this would grow for
+                        // the life of the process otherwise. The oldest are of no
+                        // further use once their file has been read.
+                        if (_progClocks.Count > 500) _progClocks.Clear();
+                        _progClocks[id] = sw;
+                    }
+                }
+                File.AppendAllText(Path.Combine(_resultDir, "playbackrun_" + id + ".progress.txt"),
+                                   string.Format(InvCi, "+{0,7} ms  {1}{2}",
+                                                 sw.ElapsedMilliseconds, text, Environment.NewLine));
+            }
+            catch { }
+        }
+        /// <summary>How many rows the strategies grid holds, or -1 when that cannot
+        /// be read at all - the two are different claims and the caller acts on it.
+        ///
+        /// ⚠ THE MEMBER IS NOT ALWAYS CALLED DataSource. This looked at that one
+        /// property, found null on a freshly created profile, and reported -1 -
+        /// "cannot read the grid" where the truth was "zero rows". The driver treats
+        /// -1 as a failed mandatory step, so the run ended before it reached the
+        /// connect (measured 2026-08-24, twice, on a UI.xml NinjaTrader had just
+        /// written itself).
+        ///
+        /// Upstream's own SnapshotGrid looks under `source`, `Entries` and
+        /// `ItemsSource`, in that order, because the member differs by NinjaTrader
+        /// build. Same list here, with DataSource kept last so nothing that used to
+        /// work stops working.</summary>
+        private int RowCount(object grid)
+        {
+            try
+            {
+                object rows = FirstMember(grid, new[] { "source", "Entries", "ItemsSource", "DataSource" });
+                System.Collections.IEnumerable seq = rows as System.Collections.IEnumerable;
+                if (seq == null) return -1;
+                int c = 0;
+                foreach (object o in seq) if (o != null) c++;
+                return c;
+            }
+            catch { return -1; }
+        }
+
+        // Parse {"fields":{"a":"b",...}} without a JSON library - the AddOn has none
+        // and the payloads are flat.
+        private static Dictionary<string, string> ParseNamedMap(string json, string name)
+        {
+            Dictionary<string, string> map = new Dictionary<string, string>();
+            if (json == null) return map;
+            int i = json.IndexOf("\"" + name + "\"", StringComparison.Ordinal);
+            if (i < 0) return map;
+            int open = json.IndexOf('{', i);
+            if (open < 0) return map;
+            int depth = 0, close = -1;
+            for (int k = open; k < json.Length; k++)
+            {
+                if (json[k] == '{') depth++;
+                else if (json[k] == '}') { depth--; if (depth == 0) { close = k; break; } }
+            }
+            if (close < 0) return map;
+            string body = json.Substring(open + 1, close - open - 1);
+            int p = 0;
+            while (p < body.Length)
+            {
+                int k1 = body.IndexOf('"', p); if (k1 < 0) break;
+                int k2 = body.IndexOf('"', k1 + 1); if (k2 < 0) break;
+                string key = body.Substring(k1 + 1, k2 - k1 - 1);
+                int c = body.IndexOf(':', k2); if (c < 0) break;
+                int v1 = body.IndexOf('"', c); if (v1 < 0) break;
+                int v2 = body.IndexOf('"', v1 + 1); if (v2 < 0) break;
+                map[key] = body.Substring(v1 + 1, v2 - v1 - 1);
+                p = v2 + 1;
+            }
+            return map;
+        }
+
+        // Walk the visual tree in document order; the last TextBlock seen is the label
+        // of the editor that follows. Writes and reads back.
+        private string SetByLabel(System.Windows.DependencyObject root, string label, string value)
+        {
+            string[] last = new string[] { null };
+            object[] target = new object[] { null };
+            WalkForLabel(root, label, last, target);
+            if (target[0] == null) return "no editor after a label '" + label + "'";
+            object el = target[0];
+
+            // An InstrumentSelector resolves what the user TYPED on commit; writing its
+            // inner TextBox leaves the resolved instrument untouched, and OK then applies
+            // the old one. Measured 2026-08-18: the dialog read back "MNQ ##-##" while
+            // the row it created said "FDAX ##-##". Set the selector's own Instrument
+            // property instead - that is the value NinjaTrader applies.
+            System.Windows.DependencyObject sel = el as System.Windows.DependencyObject;
+            while (sel != null && sel.GetType().Name.IndexOf("InstrumentSelector", StringComparison.Ordinal) < 0)
+            {
+                try { sel = System.Windows.Media.VisualTreeHelper.GetParent(sel); }
+                catch { sel = null; }
+            }
+            if (sel != null)
+            {
+                try
+                {
+                    Instrument inst2 = Instrument.GetInstrument(value);
+                    if (inst2 == null) return "instrument '" + value + "' unknown to NinjaTrader";
+                    PropertyInfo pi2 = sel.GetType().GetProperty("Instrument");
+                    if (pi2 != null && pi2.CanWrite)
+                    {
+                        pi2.SetValue(sel, inst2, null);
+                        object back2 = pi2.GetValue(sel, null);
+                        string bs2 = back2 == null ? "null" : ("" + back2);
+                        return (bs2.IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0
+                                ? "wrote" : "wrote (differs)")
+                               + " " + sel.GetType().Name + ".Instrument=" + value + " read=" + bs2;
+                    }
+                }
+                catch (Exception ex) { return "InstrumentSelector threw " + ex.GetType().Name + ": " + ex.Message; }
+            }
+            foreach (string prop in new string[] { "SelectedItem", "IsChecked", "Text", "Value" })
+            {
+                PropertyInfo pi = el.GetType().GetProperty(prop);
+                if (pi == null || !pi.CanWrite) continue;
+                try
+                {
+                    object v;
+                    if (prop == "IsChecked") v = string.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+                    else if (prop == "SelectedItem")
+                    {
+                        v = null;
+                        System.Windows.Controls.ItemsControl ic = el as System.Windows.Controls.ItemsControl;
+                        if (ic != null)
+                            foreach (object item in ic.Items)
+                                if (item != null && string.Equals("" + item, value, StringComparison.OrdinalIgnoreCase))
+                                { v = item; break; }
+                        if (v == null)
+                        {
+                            // ⚠ NO FALLING BACK TO Text. For a control with items the ITEM is
+                            // the truth and the text is a display artifact. Measured
+                            // 2026-08-19: the Account combo had no 'Playback101' (the Playback
+                            // connection was down, so no account existed); the old code wrote
+                            // .Text, read .Text back, reported "ok", and confirming the dialog
+                            // raised "Trying to add realtime strategy with no account" -
+                            // NinjaTrader had to be restarted. The value's ABSENCE from the
+                            // list is the finding, not an obstacle to route around.
+                            if (ic != null && ic.Items.Count > 0)
+                            {
+                                StringBuilder opts = new StringBuilder();
+                                int shown = 0;
+                                foreach (object item in ic.Items)
+                                {
+                                    if (shown++ >= 12) { opts.Append(", ..."); break; }
+                                    if (shown > 1) opts.Append(", ");
+                                    opts.Append(item == null ? "null" : ("" + item));
+                                }
+                                return "'" + value + "' is not among the " + ic.Items.Count
+                                     + " item(s) of " + el.GetType().Name + ": " + opts;
+                            }
+                            continue;   // genuinely not an items control - try Text/Value
+                        }
+                    }
+                    else v = value;
+                    pi.SetValue(el, v, null);
+                    object back = pi.GetValue(el, null);
+                    string bs = back == null ? "null" : back.ToString();
+                    return (string.Equals(bs, value, StringComparison.OrdinalIgnoreCase) ? "wrote" : "wrote (differs)")
+                           + " " + el.GetType().Name + "." + prop + "=" + value + " read=" + bs;
+                }
+                catch (Exception ex) { return prop + " threw " + ex.GetType().Name + ": " + ex.Message; }
+            }
+            return "no writable editor property on " + el.GetType().Name;
+        }
+
+        private void WalkForLabel(System.Windows.DependencyObject o, string label,
+                                  string[] last, object[] target)
+        {
+            if (o == null || target[0] != null) return;
+            int n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(o);
+            for (int i = 0; i < n && target[0] == null; i++)
+            {
+                System.Windows.DependencyObject k = System.Windows.Media.VisualTreeHelper.GetChild(o, i);
+                System.Windows.Controls.TextBlock tb = k as System.Windows.Controls.TextBlock;
+                if (tb != null && !string.IsNullOrWhiteSpace(tb.Text)) last[0] = tb.Text.Trim();
+                bool editor = k is System.Windows.Controls.ComboBox
+                              || k is System.Windows.Controls.CheckBox
+                              || k is System.Windows.Controls.TextBox;
+                if (editor && last[0] != null
+                    && string.Equals(last[0], label, StringComparison.OrdinalIgnoreCase))
+                { target[0] = k; return; }
+                WalkForLabel(k, label, last, target);
+            }
+        }
+        private System.Windows.Controls.Primitives.ButtonBase FindButtonByText(
+            System.Windows.DependencyObject o, string text)
+        {
+            if (o == null) return null;
+            int n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(o);
+            for (int i = 0; i < n; i++)
+            {
+                System.Windows.DependencyObject k = System.Windows.Media.VisualTreeHelper.GetChild(o, i);
+                System.Windows.Controls.Primitives.ButtonBase bb =
+                    k as System.Windows.Controls.Primitives.ButtonBase;
+                if (bb != null)
+                {
+                    // Strip WPF access-key underscores: NinjaTrader's message boxes label
+                    // their buttons "_Yes"/"_No", which renders as Yes/No with an
+                    // underlined letter. Comparing the raw content never matches, and the
+                    // dialog then blocks everything behind it.
+                    string c = bb.Content == null ? null : ("" + bb.Content).Replace("_", "").Trim();
+                    if ((c != null && string.Equals(c, text, StringComparison.OrdinalIgnoreCase))
+                        || HasVisibleText(bb, text))
+                        return bb;
+                }
+                System.Windows.Controls.Primitives.ButtonBase deep = FindButtonByText(k, text);
+                if (deep != null) return deep;
+            }
+            return null;
+        }
+        // Expand the item that shows this text, so its children are realized. Without
+        // this the child items do not exist in the visual tree and cannot be found.
+        private void ExpandSelected(System.Windows.DependencyObject root, string text)
+        {
+            int n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < n; i++)
+            {
+                System.Windows.DependencyObject k = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+                System.Windows.Controls.TreeViewItem tvi = k as System.Windows.Controls.TreeViewItem;
+                if (tvi != null && HasVisibleText(tvi, text))
+                {
+                    tvi.IsExpanded = true;
+                    tvi.UpdateLayout();
+                    return;
+                }
+                ExpandSelected(k, text);
+            }
+        }
+
+        // Does this element display exactly this text? Searches its own subtree only.
+        private bool HasVisibleText(System.Windows.DependencyObject o, string text)
+        {
+            if (o == null) return false;
+            System.Windows.Controls.TextBlock tb = o as System.Windows.Controls.TextBlock;
+            if (tb != null && tb.Text != null
+                && string.Equals(tb.Text.Replace("_", "").Trim(), text, StringComparison.OrdinalIgnoreCase)) return true;
+            int n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(o);
+            for (int i = 0; i < n; i++)
+            {
+                System.Windows.DependencyObject k = System.Windows.Media.VisualTreeHelper.GetChild(o, i);
+                // Do not descend into a nested item - that text belongs to another row.
+                if (k is System.Windows.Controls.TreeViewItem || k is System.Windows.Controls.ListBoxItem) continue;
+                if (HasVisibleText(k, text)) return true;
+            }
+            return false;
+        }
+
+        // Select an entry in the dialog's strategy tree by its header text.
+        private bool SelectTreeItem(System.Windows.DependencyObject root, string header)
+        { return SelectTreeItem(root, header, false); }
+
+        private bool SelectTreeItem(System.Windows.DependencyObject root, string header, bool leafOnly)
+        {
+            int n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < n; i++)
+            {
+                System.Windows.DependencyObject k = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+                // Header/Content are data objects here, not strings - their ToString()
+                // is not the visible name. Match the TextBlock the item actually shows.
+                // BringIntoView() before IsSelected: measured 2026-08-18, selecting an
+                // item that had never been realised left the property grid showing the
+                // previous strategy, so every field written after it belonged to the
+                // wrong bot. Realising the container first is what makes the selection
+                // reach the grid.
+                System.Windows.Controls.TreeViewItem tvi = k as System.Windows.Controls.TreeViewItem;
+                if (tvi != null && HasVisibleText(tvi, header) && !(leafOnly && tvi.HasItems))
+                {
+                    tvi.BringIntoView();
+                    tvi.IsSelected = true;
+                    return true;
+                }
+                System.Windows.Controls.ListBoxItem lbi = k as System.Windows.Controls.ListBoxItem;
+                if (lbi != null && HasVisibleText(lbi, header))
+                {
+                    lbi.BringIntoView();
+                    lbi.IsSelected = true;
+                    return true;
+                }
+                if (SelectTreeItem(k, header, leafOnly)) return true;
+            }
+            return false;
+        }
+
+        private static string SafeReadOn(PropertyInfo pi, object target)
+        {
+            try { object v = pi.GetValue(target, null); return v == null ? "null" : v.ToString(); }
+            catch (Exception ex) { return "<" + ex.GetType().Name + ">"; }
+        }
+
+        // Report what the grid considers selected, from every angle it exposes.
+        private void ReportSelection(object grid, string when, Action<string, bool, string> step)
+        {
+            foreach (string nm in new string[] { "SelectedItems", "SelectedDataItem", "SelectedDataItems", "ActiveDataItem", "ActiveRecord" })
+            {
+                PropertyInfo pi = grid.GetType().GetProperty(nm);
+                if (pi == null) { step(when + "." + nm, false, "no such property"); continue; }
+                object v = null;
+                try { v = pi.GetValue(grid, null); } catch { }
+                if (v == null) { step(when + "." + nm, true, "null"); continue; }
+                string extra = v.GetType().Name;
+                foreach (string sub in new string[] { "Records", "Cells", "DataItems" })
+                {
+                    PropertyInfo ps = v.GetType().GetProperty(sub);
+                    if (ps == null) continue;
+                    try
+                    {
+                        System.Collections.IEnumerable e2 = ps.GetValue(v, null) as System.Collections.IEnumerable;
+                        int c = 0;
+                        if (e2 != null) foreach (object x in e2) c++;
+                        extra += "  " + sub + "=" + c;
+                    }
+                    catch { }
+                }
+                step(when + "." + nm, true, extra);
+            }
+        }
+        /// <summary>Tick "Don't show this message again" on NinjaTrader's Historical
+        /// notice and confirm it. Returns what happened, for the step log.
+        ///
+        /// Scope is deliberately narrow: only a window whose text carries BOTH
+        /// "Level II market depth" and "Market Replay" is touched. That is the
+        /// wording of this one notice. Any other dialog is left standing - the rule
+        /// "a modal must never be clicked away" is unchanged for everything that is
+        /// not this measured, self-inflicted, question-free notice.
+        ///
+        /// Runs on the UI thread via BeginInvoke: a WPF modal pushes its own
+        /// dispatcher frame, and queued operations still run inside it.</summary>
+        private static string DismissHistoricalNotice(int ttlMs)
+        {
+            string outcome = "not seen";
+            int waited = 0;
+            while (waited < ttlMs)
+            {
+                Window hit = null;
+                try
+                {
+                    foreach (Window w in AllWindowsIncludingOwned())
+                    {
+                        if (w == null) continue;
+                        string text = null;
+                        try
+                        {
+                            Window ww = w;
+                            text = ww.Dispatcher.Invoke(new Func<string>(delegate
+                            {
+                                return CollectText(ww);
+                            })) as string;
+                        }
+                        catch { }
+                        if (text == null) continue;
+                        if (text.IndexOf("Level II market depth", StringComparison.OrdinalIgnoreCase) >= 0
+                            && text.IndexOf("Market Replay", StringComparison.OrdinalIgnoreCase) >= 0)
+                        { hit = w; break; }
+                    }
+                }
+                catch { }
+
+                if (hit != null)
+                {
+                    Window target = hit;
+                    int boxes = 0, buttons = 0;
+                    try
+                    {
+                        target.Dispatcher.Invoke(new Action(delegate
+                        {
+                            foreach (var cb in DescendantsOfType<System.Windows.Controls.CheckBox>(target))
+                            { cb.IsChecked = true; boxes++; }
+                            foreach (var b in DescendantsOfType<System.Windows.Controls.Button>(target))
+                            {
+                                string c = b.Content == null ? "" : b.Content.ToString();
+                                if (c.IndexOf("OK", StringComparison.OrdinalIgnoreCase) >= 0)
+                                {
+                                    var peer = new System.Windows.Automation.Peers.ButtonAutomationPeer(b);
+                                    var inv = peer.GetPattern(
+                                        System.Windows.Automation.Peers.PatternInterface.Invoke)
+                                        as System.Windows.Automation.Provider.IInvokeProvider;
+                                    if (inv != null) { inv.Invoke(); buttons++; }
+                                }
+                            }
+                        }));
+                    }
+                    catch (Exception ex)
+                    { return "found, but could not confirm: " + ex.GetType().Name + ": " + ex.Message; }
+                    return "confirmed after " + waited + " ms ("
+                           + boxes + " box(es) ticked, " + buttons + " OK invoked)"
+                           + " - it will not appear again on this machine";
+                }
+                Thread.Sleep(250);
+                waited += 250;
+            }
+            return outcome;
+        }
+
+        // ── NinjaTrader's order-rejection notice during a run ────────────────────
+        //  "Playback101, Stop price can't be changed above the market. affected
+        //  Order: Sell 1 StopMarket @ 29861,5" - an NTMessageBox NinjaTrader raises
+        //  when a strategy's stop modification is refused because the market crossed
+        //  the stop between the strategy's own side check and NinjaTrader's
+        //  validation. Measured 2026-09-02 (Playback/Historical, VwapSignal/VWAP_Long,
+        //  NinjaTrader log 16:55:34): seven such rejections in one run; the strategy
+        //  handled every one itself (closed the remainder at market) and the run
+        //  reached the data end. The box is informational - it asks nothing - but it
+        //  is MODAL: it stays until someone clicks OK, and an unattended run collects
+        //  one per rejection.
+        //
+        //  This is the second, and only other, exception to "a modal must never be
+        //  clicked away" (see StandingModal and DismissHistoricalNotice). It is as
+        //  narrow as the first: only a window whose type name carries "MessageBox"
+        //  AND whose text carries NinjaTrader's order-rejection trailer "affected
+        //  Order:" is confirmed (see the match below for the measured wordings). Every
+        //  other modal stays standing and stays a finding. The stage that runs every
+        //  sample of the play loop (`strategystate`) calls this once per sample, so a
+        //  notice stands for at most one sample interval, and the count travels in
+        //  the stage's step text ("order notices") so the transcript shows every one.
+        private static int _orderNoticesDismissed;      // per run; reset at the connect
+        private static string _orderNoticesScan = "";     // what the last scan saw, for the step detail
+
+        //  Which windows are looked at, and why all three sources: Globals.AllWindows
+        //  holds the windows NinjaTrader registers (Control Center, charts, the
+        //  Playback panel); a dialog they own is reached through OwnedWindows. A
+        //  MessageBox NinjaTrader opens without an owner is in neither - measured
+        //  2026-09-02 19:22-19:24: NinjaTrader's log carried seven rejections, the
+        //  scan over AllWindows + OwnedWindows answered "0 dismissed" every sample.
+        //  PresentationSource.CurrentSources lists EVERY WPF top-level window of the
+        //  process, each with the dispatcher of the UI thread that owns it, so a
+        //  window is read and confirmed on its own thread.
+        private int DismissOrderRejectNotices()
+        {
+            int dismissed = 0;
+            int seen = 0, boxes = 0;
+            List<Window> candidates = new List<Window>();
+            HashSet<Window> known = new HashSet<Window>();
+            List<Window> all = new List<Window>();
+            try { all.AddRange(AllWindowsIncludingOwned()); } catch { }
+            try
+            {
+                foreach (System.Windows.PresentationSource src in System.Windows.PresentationSource.CurrentSources)
+                {
+                    if (src == null) continue;
+                    System.Windows.PresentationSource s = src;
+                    Window w = null;
+                    try
+                    {
+                        w = s.Dispatcher.Invoke(new Func<Window>(delegate { return s.RootVisual as Window; }),
+                                                TimeSpan.FromSeconds(3)) as Window;
+                    }
+                    catch { }
+                    if (w != null) all.Add(w);
+                }
+            }
+            catch (Exception ex) { LogSafe("order notice: PresentationSource scan failed: " + ex.GetType().Name + ": " + ex.Message); }
+            foreach (Window w in all)
+            {
+                if (w == null || !known.Add(w)) continue;
+                seen++;
+                string ty = null;
+                try { ty = w.GetType().Name; } catch { }
+                if (ty == null || ty.IndexOf("MessageBox", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                boxes++;
+                string text = null;
+                try
+                {
+                    Window ww = w;
+                    text = ww.Dispatcher.Invoke(new Func<string>(delegate { return CollectText(ww); }),
+                                                TimeSpan.FromSeconds(3)) as string;
+                }
+                catch { }
+                // The common signature of NinjaTrader's order-rejection boxes is the
+                // trailer "affected Order: <action> <qty> <type> @ <price>". Measured
+                // 2026-09-02 20:00-20:09 on the Short variant of the same strategy,
+                // one box each: "Stop price can't be changed below the market", "Sell
+                // stop or sell stop limit orders can't be placed above the market",
+                // "Buy stop or buy stop limit orders can't be placed below the market"
+                // and "Order '...' can't be submitted: The OCO ID '...' cannot be
+                // reused" - all with that trailer; a match on the first wording alone
+                // confirmed one of seven and left six standing.
+                if (text != null && text.IndexOf("affected Order:", StringComparison.OrdinalIgnoreCase) >= 0)
+                    candidates.Add(w);
+            }
+            foreach (Window target0 in candidates)
+            {
+                Window target = target0;
+                int buttons = 0;
+                try
+                {
+                    target.Dispatcher.Invoke(new Action(delegate
+                    {
+                        foreach (var b in DescendantsOfType<System.Windows.Controls.Button>(target))
+                        {
+                            string c = b.Content == null ? "" : b.Content.ToString();
+                            if (c.IndexOf("OK", StringComparison.OrdinalIgnoreCase) >= 0)
+                            {
+                                var peer = new System.Windows.Automation.Peers.ButtonAutomationPeer(b);
+                                var inv = peer.GetPattern(
+                                    System.Windows.Automation.Peers.PatternInterface.Invoke)
+                                    as System.Windows.Automation.Provider.IInvokeProvider;
+                                if (inv != null) { inv.Invoke(); buttons++; }
+                            }
+                        }
+                    }), TimeSpan.FromSeconds(3));
+                }
+                catch (Exception ex) { LogSafe("order notice: found, but could not confirm: " + ex.GetType().Name + ": " + ex.Message); }
+                if (buttons > 0) dismissed++;
+            }
+            _orderNoticesScan = "windows " + seen + ", message boxes " + boxes + ", matching " + candidates.Count;
+            return dismissed;
+        }
+
+        /// <summary>All text of a window, for identifying a notice by its wording.</summary>
+        private static string CollectText(System.Windows.DependencyObject root)
+        {
+            var sb = new StringBuilder();
+            foreach (var tb in DescendantsOfType<System.Windows.Controls.TextBlock>(root))
+            { sb.Append(tb.Text); sb.Append(' '); }
+            foreach (var lb in DescendantsOfType<System.Windows.Controls.Label>(root))
+            { if (lb.Content != null) { sb.Append(lb.Content.ToString()); sb.Append(' '); } }
+            return sb.ToString();
+        }
+
+        /// <summary>Visual-tree descendants of one type - same walk as
+        /// FindElementStatic, by type instead of by name.</summary>
+        private static List<T> DescendantsOfType<T>(System.Windows.DependencyObject root)
+            where T : System.Windows.DependencyObject
+        {
+            var found = new List<T>();
+            if (root == null) return found;
+            int n = 0;
+            try { n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root); }
+            catch { return found; }
+            for (int i = 0; i < n; i++)
+            {
+                var child = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+                T t = child as T;
+                if (t != null) found.Add(t);
+                found.AddRange(DescendantsOfType<T>(child));
+            }
+            return found;
+        }
+
+        // Every top-level window plus the dialogs they own. Globals.AllWindows lists
+        // only the former; a picker opened from a context menu is an owned window and
+        // is otherwise invisible to us.
+        private static List<Window> AllWindowsIncludingOwned()
+        {
+            List<Window> all = new List<Window>();
+            foreach (Window w in NinjaTrader.Core.Globals.AllWindows)
+            {
+                if (w == null) continue;
+                all.Add(w);
+                try
+                {
+                    Window ww = w;
+                    System.Windows.WindowCollection owned = (System.Windows.WindowCollection)
+                        ww.Dispatcher.Invoke(new Func<System.Windows.WindowCollection>(
+                            delegate { return ww.OwnedWindows; }));
+                    foreach (Window o in owned) if (o != null) all.Add(o);
+                }
+                catch { }
+            }
+            return all;
+        }
+
+        private static string SafeRead(PropertyInfo pi, object target)
+        {
+            try { object v = pi.GetValue(target); return v == null ? "null" : v.ToString(); }
+            catch (Exception ex) { return "<" + ex.GetType().Name + ">"; }
+        }
+
+        private static string SafeReadField(FieldInfo fi, object target)
+        {
+            try { object v = fi.GetValue(target); return v == null ? "null" : v.ToString(); }
+            catch (Exception ex) { return "<" + ex.GetType().Name + ">"; }
+        }
+
+        // Write one static of the PlaybackAdapter and READ IT BACK. The read-back is
+        // the point: several of these silently ignore a write depending on connection
+        // state, and reporting "set" for those produces a run nobody can attribute.
+        /// <summary>Write a static and REPORT the read-back without judging it.
+        ///
+        /// For values the adapter does not surface until it is live: measured,
+        /// FromEst and ToEst read back as DateTime.MinValue before the connect no
+        /// matter what was written, and failing the step on that killed runs whose
+        /// connect then succeeded. The confirming check runs after the connection is
+        /// up, where the getter answers.</summary>
+        private void SetStaticQuiet(Type pb, string name, object value, Action<string, bool, string> step)
+        {
+            try
+            {
+                PropertyInfo pi = pb.GetProperty(name, BFStatic);
+                if (pi == null) { step(name, false, "property not found"); return; }
+                pi.SetValue(null, value, null);
+                object back = pi.GetValue(null);
+                bool same = back != null && back.ToString() == value.ToString();
+                step(name, true, "wrote=" + value + " read=" + back
+                     + (same ? "" : "  - not verifiable before the connect; confirmed by"
+                                    + " step 'range on the connection'"));
+            }
+            catch (Exception ex) { step(name, false, ex.GetType().Name + ": " + ex.Message); }
+        }
+
+        private void SetStatic(Type pb, string name, object value, Action<string, bool, string> step)
+        {
+            try
+            {
+                PropertyInfo pi = pb.GetProperty(name, BFStatic);
+                if (pi == null) { step(name, false, "property not found"); return; }
+                pi.SetValue(null, value, null);
+                object back = pi.GetValue(null);
+                step(name, back != null && back.ToString() == value.ToString(),
+                     "wrote=" + value + " read=" + back);
+            }
+            catch (Exception ex) { step(name, false, ex.GetType().Name + ": " + ex.Message); }
+        }
+
+        // NinjaTrader is multi-UI-threaded: Application.Current.Windows does not list
+        // every window. Globals.AllWindows does, and the title is read on the window's
+        // own dispatcher because every WPF member is thread-affine.
+        private Window FindWindowByTitle(string titlePart)
+        {
+            if (string.IsNullOrWhiteSpace(titlePart)) titlePart = "Playback";
+            // Exact title wins over a substring. NinjaTrader has both a
+            // "Control Center - Strategies" tab and a separate "Strategies" dialog;
+            // a substring search finds the wrong one and every following step then
+            // reports on a window nobody asked for.
+            // Globals.AllWindows lists NinjaTrader's own top-level windows but NOT
+            // dialogs it owns - measured: the "Strategies" picker opened by
+            // "New Strategy..." is absent there while the Win32 enumeration sees it.
+            // Owned windows live on their owner's dispatcher, so walking
+            // Window.OwnedWindows reaches them without any thread gymnastics.
+            List<Window> all = new List<Window>();
+            foreach (Window w in NinjaTrader.Core.Globals.AllWindows)
+            {
+                if (w == null) continue;
+                all.Add(w);
+                try
+                {
+                    Window ww = w;
+                    System.Windows.WindowCollection owned = (System.Windows.WindowCollection)
+                        ww.Dispatcher.Invoke(new Func<System.Windows.WindowCollection>(
+                            delegate { return ww.OwnedWindows; }));
+                    foreach (Window o in owned) if (o != null) all.Add(o);
+                }
+                catch { }
+            }
+            Window loose = null;
+            foreach (Window w in all)
+            {
+                string ti = null;
+                try { ti = (string)w.Dispatcher.Invoke(new Func<string>(delegate { return w.Title; })); }
+                catch { }
+                if (ti == null) continue;
+                if (string.Equals(ti, titlePart, StringComparison.OrdinalIgnoreCase)) return w;
+                if (loose == null && ti.IndexOf(titlePart, StringComparison.OrdinalIgnoreCase) >= 0) loose = w;
+            }
+            return loose;
+        }
+
+        private string WindowTitles()
+        {
+            List<string> t = new List<string>();
+            foreach (Window w in NinjaTrader.Core.Globals.AllWindows)
+            {
+                if (w == null) continue;
+                try { t.Add((string)w.Dispatcher.Invoke(new Func<string>(delegate { return w.Title; }))); }
+                catch { }
+            }
+            return string.Join(" | ", t.ToArray());
+        }
+
+        // FindName does not reach these: the controls live inside ControlTemplates,
+        // which is a different name scope. Walk the visual tree instead.
+        private object FindElement(System.Windows.DependencyObject root, string name)
+        {
+            if (root == null) return null;
+            int n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < n; i++)
+            {
+                System.Windows.DependencyObject k = System.Windows.Media.VisualTreeHelper.GetChild(root, i);
+                System.Windows.FrameworkElement fe = k as System.Windows.FrameworkElement;
+                if (fe != null && fe.Name == name) return fe;
+                object deep = FindElement(k, name);
+                if (deep != null) return deep;
+            }
+            return null;
+        }
+
+        private void SetElementValue(System.Windows.DependencyObject root, string name,
+                                     string property, object value, Action<string, bool, string> step)
+        { SetElementValue(root, name, property, value, step, 120.0); }
+
+        private void SetElementValue(System.Windows.DependencyObject root, string name,
+                                     string property, object value, Action<string, bool, string> step,
+                                     double ttlSec)
+        {
+            object el = FindElement(root, name);
+            if (el == null) { step(name, false, "not in the visual tree"); return; }
+            PropertyInfo pi = el.GetType().GetProperty(property);
+            if (pi == null) { step(name, false, property + " not on " + el.GetType().Name); return; }
+            try
+            {
+                // ── The four-phase handshake, for a UI write ─────────────────────────────────
+                //
+                // 1. what does it say BEFORE?  2. write  3. wait until the LIVE tree says the
+                // new value  4. report the move with its measured duration.
+                //
+                // ⚠ Phase 3 re-FINDS the element every time instead of reading back the object
+                // just written to. NinjaTrader rebuilds this panel, and a write that landed on a
+                // control it is about to discard reads back perfectly - the same shape as
+                // upstream's issue #6, where a detached template echoed its own value while the
+                // tab kept the old one. Only a fresh lookup can tell the two apart.
+                string beforeV = "";
+                try { object b0 = pi.GetValue(el, null); beforeV = b0 == null ? "null" : b0.ToString(); }
+                catch { beforeV = "<unreadable>"; }
+
+                pi.SetValue(el, value, null);
+
+                string want = value.ToString();
+                string gotV; long msV;
+                System.Windows.DependencyObject rootV = root;
+                string nameV = name, propV = property;
+                bool arrived = WaitUntilChanged(delegate
+                {
+                    try
+                    {
+                        object el2 = FindElement(rootV, nameV);          // fresh, every time
+                        if (el2 == null) return "<element gone>";
+                        PropertyInfo pi2 = el2.GetType().GetProperty(propV);
+                        if (pi2 == null) return "<property gone>";
+                        object v2 = pi2.GetValue(el2, null);
+                        return v2 == null ? "null" : v2.ToString();
+                    }
+                    catch (Exception) { return "<tree being rebuilt>"; }
+                }, beforeV, want, ttlSec, out gotV, out msV);
+
+                step(name + "." + property, arrived,
+                     beforeV + " -> " + gotV + " after " + msV + " ms (wanted " + want + ")"
+                     + (beforeV == want ? "   [was already the target - nothing moved]" : ""));
+            }
+            catch (Exception ex)
+            {
+                // A TargetInvocationException carries only "the callee threw"; the
+                // reason is one level down. Dropping it left the log naming a symptom
+                // with no cause (measured 30.08.2026 on rbHistoricalData.IsChecked).
+                string why = ex.GetType().Name + ": " + ex.Message;
+                Exception inner = ex.InnerException;
+                int depth = 0;
+                while (inner != null && depth++ < 3)
+                {
+                    why += "  <- " + inner.GetType().Name + ": " + inner.Message;
+                    inner = inner.InnerException;
+                }
+                step(name + "." + property, false, why);
+            }
+        }
+
+        // Depth 40, not 12: the Historical Data window's download fields sit deeper
+        // than 12 levels and a shallower walk finds only the window chrome.
+        private void DumpVisualTree(System.Windows.DependencyObject o, int depth, Action<string, bool, string> step)
+        {
+            if (o == null || depth > 40) return;
+            int n = System.Windows.Media.VisualTreeHelper.GetChildrenCount(o);
+            for (int i = 0; i < n; i++)
+            {
+                System.Windows.DependencyObject k = System.Windows.Media.VisualTreeHelper.GetChild(o, i);
+                System.Windows.FrameworkElement fe = k as System.Windows.FrameworkElement;
+                // Labels carry the meaning: in NinjaTrader's property grids every editor
+                // is named PART_editor, so a field is only identifiable by the TextBlock
+                // that precedes it. Report those too, in document order.
+                System.Windows.Controls.TextBlock tb = k as System.Windows.Controls.TextBlock;
+                if (tb != null && !string.IsNullOrWhiteSpace(tb.Text))
+                    step(new string(' ', depth) + "label", true, tb.Text);
+                // Report unnamed buttons too: NinjaTrader's message-box buttons carry no
+                // x:Name, so a name-only dump hides exactly the controls one needs.
+                System.Windows.Controls.Primitives.ButtonBase ub =
+                    k as System.Windows.Controls.Primitives.ButtonBase;
+                if (ub != null && (fe == null || string.IsNullOrEmpty(fe.Name)))
+                    step(new string(' ', depth) + k.GetType().Name + " (unnamed)", true,
+                         "Content=" + (ub.Content == null ? "null" : ("" + ub.Content)));
+                if (fe != null && !string.IsNullOrEmpty(fe.Name))
+                {
+                    string v = "";
+                    try
+                    {
+                        if (k is System.Windows.Controls.DatePicker)
+                            v = "SelectedDate=" + ((System.Windows.Controls.DatePicker)k).SelectedDate;
+                        else if (k is System.Windows.Controls.Primitives.RangeBase)
+                        {
+                            System.Windows.Controls.Primitives.RangeBase rb = (System.Windows.Controls.Primitives.RangeBase)k;
+                            v = "Value=" + rb.Value + " Min=" + rb.Minimum + " Max=" + rb.Maximum;
+                        }
+                        else if (k is System.Windows.Controls.ComboBox)
+                            v = "SelectedItem=" + ((System.Windows.Controls.ComboBox)k).SelectedItem;
+                        else if (k is System.Windows.Controls.TextBox)
+                            v = "Text=" + ((System.Windows.Controls.TextBox)k).Text;
+                        else if (k is System.Windows.Controls.Primitives.ToggleButton)
+                            v = "IsChecked=" + ((System.Windows.Controls.Primitives.ToggleButton)k).IsChecked
+                              + " Content=" + ((System.Windows.Controls.Primitives.ToggleButton)k).Content;
+                        else if (k is System.Windows.Controls.Button)
+                            v = "Content=" + ((System.Windows.Controls.Button)k).Content;
+                    }
+                    catch (Exception ex) { v = "<" + ex.GetType().Name + ">"; }
+                    // Report IsEnabled as well: a greyed control cannot be driven, and
+                    // without this value a failed write looks like a fault in the driving
+                    // code rather than a locked UI.
+                    System.Windows.UIElement ue = k as System.Windows.UIElement;
+                    if (ue != null && !ue.IsEnabled) v = (v.Length > 0 ? v + "  " : "") + "[DISABLED]";
+                    step(new string(' ', depth) + k.GetType().Name + " '" + fe.Name + "'", true, v);
+                }
+                DumpVisualTree(k, depth + 1, step);
+            }
+        }
+
+        // One element, its binding-relevant members and its context menu. Used to find
+        // what a grid is actually bound to — Account.Strategies is not what the
+        // Control Center shows.
+        private void DumpElement(System.Windows.DependencyObject root, string name, Action<string, bool, string> step)
+        {
+            object o = FindElement(root, name);
+            if (o == null) { step("element '" + name + "'", false, "not in the visual tree"); return; }
+            step("element '" + name + "'", true, o.GetType().FullName);
+            foreach (PropertyInfo pi in o.GetType().GetProperties(
+                         BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            {
+                string nm = pi.Name;
+                if (nm.IndexOf("Item", StringComparison.OrdinalIgnoreCase) < 0
+                    && nm.IndexOf("Source", StringComparison.OrdinalIgnoreCase) < 0
+                    && nm.IndexOf("Selected", StringComparison.OrdinalIgnoreCase) < 0
+                    && nm.IndexOf("Context", StringComparison.OrdinalIgnoreCase) < 0) continue;
+                string v;
+                try
+                {
+                    object val = pi.GetValue(o, null);
+                    v = val == null ? "null" : val.GetType().FullName;
+                    System.Collections.IEnumerable en = val as System.Collections.IEnumerable;
+                    if (en != null && !(val is string))
+                    {
+                        int c = 0;
+                        foreach (object x in en) c++;
+                        v += " (" + c + " items)";
+                    }
+                    // The grid's rows are the objects NinjaTrader itself manages. Dump the
+                    // first one so a caller can see what is settable on a strategy row
+                    // instead of guessing at Account.Strategies, which is a different
+                    // collection entirely.
+                    if (en != null && !(val is string) && nm.IndexOf("Source", StringComparison.OrdinalIgnoreCase) >= 0)
+                    {
+                        foreach (object row in en)
+                        {
+                            step("  first row", true, row == null ? "null" : row.GetType().FullName);
+                            if (row != null)
+                                foreach (PropertyInfo rp in row.GetType().GetProperties(
+                                             BindingFlags.Public | BindingFlags.Instance))
+                                {
+                                    string rv;
+                                    try { object x = rp.GetValue(row, null); rv = x == null ? "null" : x.ToString(); }
+                                    catch (Exception ex2) { rv = "<" + ex2.GetType().Name + ">"; }
+                                    step("    " + rp.Name, rp.CanWrite,
+                                         rp.PropertyType.Name + " = " + (rv.Length > 60 ? rv.Substring(0, 60) : rv));
+                                }
+                            break;
+                        }
+                    }
+                    System.Windows.Controls.ContextMenu cm = val as System.Windows.Controls.ContextMenu;
+                    if (cm != null)
+                        foreach (object it in cm.Items)
+                        {
+                            System.Windows.Controls.MenuItem mi = it as System.Windows.Controls.MenuItem;
+                            step("    menu", mi != null && mi.IsEnabled,
+                                 mi == null ? it.GetType().Name : ("" + mi.Header));
+                        }
+                }
+                catch (Exception ex) { v = "<" + ex.GetType().Name + ">"; }
+                step("  " + nm, pi.CanWrite, v.Length > 110 ? v.Substring(0, 110) : v);
+            }
+        }
+
+
+        // ── Generic, not playback-specific ───────────────────────────────────────────────
+        //  These four belong to the bridge as a whole, not to our stages. They live here
+        //  only so upstream's file stays close to GitHub; their CALL SITES are still in
+        //  NT8BridgeServer.cs, because a call inside his method cannot move. Each is a
+        //  candidate to offer upstream, with the measurement that motivated it.
+        // How long a queued request stays valid, in seconds. `ttlSec` in the request
+        // wins so the long commands (backtest, downloads, compile) can outlive the
+        // default without weakening it for everything else.
+        private const double DefaultTtlSec = 300.0;
+
+        // Reads a NUMBER, which ExtractJsonString cannot: that one takes the first
+        // '"' after the colon, and for `"ttlSec": 300` the next quote belongs to the
+        // FOLLOWING key. A quoted value is accepted as well.
+        private static double RequestTtlSec(string json)
+        {
+            if (json == null) return DefaultTtlSec;
+            const string pat = "\"ttlSec\"";
+            int i = json.IndexOf(pat, StringComparison.Ordinal);
+            if (i < 0) return DefaultTtlSec;
+            int c = json.IndexOf(':', i + pat.Length);
+            if (c < 0) return DefaultTtlSec;
+            int p = c + 1;
+            while (p < json.Length && (char.IsWhiteSpace(json[p]) || json[p] == '"')) p++;
+            int s = p;
+            while (p < json.Length && (char.IsDigit(json[p]) || json[p] == '.' ||
+                                       json[p] == '-' || json[p] == '+' ||
+                                       json[p] == 'e' || json[p] == 'E')) p++;
+            double v;
+            if (p > s && double.TryParse(json.Substring(s, p - s),
+                                         System.Globalization.NumberStyles.Float, InvCi, out v)
+                && v > 0.0)
+                return v;
+            return DefaultTtlSec;
+        }
+
+        // Result files are read once - the client polls for one name and moves on.
+        // Measured 2026-08-19: 133 MB in 392 files, the oldest from a previous
+        // session, because nothing ever deleted them.
+        private DateTime _lastPrune = DateTime.MinValue;
+
+
+        private void PruneResults()
+        {
+            try
+            {
+                if ((DateTime.UtcNow - _lastPrune).TotalMinutes < 30.0) return;
+                _lastPrune = DateTime.UtcNow;
+                if (_resultDir == null) return;
+                DateTime cutoff = DateTime.UtcNow.AddHours(-24.0);
+                int gone = 0;
+                foreach (string f in Directory.GetFiles(_resultDir, "*.json"))
+                {
+                    // heartbeat.json is rewritten continuously and must survive.
+                    if (string.Equals(Path.GetFileName(f), "heartbeat.json",
+                                      StringComparison.OrdinalIgnoreCase)) continue;
+                    try
+                    {
+                        if (File.GetLastWriteTimeUtc(f) >= cutoff) continue;
+                        File.Delete(f);
+                        gone++;
+                    }
+                    catch { }
+                }
+                // The live-progress companions (playbackrun_<id>.progress.txt) age out
+                // on the same 24h cutoff - same lifecycle as the result they belong to.
+                foreach (string f in Directory.GetFiles(_resultDir, "playbackrun_*.progress.txt"))
+                {
+                    try
+                    {
+                        if (File.GetLastWriteTimeUtc(f) >= cutoff) continue;
+                        File.Delete(f);
+                        gone++;
+                    }
+                    catch { }
+                }
+                if (gone > 0) LogSafe("pruned " + gone + " result file(s) older than 24h");
+            }
+            catch (Exception ex) { LogSafe("PruneResults: " + ex.Message); }
+        }
+
+        // Upstream's ResultPrefix() does not know our kind, and an unknown kind falls
+        // through to "compile_". Measured 2026-08-19: the TTL refusal for a `playbackrun`
+        // was therefore written as compile_<id>.json - the log said
+        //     expired playbackrun b227d6f2...: 601s old, ttl 5s - NOT executed
+        // while the caller polled playbackrun_<id>.json and waited out its own timeout.
+        // A guard that MISFILES its answer turns a safety net into the hang it exists to
+        // prevent. Kept here rather than patching his table, so his file stays close to
+        // GitHub.
+        private static string ResultPrefixEx(string kind, string upstreamPrefix)
+        {
+            if (kind == "playbackrun") return "playbackrun_";
+            if (kind == "satemplate") return "satemplate_";
+            if (kind == "analyzerrun") return "analyzerrun_";
+            return upstreamPrefix;
+        }
+    }
+}

--- a/nt8bridge/analyzerrun.py
+++ b/nt8bridge/analyzerrun.py
@@ -1,0 +1,202 @@
+# MIT License
+# Copyright (c) 2026 Quantrosoft Pty. Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""optimize / walkforward / multiobjective: NinjaTrader's own parameter search,
+driven on the Strategy Analyzer tab exactly as the Run button drives it.
+
+The three commands share ONE request kind, ``analyzerrun``, and ONE option
+syntax with the headless runner (Nt8Cli), so a run can be moved between the two
+hosts by changing nothing but the program name::
+
+    python -m nt8bridge walkforward --template=<xml> --opt=Fast:20:30:5 [--anchored]
+                                    [--optimizer=default|genetic] [--fitness=<name>]
+                                    [--OptimizationPeriod=<days>] [--TestPeriod=<days>]
+                                    [--out=<csv>] [--timeout=<s>]
+
+* ``--template`` is the strategy template file NinjaTrader wrote itself (a full
+  path, or a bare name resolved in the strategy's own template folder - the
+  same rule as ``satemplate``). It carries the complete parameter set, the
+  instrument and the window.
+* ``--opt`` is ``Name:min:max:step[,...]``; every name must be a public
+  property of the strategy. The AddOn writes them as NinjaTrader's own
+  ``Parameter`` objects onto the template's ``OptimizationParameters`` - the
+  collection the GUI's parameter grid fills - because NinjaTrader refuses a
+  run without one (``The strategy must have at least one parameter to
+  optimize``, measured on 8.1.8.2 with the type set and the collection empty).
+* Any further ``--Name=value`` is written to the strategy property of that
+  name after the template, so ``--OptimizationPeriod=10 --TestPeriod=5`` sets
+  the walk-forward window lengths in days without editing the file.
+* The AddOn sets the tab's ``BacktestType`` to the run mode and executes the
+  view model's ``RunCommand``; NinjaTrader then does what it does for a click.
+  The result is read off the tab's results grid once the run has finished:
+  one summary row, one row per window (category WalkForward, the out-of-sample
+  run) and one per combination (category Optimize under the window, the
+  in-sample run ranked by its performance value), each with its parameters
+  and performance, plus
+  the CSV files the strategy wrote during the run (read from the strategy's
+  ``LogModes`` folder when it has that property, counting only files with the
+  ``LogFilePrefix`` the AddOn sets for the run when the strategy has one;
+  ``--out`` copies them as
+  ``<out>`` for one file and ``<out>_<k><ext>`` in creation order for several,
+  which is what Nt8Cli does with the same option).
+
+Wire format::
+
+  request : {"id", "kind": "analyzerrun", "mode": "Optimize|WalkForward|
+             WalkForwardAnchored|MultiObjective", "template", "opt",
+             "optimizer", "fitness", "params": {...}, "timeoutSec", "ttlSec"}
+  response: {"id", "status": "ok"|"error", "mode", "backtestType", "category",
+             "template", "strategy", "instrument", "from", "to",
+             "parameters": [{name, type, min, max, increment}], "optimizer",
+             "fitness", "combinations", "elapsedSec", "rows": [...],
+             "windows", "rankedWindows", "logDir", "csvFiles": [...],
+             "errors": [{code, message}]}
+"""
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+from nt8bridge import ntio
+from nt8bridge.compile import new_request_id
+
+# CLI command -> the value the AddOn writes to StrategyAnalyzerTabProperties.BacktestType
+# (enum StrategyAnalyzerGuiBacktestType: Backtest, Optimize, WalkForward,
+# WalkForwardAnchored, MultiObjective, AiGenerate - read off NinjaTrader.Gui 8.1.8.2).
+MODES = {
+    "optimize": "Optimize",
+    "walkforward": "WalkForward",
+    "multiobjective": "MultiObjective",
+}
+COMMANDS = tuple(MODES)
+OPTIMIZERS = ("default", "genetic")
+DEFAULT_TIMEOUT = 1800.0
+
+
+def parse_opt_spec(spec: str) -> list[dict]:
+    """Check the SHAPE of ``Name:min:max:step[,...]`` before the request leaves.
+
+    Types are the AddOn's business (it knows the property), so min and max
+    travel as text; only the field count and the step width are judged here,
+    with the wording Nt8Cli uses for the same mistakes.
+    """
+    entries = []
+    for part in [p for p in (spec or "").split(",") if p.strip()]:
+        f = part.split(":")
+        if len(f) != 4:
+            raise ValueError("--opt entry '%s' needs 4 fields Name:min:max:step." % part)
+        name = f[0].strip()
+        if not re.match(r"^[A-Za-z_]\w*$", name):
+            raise ValueError("--opt entry '%s': '%s' is not a property name." % (part, name))
+        try:
+            step = float(f[3].strip())
+        except ValueError:
+            raise ValueError("--opt entry '%s': step '%s' is not a number." % (part, f[3].strip()))
+        if step <= 0:
+            raise ValueError("step width in '%s' must be > 0." % part)
+        entries.append({"name": name, "min": f[1].strip(), "max": f[2].strip(),
+                        "step": f[3].strip()})
+    if not entries:
+        raise ValueError("needs --opt=Name:min:max:step[,...]")
+    return entries
+
+
+def property_overrides(extra: list[str]) -> dict:
+    """Turn the unknown ``--Name=value`` tokens into strategy property writes.
+
+    This is the rule the headless runner applies to every option it does not
+    know itself; a token of any other shape is a typo, not an override.
+    """
+    out = {}
+    for tok in extra:
+        m = re.match(r"^--([A-Za-z_]\w*)=(.*)$", tok)
+        if not m:
+            raise ValueError("unexpected argument %r - a strategy property override is"
+                             " written --Name=value" % tok)
+        out[m.group(1)] = m.group(2)
+    return out
+
+
+def build_request(request_id: str, mode: str, template: str, opt: str, *,
+                  optimizer: str = "default", fitness: str = "", anchored: bool = False,
+                  params: dict | None = None, timeout: float = DEFAULT_TIMEOUT) -> dict:
+    if mode not in MODES:
+        raise ValueError("mode must be one of %s" % ", ".join(COMMANDS))
+    if optimizer not in OPTIMIZERS:
+        raise ValueError("--optimizer=%s is not a known optimizer. Valid: default | genetic."
+                         % optimizer)
+    backtest_type = MODES[mode]
+    if anchored:
+        if mode != "walkforward":
+            raise ValueError("--anchored belongs to walkforward only")
+        backtest_type = "WalkForwardAnchored"
+    return {
+        "id": request_id,
+        "kind": "analyzerrun",
+        "mode": backtest_type,
+        "template": template,
+        "opt": opt,
+        "optimizer": optimizer,
+        "fitness": fitness or "",
+        "params": dict(params or {}),
+        # The AddOn stops waiting for the grid when the client would have
+        # stopped waiting for the file; one number, read on both sides.
+        "timeoutSec": float(timeout),
+        # A request that sat in the queue past this is not executed (the AddOn's
+        # own rule); a parameter search is never worth running on a stale tab.
+        "ttlSec": 300.0,
+    }
+
+
+def run_analyzer(mode: str, template: str, opt: str, *, optimizer: str = "default",
+                 fitness: str = "", anchored: bool = False, params: dict | None = None,
+                 timeout: float = DEFAULT_TIMEOUT) -> dict:
+    """Drop one analyzerrun request for the AddOn and wait for its result file."""
+    trigger, result = ntio.ensure_bridge_dirs()
+    rid = new_request_id()
+    ntio.atomic_write_json(
+        trigger / f"analyzerrun_{rid}.json",
+        build_request(rid, mode, template, opt, optimizer=optimizer, fitness=fitness,
+                      anchored=anchored, params=params, timeout=timeout),
+    )
+    # The result arrives only after the run; the client waits the run's own
+    # budget plus a margin for the AddOn to write the file.
+    return ntio.poll_for_json(result / f"analyzerrun_{rid}.json", timeout=timeout + 30.0)
+
+
+def deliver_csvs(csv_files: list[str], out: str | None) -> list[str]:
+    """Copy the run's CSV files to ``out``: one file takes that name, several
+    become ``<out>_<k><ext>`` in the order the AddOn lists them (creation order).
+    Returns the destination paths; without ``out`` the sources are returned as
+    they are."""
+    files = [str(f) for f in (csv_files or [])]
+    if not out or not files:
+        return files
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    dests = []
+    for k, src in enumerate(files):
+        dest = out_path if len(files) == 1 else out_path.with_name(
+            out_path.stem + "_%d" % k + out_path.suffix)
+        shutil.copyfile(src, dest)
+        dests.append(str(dest))
+    return dests

--- a/nt8bridge/cli.py
+++ b/nt8bridge/cli.py
@@ -11,6 +11,8 @@ from nt8bridge import backtest as ntbacktest
 from nt8bridge import peek as ntpeek
 from nt8bridge import probe as ntprobe
 from nt8bridge import configure as ntconfigure
+from nt8bridge import satemplate as ntsatemplate
+from nt8bridge import analyzerrun as ntanalyzerrun
 from nt8bridge import batch as ntbatch
 from nt8bridge import flatten as ntflatten
 from nt8bridge import watch as ntwatch
@@ -61,6 +63,10 @@ Commands:
   python -m nt8bridge peek                       read latest SA result + param read-back (no run)
   python -m nt8bridge probe                      dump tab/tabStrategyProperties/template props (discover names)
   python -m nt8bridge configure --config c.json  set instrument/dates/bar type/fill/params on the SA tab
+  python -m nt8bridge satemplate --template X.xml  put a NinjaTrader strategy template on the SA tab
+  python -m nt8bridge optimize --template=X.xml --opt=Name:min:max:step  NinjaTrader's parameter search on the SA tab
+  python -m nt8bridge walkforward --template=X.xml --opt=Name:min:max:step [--anchored]  walk-forward optimization on the SA tab
+  python -m nt8bridge multiobjective --template=X.xml --opt=Name:min:max:step  multi-objective optimization on the SA tab
   python -m nt8bridge chartseries --instrument 'MES 09-26' --bars-type Minute --bars-value 5  change a LIVE chart's data series
   python -m nt8bridge histdump --instrument 'MNQ*' --out ./out/PARQUET  offline .nrd -> L1/L2 UTC parquet (default, no NinjaTrader; --nt8 for legacy CSV)
   python -m nt8bridge histget  --instrument 'MNQ 09-26' --from 20260706 --to 20260709  download missing MarketReplay .nrd (RequestMarketReplay per date)
@@ -69,7 +75,8 @@ Commands:
   python -m nt8bridge feedhealth --instrument 'MNQ 09-26' last-tick age (detect FROZEN feed)
   python -m nt8bridge feedwatch  --instrument 'MNQ 09-26' alert on a frozen-but-connected feed (loop)
   python -m nt8bridge connections                read connection status (live/dropped)
-  python -m nt8bridge playback                   replay transport: clock, MOVING?, speed, .nrd coverage
+  python -m nt8bridge playback [--coverage | --instrument 'MNQ 09-26']  replay transport: clock, MOVING?, speed; .nrd coverage only on request (--coverage = every instrument, minutes; --instrument = that one)
+  python -m nt8bridge playbackrun --strategy EmptyStrategy --instrument 'MNQ 09-26' --from 2026-08-10 --to 2026-08-10  playback run: connect, attach, arm, play to the data end, tear down; ONE JSON verdict
   python -m nt8bridge ntstatus                   is NT running the code on disk? (catches a stale DLL)
   python -m nt8bridge workspace                  charts + indicators + strategies AND their enabled state
   python -m nt8bridge strategies                 Control Center strategies: are they enabled? --enable to fix
@@ -151,6 +158,120 @@ def _deploy(strategy: str, kind: str) -> int:
         )
     )
     return 0
+
+
+def _playbackrun_date(value: str) -> str:
+    """argparse `type=` for playbackrun --from/--to: the driver's own check,
+    so this parser refuses exactly what the driver would refuse - and does it
+    before the driver process exists. Measured 2026-09-01: seven runs carried
+    `--to 2026-13-07` into NinjaTrader and each ended, 45-58 s of wall clock later, with
+    "FormatException: String was not recognized as a valid DateTime."
+
+    The import is deferred to this call on purpose. Measured 2026-09-02:
+    importing the driver module reconfigures sys.stdout to UTF-8 (cp1252
+    before, utf-8 after, with stdout redirected to a file), and an import at
+    the top of this module would hand that to every command. From here it
+    reaches only the playbackrun path, whose driver child prints UTF-8 anyway.
+    """
+    from nt8bridge import playback_run as ntplaybackrun
+    return ntplaybackrun.iso_date(value)
+
+
+def _playbackrun(args) -> int:
+    """Playback run: drive nt8bridge/playback_run.py.
+
+    The driver does the work and archives everything; this wrapper's job is the
+    CONTRACT: one JSON object on stdout, exit 0 only for a run that reached the
+    data end (NowEst at ToEst - the sole good exit) AND restored the baseline.
+    When the driver dies without writing a result, the tail of its transcript
+    becomes the error - a caller must never have to open files to learn what
+    went wrong.
+    """
+    import subprocess
+    import tempfile
+    # The driver is a sibling module, but it runs as its own PROCESS on purpose:
+    # it writes a transcript and a result file, and when it dies the tail of that
+    # transcript is the only thing that says why. An import would put that failure
+    # inside this process, where a caller sees a traceback instead of a verdict.
+    driver = os.path.join(os.path.dirname(os.path.abspath(__file__)), "playback_run.py")
+    if not os.path.isfile(driver):
+        print(json.dumps({"command": "playbackrun", "ok": False, "rc": 1,
+                          "error": "driver not found: %s" % driver}, indent=2))
+        return 1
+    tmp = tempfile.mkdtemp(prefix="nt8_playbackrun_")
+    res_path = os.path.join(tmp, "result.json")
+    log_path = os.path.join(tmp, "transcript.log")
+    cmd = [sys.executable, "-u", driver,
+           "--name", args.name or ("PB_" + args.strategy),
+           "--source", args.source,
+           "--tick-replay", args.tickreplay,
+           "--strategy", args.strategy,
+           "--instrument", args.instrument,
+           "--bars-type", args.barsperiod,
+           "--bars-value", str(args.barvalue),
+           "--from", args.from_,
+           "--to", args.to_,
+           "--max-wait", str(args.maxwait),
+           "--setup", "template",
+           "--log", log_path,
+           "--result", res_path]
+    if args.template:
+        cmd += ["--template", args.template]
+    # Both forwarded only when given: without them the driver sends an empty
+    # account, and the AddOn fills in the playback account NinjaTrader names
+    # itself. Passing a literal here would put the default in two places.
+    if getattr(args, "account", None):
+        cmd += ["--account", args.account]
+    # The driver has had this knob all along; it was simply not reachable from
+    # here, so a run through the bridge was stuck with the built-in 10 s / 25 s.
+    # Measured 2026-08-26: a playback connect took 25,040 ms against the 25 s the
+    # connect stage allows - short by 40 ms, and the whole batch stopped at
+    # its first test with "Status=Connecting after 25040 ms (caller allowed 24 s)".
+    # A budget that cannot be raised is a budget that decides the outcome.
+    if getattr(args, "stage_wait", None):
+        cmd += ["--stage-wait", str(args.stage_wait)]
+
+    if args.nt8_dir:
+        cmd += ["--nt8-dir", args.nt8_dir]
+    # The driver prints UTF-8 markers; without this the child would fall back
+    # to the locale codepage and crash on the first one.
+    env = dict(os.environ, PYTHONIOENCODING="utf-8")
+    # No timeout here: the driver bounds every wait itself (per-stage budgets
+    # and the --max-wait play budget). A second deadline on top would be a guess.
+    #
+    # stdout is NOT captured: the driver's console view (one line per phase,
+    # progress, the bot's output window, the closing result JSON) streams
+    # straight through to the user's console - the user watches
+    # the run live (established 2026-08-21). The machine contract moves with it:
+    # the result JSON is the LAST block the driver prints, and the full debug
+    # transcript is in log_path.
+    proc = subprocess.run(cmd, env=env)
+    if os.path.isfile(res_path):
+        try:
+            with open(res_path, encoding="utf-8") as fh:
+                result = json.load(fh)
+        except Exception as ex:  # noqa: BLE001 - the caller still gets a verdict
+            print(json.dumps({"command": "playbackrun", "ok": False,
+                              "rc": proc.returncode or 1,
+                              "error": "result file unreadable: %s" % ex},
+                             indent=2, ensure_ascii=False))
+            return proc.returncode or 1
+        # The driver already printed the result JSON as its closing block -
+        # printing it again would put two JSON objects on stdout.
+        return 0 if result.get("ok") else int(result.get("rc") or 1)
+    try:
+        with open(log_path, encoding="utf-8", errors="replace") as fh:
+            tail = fh.read().splitlines()[-30:]
+    except OSError:
+        tail = []
+    print(json.dumps({
+        "command": "playbackrun", "ok": False, "rc": proc.returncode or 1,
+        "error": "the driver ended without writing a result - the transcript "
+                 "tail carries the reason",
+        "transcript": log_path,
+        "transcriptTail": tail,
+    }, indent=2, ensure_ascii=False))
+    return proc.returncode or 1
 
 
 def _compile(type_name: str, timeout: float) -> int:
@@ -309,11 +430,18 @@ def _restart(task: str, exe: str, wait: float, stop_timeout: float) -> int:
 
 
 def _backtest(config_path: str, timeout: float, pdf=None) -> int:
-    try:
-        cfg = ntconfig.load_config(config_path)
-    except ntconfig.ConfigError as e:
-        print(json.dumps({"command": "backtest", "ok": False, "error": str(e)}, indent=2))
-        return 1
+    # No config: run the tab as it stands. The AddOn only injects params when the
+    # request carries some, so an empty one is a plain Run - the case a preceding
+    # `satemplate` sets up, where the template already holds instrument, window
+    # and parameters and repeating them here would be the drift it removes.
+    if config_path is None:
+        cfg = {}
+    else:
+        try:
+            cfg = ntconfig.load_config(config_path)
+        except ntconfig.ConfigError as e:
+            print(json.dumps({"command": "backtest", "ok": False, "error": str(e)}, indent=2))
+            return 1
     try:
         payload = ntbacktest.run_backtest(cfg, timeout=timeout)
     except TimeoutError as e:
@@ -441,6 +569,46 @@ def _configure(config_path: str, timeout: float) -> int:
     return 0 if payload.get("status") == "ok" else 1
 
 
+def _satemplate(template: str, timeout: float) -> int:
+    try:
+        payload = ntsatemplate.run_satemplate(template, timeout=timeout)
+    except TimeoutError as e:
+        print(json.dumps({"command": "satemplate", "status": "timeout", "ok": False,
+                          "message": str(e)}, indent=2))
+        return 1
+    out = {"command": "satemplate"}
+    out.update(payload)
+    print(json.dumps(out, indent=2))
+    return 0 if payload.get("status") == "ok" else 1
+
+
+def _analyzerrun(args, extra: list) -> int:
+    """optimize / walkforward / multiobjective: one request kind, the mode from
+    the command name. Unknown --Name=value tokens are strategy property
+    overrides, the rule the headless runner (Nt8Cli) applies to the same
+    commands - so `--OptimizationPeriod=10 --TestPeriod=5` works on both."""
+    cmd = args.command
+    try:
+        ntanalyzerrun.parse_opt_spec(args.opt)
+        params = ntanalyzerrun.property_overrides(extra)
+        payload = ntanalyzerrun.run_analyzer(
+            cmd, args.template, args.opt, optimizer=args.optimizer, fitness=args.fitness,
+            anchored=getattr(args, "anchored", False), params=params, timeout=args.timeout)
+    except ValueError as e:
+        print(json.dumps({"command": cmd, "ok": False, "error": str(e)}, indent=2))
+        return 2
+    except TimeoutError as e:
+        print(json.dumps({"command": cmd, "status": "timeout", "ok": False, "message": str(e)},
+                         indent=2))
+        return 1
+    out = {"command": cmd}
+    out.update(payload)
+    if payload.get("status") == "ok":
+        out["csvDelivered"] = ntanalyzerrun.deliver_csvs(payload.get("csvFiles") or [], args.out)
+    print(json.dumps(out, indent=2))
+    return 0 if payload.get("status") == "ok" else 1
+
+
 def _chartseries(args) -> int:
     try:
         payload = ntchartseries.run_chartseries(
@@ -549,9 +717,16 @@ def _connections(timeout: float) -> int:
     return 0 if payload.get("status") == "ok" else 1
 
 
-def _playback(instrument: str | None, timeout: float, require_ready: bool) -> int:
+def _playback(instrument: str | None, coverage: bool, timeout: float, require_ready: bool) -> int:
+    # --require-ready asserts "connected, loaded and PARKED". "Loaded" is a question about the
+    # store, and since the coverage scan became opt-in a request without --coverage or
+    # --instrument does not ask it: the verdict would read "coverage not scanned" and the
+    # assertion could never pass. So the assertion implies the scan - of the one instrument
+    # named, else of every instrument - while the plain report stays scan-free.
+    if require_ready and not instrument:
+        coverage = True
     try:
-        payload = ntplayback.run_playback(instrument, timeout=timeout)
+        payload = ntplayback.run_playback(instrument, coverage, timeout=timeout)
     except TimeoutError as e:
         print(json.dumps({"command": "playback", "status": "timeout", "ok": False, "message": str(e)}, indent=2))
         return 1
@@ -853,9 +1028,51 @@ def main(argv: list[str]) -> int:
                        help="seconds to wait for NT to stop before giving up (it will NOT launch a "
                             "second instance if the stop fails)")
     p_bt = sub.add_parser("backtest")
-    p_bt.add_argument("--config", required=True)
+    p_bt.add_argument("--config", default=None,
+                      help="config.json with the run and its params. Optional: without "
+                           "it the tab is run exactly as it stands, which is what a "
+                           "preceding `satemplate` leaves behind - the template already "
+                           "carries instrument, window and every parameter, and "
+                           "restating them here is the drift it exists to remove.")
     p_bt.add_argument("--timeout", type=float, default=120.0)
     p_bt.add_argument("--pdf", nargs="?", const="report.pdf", default=None)
+    p_pr = sub.add_parser(
+        "playbackrun",
+        help="run a strategy through the Playback connection without a click: "
+             "connect, attach, arm, play to the data end, tear down. Prints ONE "
+             "JSON result; ok only if NowEst reached ToEst AND the baseline was "
+             "restored. Failures name the stage, the sub-step and NinjaTrader's "
+             "own detail line.")
+    p_pr.add_argument("--strategy", required=True, help="strategy class name, e.g. EmptyStrategy")
+    p_pr.add_argument("--instrument", required=True, help="e.g. 'MNQ 09-26'")
+    p_pr.add_argument("--source", choices=["historical", "marketreplay"], default="historical")
+    p_pr.add_argument("--tick-replay", dest="tickreplay", choices=["true", "false"], default="false")
+    p_pr.add_argument("--bars-type", dest="barsperiod", choices=["Tick", "Minute", "Wave"], default="Tick")
+    p_pr.add_argument("--bars-value", dest="barvalue", default="1")
+    # type=: a malformed date is refused here, with the accepted form and the
+    # value, before the driver process exists - see _playbackrun_date.
+    p_pr.add_argument("--from", dest="from_", required=True, type=_playbackrun_date,
+                      help="range start EST, YYYY-MM-DD")
+    p_pr.add_argument("--to", dest="to_", required=True, type=_playbackrun_date,
+                      help="range end EST, YYYY-MM-DD, inclusive; the same day as "
+                           "--from or later")
+    p_pr.add_argument("--account", default=None,
+                      help="account to run on; default is the playback account "
+                           "NinjaTrader names itself. An unknown name stops the run.")
+    p_pr.add_argument("--stage-wait", dest="stage_wait", type=int, default=None,
+                      help="seconds one ordinary stage may take; the connect and "
+                           "Reset stages get 2.5x that. Defaults to the driver's "
+                           "10 / 25. Raise it on a box where NinjaTrader is slow "
+                           "to reach its provider - a connect that misses the "
+                           "budget stops the run, and 25 s is not much when "
+                           "another connection is already up.")
+    p_pr.add_argument("--template", default=None, help="strategy template name (default: bot defaults)")
+    p_pr.add_argument("--name", default=None, help="archive name (default: PB_<strategy>)")
+    p_pr.add_argument("--max-wait", dest="maxwait", type=int, default=40,
+                      help="play-loop budget in rounds of 30 s on the range end")
+    p_pr.add_argument("--nt8-dir", dest="nt8_dir", default=None,
+                      help="NinjaTrader data directory this run talks to. Give "
+                           "each run its own to keep several apart.")
     p_acct = sub.add_parser("account")
     p_acct.add_argument("--name", default="", help="account name filter, e.g. Sim101 (empty = all)")
     p_acct.add_argument("--timeout", type=float, default=15.0)
@@ -879,6 +1096,36 @@ def main(argv: list[str]) -> int:
     p_conf = sub.add_parser("configure")
     p_conf.add_argument("--config", required=True, help="config.json with params to apply to the SA tab")
     p_conf.add_argument("--timeout", type=float, default=30.0)
+    p_satpl = sub.add_parser("satemplate")
+    p_satpl.add_argument("--template", required=True,
+                         help="strategy template: a full path to the .xml, or a bare "
+                              "name looked up in the strategy's own template folder. "
+                              "When it belongs to a different strategy than the tab "
+                              "holds, the strategy is selected first - the other order "
+                              "silently discards the template.")
+    p_satpl.add_argument("--timeout", type=float, default=30.0)
+    # optimize / walkforward / multiobjective share one option set with the
+    # headless runner (Nt8Cli): --template --opt --optimizer --fitness --out, and
+    # --Name=value for any strategy property. allow_abbrev=False so that an
+    # override such as --OptimizationPeriod=10 is never read as an abbreviation.
+    for _cmd in ntanalyzerrun.COMMANDS:
+        p_ar = sub.add_parser(_cmd, allow_abbrev=False,
+                              help=_cmd + " on the SA tab through NinjaTrader's own optimizer")
+        p_ar.add_argument("--template", required=True,
+                          help="strategy template .xml: full path, or a bare name in the "
+                               "strategy's template folder (as satemplate)")
+        p_ar.add_argument("--opt", required=True,
+                          help='"Name:min:max:step[,...]" - the parameters to search')
+        p_ar.add_argument("--optimizer", choices=list(ntanalyzerrun.OPTIMIZERS), default="default")
+        p_ar.add_argument("--fitness", default="",
+                          help="OptimizationFitness class name, e.g. MaxProfitFactor (default: the template's)")
+        p_ar.add_argument("--out", default=None,
+                          help="copy the CSV files the strategy wrote: <out> for one, <out>_<k><ext> for several")
+        p_ar.add_argument("--timeout", type=float, default=ntanalyzerrun.DEFAULT_TIMEOUT,
+                          help="seconds to wait for the run (default %d)" % ntanalyzerrun.DEFAULT_TIMEOUT)
+        if _cmd == "walkforward":
+            p_ar.add_argument("--anchored", action="store_true",
+                              help="anchored walk-forward (in-sample windows grow from the start)")
     p_flat = sub.add_parser("flatten")
     p_flat.add_argument("--name", required=True, help="account to flatten, e.g. Sim101 (REQUIRED)")
     p_flat.add_argument("--instrument", default="", help="limit to one instrument, e.g. 'MNQ 06-26' (empty = all)")
@@ -890,10 +1137,18 @@ def main(argv: list[str]) -> int:
     p_watch.add_argument("--once", action="store_true", help="single scan (no loop) — for testing")
     p_conns = sub.add_parser("connections")
     p_conns.add_argument("--timeout", type=float, default=15.0)
-    p_pb = sub.add_parser("playback", help="replay transport state: clock, MOVING?, speed, .nrd coverage")
-    p_pb.add_argument("--instrument", help="limit .nrd coverage to one instrument (default: all)")
+    p_pb = sub.add_parser("playback", help="replay transport state: clock, MOVING?, speed, "
+                                           ".nrd coverage on request (--coverage or --instrument)")
+    p_pb.add_argument("--instrument", help="scan .nrd coverage for this one instrument only")
+    p_pb.add_argument("--coverage", action="store_true",
+                      help="scan .nrd coverage for EVERY instrument. Costly: the wide scan reads "
+                           "every .nrd on disk and holds the AddOn's poller for minutes "
+                           "(measured 2026-08-19: 3-7 min, 35 instruments). Without --coverage "
+                           "or --instrument the store is not scanned and coverageScanned is false")
     p_pb.add_argument("--require-ready", action="store_true",
-                      help="exit 2 unless the transport is connected, loaded and PARKED (for bake scripts)")
+                      help="exit 2 unless the transport is connected, loaded and PARKED (for bake "
+                           "scripts). Implies the coverage scan: of --instrument when given, else "
+                           "of every instrument")
     p_pb.add_argument("--timeout", type=float, default=30.0)
     p_nts = sub.add_parser("ntstatus", help="is NT running the code on disk? exit 2 if the DLL is newer")
     p_nts.add_argument("--timeout", type=float, default=15.0)
@@ -993,6 +1248,9 @@ def main(argv: list[str]) -> int:
         print(CAPABILITY)
         return 0
 
+    if argv[0] in ntanalyzerrun.COMMANDS:
+        args, extra = parser.parse_known_args(argv)
+        return _analyzerrun(args, extra)
     args = parser.parse_args(argv)
     if args.command == "doctor":
         return _doctor()
@@ -1010,6 +1268,14 @@ def main(argv: list[str]) -> int:
         return _regions(args.root, args.strip, args.all_files)
     if args.command == "restart":
         return _restart(args.task, args.exe, args.wait, args.stop_timeout)
+    if args.command == "playbackrun":
+        # The order check needs both dates, which `type=` sees one at a time.
+        # Same refusal as a malformed date: usage line, exit 2, no driver.
+        from nt8bridge import playback_run as ntplaybackrun  # deferred, see _playbackrun_date
+        order = ntplaybackrun.date_order_error(args.from_, args.to_)
+        if order:
+            p_pr.error(order)
+        return _playbackrun(args)
     if args.command == "backtest":
         return _backtest(args.config, args.timeout, args.pdf)
     if args.command == "account":
@@ -1026,6 +1292,8 @@ def main(argv: list[str]) -> int:
         return _probe(args.timeout)
     if args.command == "configure":
         return _configure(args.config, args.timeout)
+    if args.command == "satemplate":
+        return _satemplate(args.template, args.timeout)
     if args.command == "flatten":
         return _flatten(args.name, args.instrument, args.timeout)
     if args.command == "watch":
@@ -1033,7 +1301,7 @@ def main(argv: list[str]) -> int:
     if args.command == "connections":
         return _connections(args.timeout)
     if args.command == "playback":
-        return _playback(args.instrument, args.timeout, args.require_ready)
+        return _playback(args.instrument, args.coverage, args.timeout, args.require_ready)
     if args.command == "ntstatus":
         return _ntstatus(args.timeout)
     if args.command == "screenshot":

--- a/nt8bridge/ntstatus.py
+++ b/nt8bridge/ntstatus.py
@@ -45,6 +45,9 @@ class NtStatus:
     pid: int | None = None
     process_start: str | None = None
     dll_built: str | None = None
+    sources_newer: bool | None = None   # a .cs under bin\Custom is newer than the executing assembly
+    running_built: str | None = None    # build time of the assembly NinjaTrader executes
+    newest_source: str | None = None
 
 
 def build_ntstatus_request(request_id: str) -> dict:
@@ -77,15 +80,38 @@ def _parse(ts: str | None) -> datetime | None:
 def assess(payload: dict) -> NtStatus:
     """Turn the raw payload into the one judgement callers actually want.
 
-    STALE means the assembly on disk was built AFTER this NinjaTrader process started, so the
-    running process cannot be executing it. That is the 33-minute-wasted-cell condition, and the
-    fix for it is a restart, not another deploy.
+    STALE means NinjaTrader is not running the NinjaScript sources on disk: a .cs under
+    bin\Custom is newer than the assembly the AddOn executes from (`sourcesNewerThanRunningCode`,
+    with `runningAssembly.builtUtc` and `newestSource` reported). When the AddOn could not read
+    one side, the older time rule applies (the DLL built after the process started) and the
+    verdict says so. That is the 33-minute-wasted-cell condition, and the fix for it is a
+    reload or a restart, not another deploy. Measured 2026-09-02/03: NinjaTrader executes a
+    reload from a temp assembly compiled once more from the sources, so neither the DLL's build
+    time nor its identity tells what runs; the time rule answered "restart it" after every
+    reload while the reloaded code was running.
     """
     if payload.get("status") != "ok":
         return NtStatus(ok=False, reason="AddOn returned status=" + str(payload.get("status")))
 
     start = _parse(payload.get("processStartUtc"))
     disk = _parse((payload.get("dllOnDisk") or {}).get("builtUtc"))
+    newer = payload.get("sourcesNewerThanRunningCode")
+    running = (payload.get("runningAssembly") or {}).get("builtUtc")
+    newest = (payload.get("newestSource") or {}).get("path")
+    if isinstance(newer, bool):
+        return NtStatus(
+            ok=True,
+            stale=newer,
+            reason=(f"a source is newer than the running code ({newest}) — NT is running older "
+                    f"code; reload or restart it" if newer
+                    else "the running code is newer than every source on disk — running current code"),
+            pid=payload.get("pid"),
+            process_start=payload.get("processStartUtc"),
+            dll_built=(payload.get("dllOnDisk") or {}).get("builtUtc"),
+            sources_newer=newer,
+            running_built=running,
+            newest_source=newest,
+        )
     if start is None or disk is None:
         return NtStatus(
             ok=True,
@@ -99,10 +125,10 @@ def assess(payload: dict) -> NtStatus:
     stale = disk > start
     mins = abs((disk - start).total_seconds()) / 60.0
     reason = (
-        f"DLL built {mins:.0f} min AFTER NT started — NT is running older code; restart it"
+        f"DLL built {mins:.0f} min AFTER NT started — NT is running older code; reload or restart it"
         if stale
         else f"NT started {mins:.0f} min after the DLL was built — running current code"
-    )
+    ) + " (time rule; the AddOn reported no source comparison)"
     return NtStatus(
         ok=True,
         stale=stale,
@@ -110,6 +136,8 @@ def assess(payload: dict) -> NtStatus:
         pid=payload.get("pid"),
         process_start=payload.get("processStartUtc"),
         dll_built=(payload.get("dllOnDisk") or {}).get("builtUtc"),
+        running_built=running,
+        newest_source=newest,
     )
 
 

--- a/nt8bridge/playback.py
+++ b/nt8bridge/playback.py
@@ -21,14 +21,22 @@ WHAT `coverage` IS FOR
     slider: the slider's bounds are the CONNECTION range you typed, not the indexed data, and
     reading it as proof that data was loaded cost hours on the same day.
 
+    The scan is OPT-IN. Wide, it reads every `.nrd` of every instrument and holds the AddOn's
+    poller for minutes (measured 2026-08-19: 3-7 min, 35 instruments); a named instrument scans
+    just that one. The AddOn scans when the request names an instrument or carries
+    `"coverage": "true"` (the string — that is what the AddOn compares), and it always answers
+    `coverageScanned`, so an unscanned store reads as "not looked", never as "nothing there":
+    the empty list alone cannot tell the two apart.
+
 JSON contract (the in-NT8 AddOn honors):
-  request : {"id": str, "kind": "playback", "instrument": str|None}
+  request : {"id": str, "kind": "playback", "instrument": str|None, "coverage": "true" (optional)}
   response: {"id": str, "status": "ok"|"error", "ts": str,
              "transportResolved": bool,
              "connection": {"status": str, "connected": bool},
              "clockEst": str|None, "clockEstFirst": str|None,
              "sampleMs": int, "movingSec": float, "moving": bool,
              "speed": int|None, "maxSpeedValue": int|None,
+             "coverageScanned": bool,   # absent from an AddOn without the opt-in: read as true
              "coverage": [{"instrument": str, "files": int, "readable": int, "unreadable": int,
                            "from": str|None, "to": str|None, "days": [...]}],
              "errors": [...]}
@@ -49,6 +57,9 @@ class PlaybackState:
     clock_est: str | None = None
     speed: int | None = None
     coverage: list[dict] = field(default_factory=list)
+    # False when the AddOn did not look at the store (no instrument, no coverage opt-in). An
+    # AddOn without the opt-in never writes the key and always scans, so absent means True.
+    coverage_scanned: bool = True
     errors: list[dict] = field(default_factory=list)
 
     def span(self, instrument: str) -> tuple[str | None, str | None]:
@@ -83,15 +94,25 @@ class PlaybackState:
                            "sentinel. Connected is not the same as loaded.")
         if self.moving:
             return False, f"replay clock is advancing (clock {self.clock_est}) — playback is running"
+        # An unscanned store is not an empty store. Without this, a request that named neither an
+        # instrument nor the coverage opt-in came back with coverage [] and read as "nothing to
+        # replay" — a verdict about data nobody had looked at.
+        if not self.coverage_scanned:
+            return False, "coverage not scanned (pass --coverage or --instrument)"
         if not any(c.get("readable", 0) for c in self.coverage):
             return False, "no readable .nrd files on disk — nothing to replay"
         return True, f"transport parked at {self.clock_est}"
 
 
-def build_playback_request(request_id: str, instrument: str | None = None) -> dict:
+def build_playback_request(request_id: str, instrument: str | None = None,
+                           coverage: bool = False) -> dict:
     req = {"id": request_id, "kind": "playback"}
     if instrument:
         req["instrument"] = instrument
+    if coverage:
+        # The string "true", not a JSON bool: the AddOn reads the value with its string
+        # extractor and compares it to "true".
+        req["coverage"] = "true"
     return req
 
 
@@ -104,23 +125,27 @@ def parse_playback_response(payload: dict) -> PlaybackState:
         clock_est=payload.get("clockEst"),
         speed=payload.get("speed"),
         coverage=payload.get("coverage", []),
+        coverage_scanned=bool(payload.get("coverageScanned", True)),
         errors=payload.get("errors", []),
     )
 
 
-def run_playback(instrument: str | None = None, timeout: float = 30.0) -> dict:
+def run_playback(instrument: str | None = None, coverage: bool = False,
+                 timeout: float = 30.0) -> dict:
     """Read replay transport state from the in-NT8 AddOn.
 
     Returns the raw response payload. Raises TimeoutError if the AddOn does not respond — itself
     diagnostic: NT8 is down, or NT8BridgeServer is not loaded/compiled.
 
     Note the default timeout is higher than most read commands: the handler deliberately sleeps
-    between its two clock samples, and coverage walks every .nrd on disk.
+    between its two clock samples. With `coverage` (every instrument) or `instrument` (that one)
+    it also walks the .nrd files; the wide walk took 3-7 min for 35 instruments on 2026-08-19,
+    so a caller asking for it sets the timeout accordingly.
     """
     trigger, result = ntio.ensure_bridge_dirs()
     request_id = new_request_id()
     ntio.atomic_write_json(
         trigger / f"playback_{request_id}.json",
-        build_playback_request(request_id, instrument),
+        build_playback_request(request_id, instrument, coverage),
     )
     return ntio.poll_for_json(result / f"playback_{request_id}.json", timeout=timeout)

--- a/nt8bridge/playback_run.py
+++ b/nt8bridge/playback_run.py
@@ -1,0 +1,2335 @@
+# MIT License
+# Copyright (c) 2026 Quantrosoft Pty. Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+r"""Run ONE Playback measurement end to end over the bridge, and archive it.
+
+The order below was measured by hand on 2026-08-18/19 and renumbered on
+2026-08-20, when switching every connection off became step 1:
+
+    1a alloff       EVERY connection off, from the LIVE list - not from the
+                    configuration, which hid a running connection (see below)
+    1b clean start  strategy rows gone, dialogs closed, transport parked
+    2  connect      source via the adapter statics, BEFORE connecting - and it
+                    waits for the panel transition itself: grey seen -> free
+                    seen -> stable, ~11-18 s, reported as `panel usable`
+    3  source check verify the source took, and report what the panel shows
+    4  dates        start and end into the panel editors, end AFTER start
+    5  range        the same range into the adapter, then Reset - which parks
+                    the clock at the range start
+    6  speed        the panel's paused memory only; writing the adapter static
+                    here would start the transport
+    7  attach       ONE call: add the strategy and enable it. No window, no
+                    dialog, no click - the dialog path WAS the clicking and is
+                    gone. Enable/Disable/Remove go through StrategiesGrid.
+    8  start        the transport is started by WRITING THE SPEED, never by
+                    pressing play
+
+⚠ There is no separate "panel ready" step any more. It waited for the same
+transition as `connect`, and once `connect` waited for it too, the second wait
+demanded an event that was already over: measured 2026-08-20, "never went grey
+within 40000 ms". Trigger and wait belong together, in one step.
+    wait            sample NowEst twice - a single reading cannot tell a parked
+                    clock from a running one, and the play button answers a
+                    different question entirely
+    teardown        ALWAYS, see below
+
+⚠ Step 1 exists because a run has to survive ANY starting situation: nothing
+connected, one live feed, several at once. Playback refuses to connect while
+anything else is up and says so in a MODAL dialog that blocks the dispatcher -
+the bridge then stops answering at all. And the report that was supposed to
+answer "is anything else connected?" was built from the CONFIGURATION: measured
+2026-08-20, it listed six rows without the connection NinjaTrader had open.
+
+Every value written is read back. A run on an unverified setting produces
+numbers nobody can attribute.
+
+THREE GUARANTEES, each paid for with a destroyed measurement
+------------------------------------------------------------
+1.  RESTORE THE BASELINE, ALWAYS. The teardown runs in a `finally`, so an
+    exception, a failed mandatory step or Ctrl-C leaves the same state a clean
+    finish does: transport parked, strategy disabled and removed, no dialog
+    open. Measured 2026-08-19: an aborted attempt left an ObjectDialog and an
+    enabled strategy behind, and the next run started on top of them.
+
+2.  ORDER: range/Reset BEFORE enable. `range` calls PlaybackAdapter.Reset,
+    which rebuilds the transport - NinjaTrader disables the strategy while
+    doing so. Four modes ran with no bot at all: the grid reported
+    IsEnabled=True and not one bot log folder appeared in 90 minutes.
+
+3.  CLOCK PRECONDITION before enable. With the clock PAST the range end,
+    NinjaTrader disables Enable, Disable and Remove - none of them is
+    meaningful for a range already played. The menu then reports "disabled"
+    even though the row is selected correctly. After a Reset to the range
+    start, Enable works on the first try. The transport also restarts BY
+    ITSELF after the Reset, so it must be parked again before the strategy is
+    attached - otherwise the bot joins mid-stream and the runs are not
+    comparable.
+
+Every request carries `ttlSec`. A request that waits longer than that in the
+server's queue is discarded instead of executed - see the AddOn's
+HandleTrigger. Measured 2026-08-19: a backlog released after 11 minutes
+enabled, disabled and removed a strategy in the middle of a running
+measurement.
+
+Before step 1 the run asks the bridge ONE cheap question (stage 0, the
+preflight) - and when nothing answers it KEEPS ASKING, up to PREFLIGHT_WAIT.
+A silent bridge can be a NinjaTrader that is busy, not one that is broken:
+seven archived runs between 2026-08-29 and 2026-09-02 ended with "preflight:
+the bridge did not answer" after a single 20 s ask, and for the last of them
+NinjaTrader's own log shows a Playback connect in progress (05:15:46 ->
+05:22:14, 388 s) that answered nothing meanwhile. Holds of the same kind
+measured 423-453 s (2026-08-28/29) and 735 s for a cold start (2026-09-01).
+The poll reports on the console at most every 30 s, and its wall-clock duration lands
+in result.json as `preflightSeconds`. The one silence it does not wait out:
+no NinjaTrader.exe process at all - the process list is read after every
+unanswered probe, so a NinjaTrader that is not running costs one probe
+(26 s), not the budget, and fails with the same error string. Only a list
+that was READ and does not name the process is that verdict; a list that
+could not be read says nothing, and the poll keeps waiting.
+
+Usage:
+    python playback_run.py --name RUN1 --source historical --tick-replay false \
+        --strategy SampleMACrossOver --instrument "MNQ 09-26" \
+        --bars-type Minute --bars-value 1 --from 2026-08-10 --to 2026-08-14
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import time
+import traceback
+import uuid
+from datetime import date, datetime
+from pathlib import Path
+
+# The process check of the preflight poll - see the PREFLIGHT_WAIT block. ONE
+# implementation, restart.process_listed, reached by the name that resolves in the
+# way this file is running: cli.py starts the driver as its own process BY
+# PATH (`[sys.executable, "-u", driver, ...]`), and there sys.path[0] is this
+# folder, `__package__` is None and only the sibling name resolves; the tests
+# and cli.py's own deferred import load this file as a member of the package,
+# where `__package__` is "nt8bridge" and the package name resolves. Measured
+# 2026-09-02 with sys.path[0] set to this folder, PYTHONPATH empty and the
+# package not installed: `import nt8bridge` -> ModuleNotFoundError, `import
+# restart` -> the sibling file.
+if __package__:
+    from nt8bridge.restart import process_listed as ninjatrader_process_listed
+else:
+    from restart import process_listed as ninjatrader_process_listed
+
+# Every path hangs off the NinjaTrader data directory this run talks to, so
+# --nt8-dir moves trigger, result and archive together. Nothing here is built
+# from a literal carrying a user name.
+_HOME = Path(os.path.expanduser("~"))
+NT8 = _HOME / "Documents" / "NinjaTrader 8"
+TRIG = NT8 / "NT8Bridge/trigger"
+RES = NT8 / "NT8Bridge/result"
+# Where a finished run is archived. --archive overrides it.
+ARCHIVE = NT8 / "NT8Bridge" / "runs"
+# A strategy that writes its own log files can have them collected into the
+# archive - but only its author knows where it writes, so this stays OFF
+# until --bot-logs names a directory.
+BOTLOGS = None
+
+
+def set_nt8_dir(path: str) -> None:
+    """Point the driver at another data directory - trigger, result and the
+    run archive all hang off it. Called once from main(), before the first
+    request is written.
+
+    BOTLOGS is NOT touched here: it names a directory belonging to a
+    strategy, not to NinjaTrader, so only --bot-logs sets it.
+    """
+    global NT8, TRIG, RES, ARCHIVE
+    NT8 = Path(path)
+    TRIG = NT8 / "NT8Bridge/trigger"
+    RES = NT8 / "NT8Bridge/result"
+    ARCHIVE = NT8 / "NT8Bridge" / "runs"
+
+for _s in (sys.stdout, sys.stderr):
+    try:
+        _s.reconfigure(encoding="utf-8")
+    except AttributeError:
+        pass
+
+# ⚠ THE STATE MACHINE FOR EVERY ACTION
+#
+#   1. trigger it
+#   2. wait for the reaction it MUST produce - seconds, not minutes
+#   3. carry on
+#
+# A pure UI operation answers within seconds; a person would not sit through
+# more either. So the budget is small, and running it out is not "slow", it is
+# the finding: NinjaTrader is doing something this stage never asked for. The
+# old 180 s / 900 s budgets hid exactly that - three minutes of silence, a
+# shrugged "PROBLEM", and the actual cause never named.
+#
+# The one genuinely long operation, playing a range, is NOT a stage: it is the
+# sampling loop in main(), which reports once per SAMPLE_S and says why it
+# stopped.
+# ⚠ A STAGE BUDGET IS A GUESS ABOUT SOMEONE ELSE'S MACHINE - SO IT IS A
+# PARAMETER. --stage-wait overrides both numbers below.
+#
+# What they have to cover, measured 2026-08-24: the AddOn's own work per stage
+# is 0-2 ms for everything except the connect (10.7 s, NinjaTrader talking to
+# its provider) and `restore` (1.2 s). What costs the rest is the round trip -
+# a steady ~3 s per request - and the driver sends `uiidle` and `ntlog` around
+# every stage, so one logical step is three requests before any work happens.
+#
+# A machine that is slower, or a NinjaTrader that is busier, needs more, and
+# that has to be settable without editing this file.
+STAGE_WAIT = 10          # any ordinary UI action
+SLOW_WAIT = 25           # Reset / range / speed - NinjaTrader talks to its provider
+
+# ⚠ THE PLAYBACK CONNECT GETS ITS OWN BUDGET - IT DOES NOT SCALE WITH THE UI.
+#
+# Measured 2026-08-28 (NinjaTrader's own trace.20260828.00001.txt): 23 playback
+# connects, each 16-30 s - and ONE that sat in PlaybackAdapter.Connect for
+# 423 s (16:12:08 -> 16:19:11, derived from Core.Connection.Statistics'
+# running mean: 34x38032.3 - 33x26365.3 ms) with zero log lines and zero
+# disk reads while it waited, then came back Connected and served RequestBars
+# normally. The stall is inside NinjaTrader's encrypted Core (not statically
+# readable, see Nt8Tools finding of the same day), so the only place to be
+# correct about it is the caller's budget: a bound of SLOW_WAIT (49 s at the
+# caller's --stage-wait 20) turned that one healthy-but-slow connect into an
+# ERROR, which ended a ~29 h batch of runs that stops on the first one - at
+# the measured 1-in-23 rate such a batch could never finish. The budget
+# must cover the measured worst case, not the typical one; a connect slower
+# than SLOW_WAIT is still REPORTED loudly (see stage 2) so pathology stays
+# visible instead of being averaged away.
+CONNECT_WAIT = 600
+
+# ⚠ THE PREFLIGHT WAITS FOR A BUSY NINJATRADER - IT DOES NOT FAIL ON ONE.
+#
+# Stage 0 asks one cheap `transport` question to learn whether the bridge
+# answers at all. It used to ask ONCE with a 20 s budget and treat silence as
+# "NinjaTrader is not answering - restart it". Seven archived runs ended that
+# way with rc 2 and nothing started (result.json of 2026-08-29 10:12,
+# 2026-08-31 12:12 / 12:15 / 12:18 / 12:21, 2026-09-01 08:47 and 2026-09-02
+# 05:20, every one with wallClockSeconds 88.3-88.4). For the last one
+# NinjaTrader's own log says what it was doing: a Playback connect ran from
+# 05:15:46 to 05:22:14, 388 s, and the run's result.json is stamped 05:20:59
+# - inside that window. Other measured holds of the same kind: 423 / 437 /
+# 453 s on 2026-08-28/29, and a restarted NinjaTrader that wrote nothing to
+# its log for 735 s on 2026-09-01 (a cold start).
+#
+# Why a connect silences EVERY request: the AddOn's poller handles triggers
+# one at a time on one timer thread - Poll() takes a gate (Monitor.TryEnter)
+# and a tick that finds it taken returns without reading a trigger
+# (NT8BridgeServer.cs, Poll/HandleTrigger). Stage_Connect runs on that
+# thread: it calls Connection.Connect and then waits for Status == Connected
+# in a sleep loop bounded by the request budget (NT8BridgeServerPlayback.cs,
+# Stage_Connect), so until the connect returns no trigger is read and no
+# result written. The heartbeat cannot tell: TryBeat writes heartbeat.json
+# through Globals.MainThreadDispatcher, not from the poller thread, so a
+# fresh beat says the UI thread is alive - not that the poller is free.
+#
+# So silence is a WAIT, not a verdict: the driver repeats the probe until one
+# is answered or this budget ends. 1800 s is 2.4x the longest measured silence
+# (735 s) and 4.0-4.6x the measured connects (388-453 s). A budget that ends
+# before the measured worst case turns a healthy NinjaTrader into rc 2 and a
+# batch's stop-on-first-error into a dead batch (the same arithmetic as
+# CONNECT_WAIT); a
+# run that waits costs only the time it waits, and that time is REPORTED -
+# every PREFLIGHT_REPORT_S on the console, and as `preflightSeconds` in
+# result.json - so a slow preflight stays visible instead of averaged away.
+#
+# Each probe keeps the SHORT TTL the single ask always had: the AddOn compares
+# a trigger's age with its ttlSec when it finally reads it (HandleTrigger) and
+# discards a stale one unexecuted, so a probe the poller could not pick up in
+# time can never run late. The driver also takes its own unanswered trigger
+# back before asking again, so a poller that comes back finds ONE probe, not
+# one per probe interval, and the trigger folder is clean after the poll.
+#
+# ⚠ THE ONE SILENCE THAT IS A VERDICT: NO NinjaTrader.exe PROCESS AT ALL.
+#
+# heartbeat.json cannot deliver that verdict. The AddOn writes the file when
+# it has loaded and rewrites it from the main UI dispatcher, so until a cold
+# start has loaded the AddOn the file is absent or left over from the previous
+# session - and the cold start of 2026-09-01 answered nothing for 735 s. A
+# poll that judged on the file would abort exactly the runs it exists for.
+# The process list can deliver it: with no NinjaTrader.exe there is nothing
+# that could ever answer, and every further probe is pure cost. So after each
+# UNANSWERED probe the poll reads the process list once (restart.process_listed,
+# one `tasklist` call; measured 2026-09-02: 0.065-0.072 s per call) and stops
+# at once when the list was read and does not name the process. A NinjaTrader
+# that is not running then costs one probe - PREFLIGHT_PROBE_WAIT plus the 6 s
+# grace of stage(), 26 s, the same 26 s the single ask cost - where the poll
+# alone would have spent the whole budget on it. The verdict keeps the error
+# string of a spent budget, "preflight: the bridge did not answer" (callers
+# match on it), and quotes what tasklist answered on the console and in the
+# transcript. The check comes only AFTER an unanswered probe, never before the
+# first one: a run whose first probe is answered never makes it, so the fast
+# path is unchanged.
+#
+# ⚠ A PROCESS LIST THAT COULD NOT BE READ IS NOT THAT VERDICT. tasklist can be
+# missing from PATH, time out, exit non-zero or print nothing (measured
+# 2026-09-02: an unknown filter exits 1 with nothing on stdout, a missing
+# executable raises FileNotFoundError, a hung one TimeoutExpired); none of
+# that says anything about the process. The first version read every one of
+# those as "not running" and ended the run after one probe with a message
+# that asserted an empty process list nobody had seen. Such a read is now
+# said once per distinct failure, and the silence stays what it was: a wait,
+# up to the budget - whose report then says the process is UNKNOWN, not that
+# it exists.
+PREFLIGHT_WAIT = 1800
+PREFLIGHT_PROBE_WAIT = 20    # TTL of one probe - the 20 s the single ask had
+PREFLIGHT_REPORT_S = 30      # a console line while waiting, at most this often
+
+# ⚠ ARMING IS NOT A UI ACTION - IT IS A DATA LOAD.
+#
+# Behind `attach` NinjaTrader loads the series the strategy asks for. That is
+# minutes for a tick day, not seconds, and it happens on the UI thread, so the
+# whole interface is busy while it runs.
+#
+# Measured 2026-08-20, the SAME attach on the same day and instrument:
+#     1.5 s   NinjaScriptStrategyBaseEnabling1 arrived, run continued
+#    26.1 s   nothing reported within the 25 s budget, then NinjaTrader stayed
+#             busy for another 31 s
+# Same action, different duration - because the second time the data was not
+# already there. A budget of 25 s does not measure the action, it measures my
+# impatience, and then reports a healthy step as failed.
+#
+# This is NOT a timeout in the forbidden sense: nothing here waits for a
+# duration. The wait still ends on NinjaTrader's own log entry; this number is
+# only how long the CALLER is willing to stay - the one bound the rules allow,
+# and it has to be bigger than the work behind the step.
+ARM_WAIT = 420           # attach: the enable plus whatever data it pulls in
+
+# Single-step mode, set from --step in main(). Module level because `stage()` is
+# where every sub-step ends, and a pause that has to be added at each call site is
+# a pause someone will forget at exactly the call site that mattered.
+STEP_MODE = {"on": False}
+
+# The first mandatory step that failed, for the machine-readable result the
+# headless caller gets (result.json). Filled by stage()'s hard stop and by
+# mandatory(); empty step means no step-level failure was recorded.
+FAIL = {"stage": None, "step": None, "detail": None}
+
+# The bots of this run as (strategy, account, template) triples - exactly one
+# entry, filled from --strategy / --account / --template.
+BOTS = []
+
+
+class _Tee:
+    """Write to the console AND to a file, without a pipe in between.
+
+    A pipe would buffer, and a buffered prompt is invisible - the run then looks
+    hung at the very moment it is waiting for the user.
+    """
+
+    def __init__(self, stream, path) -> None:
+        self.stream = stream
+        self.fh = open(path, "a", encoding="utf-8", buffering=1)
+
+    def write(self, s) -> int:
+        self.stream.write(s)
+        try:
+            self.fh.write(s)
+        except ValueError:
+            pass
+        return len(s)
+
+    def flush(self) -> None:
+        self.stream.flush()
+        try:
+            self.fh.flush()
+        except ValueError:
+            pass
+
+
+class _FileOnly:
+    """The debug sink of the end-user console mode: everything print()ed goes
+    into the transcript file ONLY - the console stays clean for user() lines.
+
+    Requirement (2026-08-21): no debug output in the user console. Where
+    debug output is needed it belongs in a second console or in a log file.
+    """
+
+    def __init__(self, path) -> None:
+        self.fh = open(path, "a", encoding="utf-8", buffering=1)
+
+    def write(self, s) -> int:
+        try:
+            self.fh.write(s)
+        except ValueError:
+            pass
+        return len(s)
+
+    def flush(self) -> None:
+        try:
+            self.fh.flush()
+        except ValueError:
+            pass
+
+
+# The REAL console, saved before any redirect. In user mode sys.stdout becomes
+# the transcript file, so this is the only way user() lines still reach the eye.
+_CONSOLE = sys.__stdout__
+# user_mode: console shows ONLY the end-user view (one line per phase, plus the
+# bot's output-window lines prefixed [BOT]); the full debug transcript goes to
+# the --log file. on_progress: the last console write was a CR-overwritten
+# progress line, so a normal line must terminate it with a newline first.
+_UI = {"user_mode": False, "on_progress": False}
+
+
+def user(text: str = "") -> None:
+    """One line for the END USER's console - and into the transcript, so the
+    log file stays the complete record."""
+    if not _UI["user_mode"]:
+        print(text, flush=True)      # debug mode: the tee reaches both already
+        return
+    if _UI["on_progress"]:
+        _CONSOLE.write("\n")
+        _UI["on_progress"] = False
+    _CONSOLE.write(text + "\n")
+    _CONSOLE.flush()
+    print(text, flush=True)          # stdout is the transcript file here
+
+
+def user_progress(text: str) -> None:
+    """A progress line, overwritten in place with CR - never flooding the
+    console. The transcript gets it as a normal line."""
+    if not _UI["user_mode"]:
+        print(text, flush=True)
+        return
+    width = 110
+    _CONSOLE.write("\r" + text[:width].ljust(width))
+    _CONSOLE.flush()
+    _UI["on_progress"] = True
+    print(text, flush=True)
+
+
+def step_pause(label: str) -> None:
+    """Stop until the user presses a key. Only in --step mode."""
+    if not STEP_MODE["on"]:
+        return
+    print("")
+    print("   " + "=" * 66)
+    print(f"   PAUSED after: {label}")
+    print("   Press ENTER to run the next sub-step, or type q + ENTER to stop.")
+    print("   " + "=" * 66)
+    try:
+        answer = input("   > ").strip().lower()
+    except EOFError:
+        # no console attached - do not silently run on, that would defeat the mode
+        raise RuntimeError("--step needs a console; stdin is closed")
+    if answer.startswith("q"):
+        print("   [key registered: q] stopping. Teardown follows.")
+        raise KeyboardInterrupt(f"stopped by the user at: {label}")
+    # ⚠ ACKNOWLEDGE THE KEYPRESS IMMEDIATELY.
+    #
+    # Requirement (2026-08-20): a person always needs feedback on their action.
+    # The next stage can take 15 s before it prints anything, so without this line
+    # the console sits silent after the key and the only honest reading is "did it
+    # register?". A prompt that answers nothing invites a second press, and a
+    # second press runs a sub-step nobody asked for.
+    print("   [key registered] running the next sub-step ...")
+
+
+def heartbeat_age() -> float:
+    """Age of heartbeat.json in seconds, -1.0 when there is none.
+
+    The AddOn rewrites the file once per second from Globals.MainThreadDispatcher
+    (TryBeat), so its age is NinjaTrader's own statement about THAT UI thread.
+    It is reported as a measurement, never used as a deadline. And it answers
+    for that one thread only: the AddOn reads and answers triggers on its own
+    poller thread, so a fresh beat does not say that thread is free - see the
+    PREFLIGHT_WAIT block for the measurement behind that.
+    """
+    try:
+        return time.time() - (RES / "heartbeat.json").stat().st_mtime
+    except OSError:
+        return -1.0
+
+
+def stage(title: str, req: dict, wait: int = None, show: bool = True,
+          report_miss: bool = True, lease: int = 120) -> dict:
+    """Submit one playbackrun stage and wait for its result.
+
+    `ttlSec` is the server-side guarantee that a request we stopped waiting for
+    is never executed later.
+
+    `report_miss=False` keeps the NO REACTION report out of the transcript. That
+    report is written for a step whose run ENDS on the silence ("not waiting
+    longer, that IS the finding"); a caller that asks AGAIN on silence records
+    each miss in its own words (preflight()). Measured 2026-09-02 with the real
+    stage(), no AddOn, budget 100 s: four unanswered probes wrote that verdict
+    four times, with the poll's own "asking again" between them - 25 lines
+    whose record contradicted itself once per probe, up to 70 times per
+    PREFLIGHT_WAIT. The returned dict is the same either way.
+
+    ⚠ `wait=STAGE_WAIT` IN THE SIGNATURE WAS A BUG, NOT A DEFAULT. A default
+    argument is evaluated ONCE, when the def runs at import, so raising
+    STAGE_WAIT in main() reached every call that passes `wait=` explicitly and
+    none of the ones relying on the default. Measured in a single run: connect
+    reported "caller allowed 74 s" while `source check` was still cut off at
+    10 s + grace. Resolving it here, at call time, is what makes the setting
+    apply.
+    """
+    if wait is None:
+        wait = STAGE_WAIT
+    # ⚠ A UNIQUE id per request, never a running number.
+    #
+    # Measured 2026-08-19: with ids pl001, pl002, ... a teardown read six result
+    # files left in the directory by a run on 18.08 17:06 - they existed the
+    # instant the trigger was written, so the poll returned yesterday's answer
+    # before NinjaTrader had done anything. Five steps reported "ok" and one
+    # reported a `dialogset` step that this stage never runs. A reused name turns
+    # the result directory into a source of silent wrong answers.
+    rid = uuid.uuid4().hex
+    req = dict(req)
+    req["id"] = rid
+    req["kind"] = "playbackrun"
+    req["ttlSec"] = wait
+    # If this driver is killed, the AddOn restores the baseline itself after
+    # this many seconds. A killed process cannot run its own teardown -
+    # measured three times on 2026-08-19, each time the user found the mess.
+    #
+    # The AddOn counts from the moment it ANSWERED the previous request (not
+    # from the receipt: measured 2026-09-07, a 282 s connect outlived a lease
+    # taken at receipt and the AddOn tore down the connection it had just
+    # built). `lease=0` is the clean exit: the run's last requests send it, so
+    # a finished run leaves nothing that fires two minutes later.
+    req["leaseSec"] = lease
+    out = RES / (f"playbackrun_{rid}.json")
+    try:
+        out.unlink()          # belt and braces: never poll onto a pre-existing file
+    except FileNotFoundError:
+        pass
+    t0 = time.time()
+    _UI["last_permille"] = -1        # a fresh stage starts its own progress line
+    (TRIG / (f"playbackrun_{rid}.json")).write_text(json.dumps(req), encoding="utf-8")
+    # ⚠ POLL AT 100 ms, NOT 1 s.
+    #
+    # The old loop slept a full second between checks, so every stage cost at
+    # least ~1 s of pure granularity even when the AddOn answered in 50 ms. Across
+    # a dozen setup stages that was most of the setup time - and it was ours, not
+    # NinjaTrader's. Measured per stage below, so the claim stays checkable.
+    # ⚠ LISTEN LONGER THAN THE SERVER'S OWN BUDGET.
+    #
+    # `ttlSec` is what the AddOn may spend, and it is allowed to spend ALL of it -
+    # its internal waits are bounded by exactly this number. Polling for the same
+    # span means an answer written at the boundary arrives one sample too late,
+    # and the run reports NO REACTION for a stage that did answer.
+    #
+    # Measured twice on 2026-08-20: `connect` answered after 122 s while the client
+    # gave up at 120 s, and `attach` answered at 14:28:17 with a complete result
+    # after the client had already declared it dead at 25 s. Both times the finding
+    # was real and the report was wrong about where it came from.
+    #
+    # The grace is the client's own patience, not a second deadline for the server.
+    GRACE = 6.0
+    # Live sub-step feed. The AddOn appends one line per completed sub-step to
+    # playbackrun_<id>.progress.txt the moment it happens, plus "->" markers
+    # naming each call that is about to run on the UI thread. The result JSON
+    # only exists once the whole stage RETURNS - measured 2026-08-20 (runs 5
+    # and 8): the UI thread died inside the enable and nothing showed how far
+    # the stage had got. Tailing this file is what shows WHERE a run dies,
+    # while it dies.
+    prog = RES / (f"playbackrun_{rid}.progress.txt")
+    prog_pos = [0]
+    def feed_progress() -> None:
+        try:
+            data = prog.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return
+        new = data[prog_pos[0]:]
+        if not new:
+            return
+        prog_pos[0] = len(data)
+        if show:
+            for ln in new.splitlines():
+                print(f"   [{title.strip()}] {ln}", flush=True)
+    # UI-liveness: heartbeat_age() is reported as a measurement, not used as a
+    # deadline - the wait stays bounded by ttlSec alone.
+    for _i in range(int((wait + GRACE) / 0.1)):
+        if out.exists():
+            feed_progress()
+            d = json.loads(out.read_text(encoding="utf-8"))
+            if show:
+                print(f"--- {title} ---   ({time.time() - t0:.1f} s)")
+                if d.get("status") == "expired":
+                    print("   EXPIRED - server dropped it, not executed")
+                for s in d.get("steps", []):
+                    print(f"   {s['step'].strip()[:30]:<30} "
+                          f"{'ok' if s['ok'] else 'FAIL':<6} {s['detail'][:78]}")
+            shot(title)          # look at what the stage actually did
+
+            # ⚠ HANDSHAKE BETWEEN THE STEPS, NOT ONLY INSIDE THEM.
+            #
+            # Every stage waits for its OWN effect and then returns - while
+            # NinjaTrader keeps working. The next stage used to fire into exactly
+            # that. Measured 2026-08-20: the same `attach` came back in 1.9 s when
+            # the user stepped through by hand and left its enable operation
+            # Pending when the steps ran back to back. His keypresses had been
+            # supplying the missing handshake.
+            #
+            # `uiidle` posts a delegate at ApplicationIdle and reports when the
+            # dispatcher has drained its queue - NinjaTrader's own signal, no
+            # duration guessed anywhere. It is sent HERE rather than at each call
+            # site, because a handshake that has to be remembered per call is one
+            # that will be missing exactly where it mattered.
+            if show and req.get("stage") not in ("uiidle", "ntlog", "transport",
+                                                 "strategystate"):
+                idle = stage("   ui idle", {"stage": "uiidle"}, wait=wait, show=False)
+                bad = [s for s in idle.get("steps", []) if not s.get("ok")]
+                if not idle.get("steps"):
+                    print("   ui idle                        NO ANSWER - NinjaTrader is "
+                          "still working; the next step would fire into that")
+                elif bad:
+                    print(f"   ui idle                        STILL BUSY: {bad[0]['detail'][:70]}")
+                else:
+                    drained = [s["detail"] for s in idle.get("steps", [])
+                               if s["step"].strip().startswith("idle ")]
+                    print(f"   ui idle                        {'; '.join(drained)[:74]}")
+
+            # ⚠ HARD STOP ON A FAILED STEP - BEFORE any pause.
+            #
+            # Asked for on 2026-08-20: hard stop on errors like these. Until then
+            # the pause came first, so a FAIL was followed by "Press ENTER to run
+            # the next sub-step" - an invitation to build on a step that did not do
+            # what it says. Every later measurement would then rest on it.
+            #
+            # ANY failed step stops the run, not only the ones a call site listed
+            # as mandatory. A step that reports FAIL did not do its job; deciding
+            # afterwards that it did not matter is how four empty modes once got
+            # pulled through and archived as a result.
+            # ⚠ ONLY VISIBLE STEPS. Measured 2026-08-20: applied to every call, the
+            # hard stop killed a healthy run twice on `strategystate`, an internal
+            # READ whose `terminated` step used ok as a data field. A probe that
+            # reports a state is not an action that failed. Visible steps are the
+            # ones that DO something; those are the ones nothing may be built on.
+            failed = [s for s in d.get("steps", [])
+                      if not s.get("ok")] if show else []
+            if failed:
+                print("")
+                print("   " + "!" * 66)
+                print(f"   HARD STOP - a step reported FAIL in: {title}")
+                for s in failed:
+                    print(f"   {s['step'].strip()[:28]:28} {s.get('detail', '')[:96]}")
+                print("   Nothing further runs on top of it. Teardown follows.")
+                print("   " + "!" * 66)
+                FAIL.update(stage=title.strip(), step=failed[0]["step"].strip(),
+                            detail=failed[0].get("detail", ""))
+                raise RuntimeError(f"{title}: {failed[0]['step'].strip()} - "
+                                   f"{failed[0].get('detail', '')[:200]}")
+
+            if show:
+                step_pause(title)
+            return d
+        time.sleep(0.1)
+        feed_progress()
+        # ⚠ SHOW THAT IT IS STILL ALIVE.
+        #
+        # A stage that talks to NinjaTrader can be quiet for its whole budget -
+        # `connect` measured 10.5 s to Connected, and before the fix it sat out
+        # the full 25 s. The console showed one line and then nothing, which is
+        # indistinguishable from a hang: the operator closed the window on a run
+        # that was working (2026-08-24).
+        #
+        # One line, overwritten in place with CR, so it never scrolls the
+        # transcript away - the same shape the closing result block uses. It is
+        # written to the CONSOLE only; the transcript already has the stage's own
+        # lines and does not need 250 progress samples per stage.
+        # The shape is not invented here. It is the progress line the headless
+        # runner already writes, so a run over the bridge and a run beside it read
+        # the same:
+        #     "\r" + <data time> + "Progress | " + label + " | " + pct + " %   "
+        # emitted only when the permille CHANGED, which is what keeps it one line
+        # instead of a stream. No bar, no seconds - percent, like everywhere else.
+        #
+        # No time in front here: a stage that is connecting has no stream time
+        # yet, and a wall clock on a progress line is exactly what must not
+        # appear. The data time comes back on the play loop, which has one.
+        if _UI["user_mode"]:
+            _pm = int(min(1.0, (time.time() - t0) / max(wait, 1)) * 1000)
+            if _pm != _UI.get("last_permille"):
+                _UI["last_permille"] = _pm
+                # ⚠ PAD TO A FIXED WIDTH. A carriage return moves the cursor, it
+                # does not erase: a shorter line leaves the tail of the longer one
+                # behind it, and the console then reads
+                #     Progress | ntlog | 10.0 %   %   %   1.1 %
+                # which is three dead labels and one live number. The blanks are
+                # what removes them.
+                _CONSOLE.write(f"\r{title} | {_pm / 10.0:.1f} %".ljust(100))
+                _CONSOLE.flush()
+                _UI["on_progress"] = True
+        # Report the heartbeat age every ~10 s while it is stale. The beat is
+        # 1 s when the UI thread runs; an age of minutes IS the freeze, live.
+        if show and (_i % 100) == 99:
+            _age = heartbeat_age()
+            if _age > 5.0:
+                print(f"   [{title.strip()}] ! heartbeat.json is {_age:.0f} s old "
+                      f"(UI dispatcher rewrites it every 1 s - the UI thread is not "
+                      f"running)", flush=True)
+    # ⚠ THIS VERDICT BELONGS TO A STEP THAT STOPS HERE. A caller that asks
+    # again on silence passes report_miss=False and records the miss itself;
+    # with the verdict printed anyway, its transcript read "not waiting longer"
+    # and "asking again" back to back, once per probe (see the docstring).
+    if report_miss:
+        print(f"--- {title} ---   ({time.time() - t0:.1f} s)")
+        print(f"   ⚠ NO REACTION in {wait + GRACE:.0f} s "
+              f"(server budget {wait:d} s + {GRACE:.0f} s grace).")
+        print("   A UI action answers in seconds. This means NinjaTrader is busy with")
+        print("   work this stage never asked for - not waiting longer, that IS the finding.")
+        feed_progress()
+        _age = heartbeat_age()
+        if _age >= 0:
+            print(f"   heartbeat.json age: {_age:.0f} s (the UI dispatcher rewrites it "
+                  f"every 1 s while the UI thread runs)")
+        if prog_pos[0] == 0:
+            print("   progress file: never written - the stage did not reach its first "
+                  "sub-step (or the AddOn build predates the progress channel)")
+    # Pause here too - but only for a VISIBLE step. Measured 2026-08-20: the
+    # teardown's own `restore` got no answer while the transport was running at max
+    # speed, and single-step mode stopped there waiting for a keypress. A teardown
+    # cleans up; it does not measure, and it must never sit and wait while an armed
+    # strategy runs on a moving transport.
+    if show:
+        step_pause(title + "  [NO REACTION]")
+    # The id travels back like it does in an answered result, so a caller that
+    # gave up can take its own trigger out of the folder (see preflight()).
+    return {"status": "noreaction", "steps": [], "id": rid}
+
+
+# Where this run's screenshots go. Set by main() before the first stage.
+_shots = {"dir": None, "n": 0}
+
+
+def shot(label: str) -> None:
+    """Capture NinjaTrader's own windows after an action.
+
+    An action is not verified until it has been LOOKED at. The bridge takes the
+    picture inside NinjaTrader, which is the only way to reach the monitor the
+    Control Center actually sits on (measured 2026-08-19: it is at Left=-942, and
+    a desktop capture of the primary screen never shows it).
+
+    Never raises - a missing picture must not end a run.
+    """
+    if _shots["dir"] is None:
+        return
+    _shots["n"] += 1
+    for title in ("Control Center", "Playback"):
+        rid = uuid.uuid4().hex
+        out = RES / (f"screenshot_{rid}.json")
+        png = _shots["dir"] / (f"{_shots['n']:02d}_{label.replace(' ', '-')}_"
+                               f"{title.split()[0].lower()}.png")
+        try:
+            out.unlink()
+        except FileNotFoundError:
+            pass
+        (TRIG / (f"screenshot_{rid}.json")).write_text(
+            json.dumps({"id": rid, "kind": "screenshot", "title": title,
+                        "out": str(png), "ttlSec": 120}), encoding="utf-8")
+        for _ in range(120):
+            if out.exists():
+                break
+            time.sleep(1)
+
+
+# ---------------------------------------------------------------------------
+# NinjaTrader's OWN log, through the AddOn's in-memory Cbi.Log buffer.
+#
+# ⚠ These three were CALLED in six places and DEFINED NOWHERE - not in this
+# file, not in any backup, not in git (checked 2026-08-20 across commit
+# 0a403be and every .bak in the workbench). Every one of those paths would have
+# died with NameError, and a syntax-only check reports such a file as fine,
+# because Python resolves names at run time. Only a name check finds it.
+#
+# ⚠ MATCH ON THE NAME, NOT ON THE TEXT. A buffer line is
+#     time|LogLevel|LogCategory|Name|ResourceType|Message
+# and field 3 is the resource name NinjaTrader passed to Log.Process - the same
+# on any UI language and across versions. The message is only its rendering.
+
+
+# How many bot-output lines the AddOn had seen at the last read, so the next call
+# asks for exactly what arrived in between - same contract as nt_index().
+#
+# It is a running COUNT, not a position in the buffer: the buffer is a ring and
+# drops from the front, so a slot index would stop meaning anything the moment it
+# wraps. The AddOn hands back that count as `nowIndex` and converts it back into a
+# slot on its side.
+_bot_out = {"since": 0}
+
+
+def bot_output(lease: int = 120) -> list:
+    """The bot's Print() lines written since the last call.
+
+    NinjaTrader routes every NinjaScript Print() through one static event
+    (NinjaTrader.Code.Output.OutputEvent, measured 2026-08-21); the AddOn
+    subscribes from its poller and buffers, this reads the buffer and moves the
+    index on. So the console can show harness lines and [BOT] lines together
+    in one stream.
+
+    ⚠ OUTPUT ONLY, never evidence. Goal 1 is a bot that prints NOTHING - no
+    step may wait for a line from here or conclude anything from one.
+    """
+    d = stage("botout", {"stage": "botout", "since": str(_bot_out["since"])},
+              wait=STAGE_WAIT, show=False, lease=lease)
+    lines, dropped = [], None
+    for s in d.get("steps", []):
+        k = s["step"].strip()
+        if re.match(r"^o\d+$", k):
+            lines.append(s["detail"])
+        elif k == "nowIndex":
+            try:
+                _bot_out["since"] = int(s["detail"])
+            except ValueError:
+                pass
+        elif k == "dropped" and not s.get("ok"):
+            dropped = s["detail"]
+    if dropped:
+        # A ring buffer that overflowed has LOST bot output - say it, never let
+        # a gap pass as silence.
+        print(f"   [BOT] !! output buffer overflowed: {dropped}", flush=True)
+    return lines
+
+
+def print_bot_output(lease: int = 120) -> None:
+    """Show what the bot printed since the last look, prefixed [BOT] so harness
+    and bot lines stay distinguishable in one console. `lease=0` marks the run's
+    last request (the fetch after the teardown) as the clean exit."""
+    for ln in bot_output(lease=lease):
+        for part in ln.splitlines() or [ln]:
+            user(f"[BOT] {part}")
+
+
+def nt_index() -> int:
+    """Where NinjaTrader's log buffer stands right now, so a later call can ask
+    what arrived IN BETWEEN instead of guessing when to look."""
+    d = stage("ntlog index", {"stage": "ntlog", "since": "2000000000"}, show=False)
+    for s in d.get("steps", []):
+        if s["step"].strip() == "index":
+            try:
+                return int(s["detail"])
+            except ValueError:
+                return 0
+    return 0
+
+
+def nt_entries(since: int, contains: str = None) -> list:
+    """Every entry NinjaTrader wrote after index `since`.
+
+    With `contains` the AddOn filters SERVER-SIDE, so only matching lines
+    count against its cap. That matters because the cap hits the OLDEST
+    entries first: Stage_Ntlog walks `for (i = from; i < snap.Count; i++)`
+    and breaks at `++shown >= 60`, so an unfiltered call returns the 60
+    oldest lines of the window - never the newest.
+
+    Measured 2026-08-30: a playback connect emitted 21,578 lines in 11.6 s
+    (one per recording, from the "12-99" alias junctions the NRD decoder
+    needs). The buffer holds NtLogMax = 2000, so NtLogOffset returned 0 -
+    correctly, "everything still held" - and the caller received that
+    window's first 60, all of them alias noise. NinjaTrader had logged
+    "Connected" as the YOUNGEST entry of the same window. The check
+    reported "never logged ... 60 entries seen" and the run aborted 9 s
+    later, on a connection that was up.
+    """
+    req = {"stage": "ntlog", "since": str(since)}
+    if contains:
+        req["contains"] = contains
+    d = stage("ntlog", req, show=False)
+    return [s["detail"] for s in d.get("steps", [])
+            if re.match(r"^e\d+$", s["step"].strip())]
+
+
+def nt_name(entry: str) -> str:
+    """The resource name of one buffer line - field 3, or "" if the line is short."""
+    parts = entry.split("|")
+    return parts[3].strip() if len(parts) > 3 else ""
+
+
+def nt_check(since: int, expect: str = None, contains: str = None, what: str = "") -> list:
+    """Report what NinjaTrader itself logged since `since`, and abort on an error.
+
+    `expect` is a resource NAME, not a message. With `contains`, the message of
+    the matching entry must also carry that text - the same pair the AddOn's
+    WaitForLogName uses, so both sides identify an event the same way.
+
+    Fails loudly: an Error entry, or a missing expectation, raises. A step that
+    reports "ok" for an action NinjaTrader complained about is worse than no
+    check at all.
+    """
+    entries = nt_entries(since)
+    # The expectation gets its OWN, server-side filtered query. The
+    # unfiltered list above is capped at the 60 OLDEST lines of the window
+    # (Stage_Ntlog: `if (++shown >= 60) break;`), while the awaited event is
+    # always among the newest - so searching it there succeeds only while
+    # the buffer is quiet. See nt_entries for the measurement.
+    expect_pool = nt_entries(since, contains=expect) if expect else entries
+    # Sound playback is cosmetics, not the action under test. Measured
+    # 2026-08-21: in an RDP session without an audio device NinjaTrader logs
+    #   |Error|...|CoreSoundThreadProc|...|Failed to play sound file
+    #   '...Connected.wav': BadDeviceId calling waveOutOpen
+    # for the CONNECT chime - the connection itself was up. Treating that as
+    # fatal aborted the run before it ever reached the stage being tested.
+    #
+    # Measured 2026-08-30: the same holds for the alias junctions the NRD
+    # decoder needs. `db\replay\<SYM> 12-99` is a junction onto the
+    # `<SYM> ##-##` store - NT8 formats the MaxDate sentinel expiry
+    # 2099-12-01 as "12-99" and DumpMarketDepth looks there (a store-side
+    # junction of that name points back at the real store). NinjaTrader then SEES
+    # EVERY RECORDING TWICE and logs the second view as
+    #   |Error|Connection|AdapterPlaybackAdapterInit|Resource|Playback file
+    #   '...\db\replay\YM 12-99\20200715.nrd' is corrupted and will be skipped
+    # It says "will be skipped" and means it. Proof, two runs of the same day
+    # on the same data: a headless Market Replay run (NinjaTrader's engine
+    # hosted without its GUI) logged 21,578 of
+    # these lines in its own instance log AND completed - "Range played;
+    # NowEst=27.08.2026 23:59:59", exit 0, 34,010,547 Cbi events, 100 % of the
+    # range. The bridge aborted at stage 'connect' with rc 2 on the identical
+    # store. So the recordings are intact and NinjaTrader carries on; only this
+    # check stopped.
+    #
+    # Narrowed on a count, not on a hunch: in that same log 21,578 of 21,578
+    # such lines name a " 12-99" path and none names anything else. A genuinely
+    # damaged recording surfaces under its REAL contract (" ##-##" or e.g.
+    # "MNQ 09-26") and still aborts the run, as it must.
+    #
+    # Only these two measured patterns are excused; every other Error aborts.
+    errors = [e for e in entries
+              if "|Error|" in e
+              and "CoreSoundThreadProc" not in e
+              and not ("is corrupted and will be skipped" in e
+                       and " 12-99" in e)]
+    if errors:
+        raise RuntimeError(f"NinjaTrader logged an error during '{what}': {errors[0][:200]}")
+    if expect:
+        hit = [e for e in expect_pool
+               if nt_name(e) == expect and (not contains or contains.lower() in e.lower())]
+        if not hit and not entries:
+            # ⚠ NO SOURCE IS NOT A NEGATIVE RESULT.
+            #
+            # With ZERO entries the log channel said nothing at all - it cannot
+            # confirm the effect and it cannot deny it either. Measured
+            # 2026-08-24 in the GUI-less host: the connection object reported
+            # "Status=Connected after 11369 ms" while this read 0 entries, and
+            # aborting there threw away a connect that had demonstrably worked.
+            #
+            # An empty instrument is reported as empty. The moment entries DO
+            # arrive and the expected one is missing, that is evidence of
+            # absence and still aborts, below.
+            print(f"   nt: no log entries available during '{what}' - this channel "
+                  f"could not confirm {expect}"
+                  f"{'/' + contains if contains else ''}. Not treated as its absence; "
+                  f"the step's own read-back stands.")
+        elif not hit:
+            raise RuntimeError(
+                f"NinjaTrader never logged {expect}"
+                f"{'/' + contains if contains else ''} during '{what}' - "
+                f"{len(entries):d} entries seen. "
+                f"The action returned, its effect did not appear.")
+        else:
+            print(f"   nt: {hit[0][:150]}")
+    elif entries:
+        print(f"   nt: {len(entries):d} entr{'y' if len(entries) == 1 else 'ies'} "
+              f"since '{what}', last: {entries[-1][:120]}")
+    return entries
+
+
+def clock_vs_end() -> tuple:
+    """(NowEst, moving, ToEst) - the run is over when NowEst reaches ToEst.
+
+    Both values come from PlaybackAdapter, so this works for any strategy and
+    needs no GUI element.
+    """
+    d = stage("clockend", {"stage": "transport"}, wait=STAGE_WAIT, show=False)
+    v = {str(s.get("step", "")).strip(): str(s.get("detail", "")) for s in d.get("steps", [])}
+    raw = v.get("NowEst", "")
+    a_, _, b_ = raw.partition("->")
+    now = (b_.strip() or a_.strip()) or None
+    moving = bool(a_.strip() and b_.strip() and a_.strip() != b_.strip())
+    to = v.get("ToEst", "").strip() or None
+    return now, moving, to
+
+
+def preflight(budget: float = None, clock=time.monotonic, sleep=time.sleep,
+              process=None) -> dict:
+    """Ask the bridge ONE cheap question - and keep asking until it answers.
+
+    Returns {"answered": bool, "steps": list, "seconds": float, "probes": int,
+    "process": dict | None} and never raises: the caller decides what an
+    unanswered preflight means. `seconds` is the wall clock the poll took -
+    the one quantity a wall clock is right for - and goes into result.json as
+    `preflightSeconds`. `process` is the LAST reading of the process list,
+    {"listed": True | False | None, "detail": str} as restart.process_listed
+    returns it, or None when no reading was made (the first probe answered).
+    An unanswered preflight always carries one: `listed` is False only when
+    the poll stopped because the list was read and does not name
+    NinjaTrader.exe (see below), None when the last read failed.
+
+    ⚠ SILENCE IS A WAIT, NOT A VERDICT - up to `budget` (PREFLIGHT_WAIT). See
+    that block for the measurements: a Playback connect keeps the AddOn's
+    single poller thread busy for 388-453 s, a cold start answers nothing for
+    735 s, and no request of any kind is answered meanwhile.
+
+    ⚠ EXCEPT ONE: NO NinjaTrader.exe PROCESS. After each unanswered probe the
+    poll reads the process list once (`process`, restart.process_listed by
+    default) and stops at once when the list was read and does not name the
+    process - nothing could ever answer, so a NinjaTrader that is not running
+    costs one probe, not the budget. Never before the first probe: an
+    answered fast path makes no check. A list that could NOT be read is no
+    verdict: it is said on the console once per distinct failure, and the
+    poll goes on waiting.
+
+    Each probe is one `transport` request with the short TTL
+    PREFLIGHT_PROBE_WAIT, so the AddOn discards a probe it reads late instead
+    of executing it (HandleTrigger compares the trigger's age with ttlSec).
+    An unanswered probe is taken back out of the trigger folder before the
+    next one is written; that keeps the folder at ONE pending probe and leaves
+    it empty after the poll. A result that came back WITHOUT steps (an
+    `expired` or `error` file) is a reaction, not an answer: the poller is
+    reading triggers again, so the next probe follows after one poller tick
+    (the AddOn polls once per second) instead of in a hot loop.
+
+    An unanswered probe that is asked again leaves ONE line in the transcript,
+    the poll's own "no answer to probe N ... asking again" (plus the user line
+    every PREFLIGHT_REPORT_S); the last one is recorded by the caller's verdict.
+    The probes are sent with report_miss=False: stage()'s NO REACTION report
+    declares the silence final, and this poll does not - see the stage()
+    docstring for the transcript that had both, once per probe.
+
+    `clock`, `sleep` and `process` are parameters so a test can run the poll
+    in milliseconds and decide what the process list says; the defaults are
+    the real ones.
+    """
+    if budget is None:
+        budget = PREFLIGHT_WAIT      # at call time - see `wait` in stage()
+    if process is None:
+        process = ninjatrader_process_listed     # at call time, like `budget`
+    t0 = clock()
+    last_report = None
+    last_process = None          # the last reading of the process list
+    unreadable_said = None       # the failure text already on the console
+    probes = 0
+    while True:
+        probes += 1
+        # report_miss=False: the miss is recorded below, in the poll's own
+        # words; the stage's NO REACTION verdict is written for a step that
+        # stops on silence, and this one asks again.
+        d = stage("0 preflight", {"stage": "transport", "sampleMs": "200"},
+                  wait=PREFLIGHT_PROBE_WAIT, show=False, report_miss=False)
+        elapsed = clock() - t0
+        if d.get("steps"):
+            if probes > 1:
+                # Loud, like SLOW CONNECT: a run that had to wait says so on
+                # the console, in seconds of wall clock.
+                user(f"Bridge answered after {elapsed:.0f} s ({probes:d} probes) - "
+                     f"NinjaTrader was busy; the run continues.")
+            return {"answered": True, "steps": d.get("steps", []),
+                    "seconds": elapsed, "probes": probes, "process": last_process}
+        # Take the unanswered probe back. Gone already = the AddOn consumed it
+        # and is either executing it (blocked) or has discarded it as expired.
+        # A file that cannot be removed is left to the TTL, which guarantees
+        # the same thing: it is never executed late.
+        rid = d.get("id")
+        if rid:
+            try:
+                (TRIG / (f"playbackrun_{rid}.json")).unlink()
+            except OSError:
+                pass
+        # The one silence that is a verdict - see the PREFLIGHT_WAIT block.
+        # Read here, after the probe was taken back and before the budget is
+        # judged, so a dead process is named even on the round the budget ends.
+        listed, detail = process()
+        last_process = {"listed": listed, "detail": detail}
+        if listed is False:
+            user(f"NinjaTrader.exe is not running - {detail}; no process can "
+                 f"answer a probe, so the poll stops after probe {probes:d} "
+                 f"({elapsed:.0f} s of {budget:.0f} s).")
+            return {"answered": False, "steps": [], "seconds": elapsed,
+                    "probes": probes, "process": last_process}
+        if listed is None and detail != unreadable_said:
+            # Not a verdict - nothing was measured about the process. Said
+            # once per distinct failure, not once per probe.
+            unreadable_said = detail
+            user(f"The process list could not be read after probe {probes:d} "
+                 f"({detail}) - whether NinjaTrader.exe is running is not "
+                 f"known, so the silence stays a wait.")
+        if elapsed >= budget:
+            return {"answered": False, "steps": [], "seconds": elapsed,
+                    "probes": probes, "process": last_process}
+        print(f"   [0 preflight] no answer to probe {probes:d} "
+              f"({elapsed:.0f} s of {budget:.0f} s) - asking again", flush=True)
+        if last_report is None or elapsed - last_report >= PREFLIGHT_REPORT_S:
+            last_report = elapsed
+            age = heartbeat_age()
+            beat = (f" (heartbeat.json is {age:.0f} s old - the main UI thread's "
+                    f"beat, not the poller thread's)" if age >= 0 else "")
+            user(f"NinjaTrader is busy - no answer for {elapsed:.0f} s, "
+                 f"waiting up to {budget:.0f} s{beat}")
+        if d.get("status") != "noreaction":
+            sleep(1.0)
+
+
+def restore_baseline(strategy: str) -> list:
+    """Put NinjaTrader back with ONE call. Never raises.
+
+    ⚠ The AddOn does the work; this only reports it.
+
+    It used to be ten stages from here - park, disable, remove, answer, close -
+    each with its own budget. Measured 2026-08-19: whenever NinjaTrader was busy
+    (which is exactly when a cleanup is needed) that cost minutes, and the user
+    watched an enabled strategy sit there while this tool "cleaned up". The
+    AddOn's `restore` stage disconnects first - the universal abort, and the one
+    thing proven to stop the transport - then clears rows and dialogs, and
+    answers in about 5 s.
+    """
+    # lease=0: the teardown is the clean exit. Every request before it re-armed
+    # the AddOn's lease; without the release the AddOn restored the baseline a
+    # second time two minutes after every finished run (bridge.log 2026-09-07
+    # 06:26:06Z, 06:24:01Z - after the 08:24:09 teardown).
+    d = stage("restore", {"stage": "restore"}, wait=30, show=False, lease=0)
+    steps = d.get("steps", [])
+    ok = bool(steps) and all(s.get("ok") for s in steps)
+    if not steps:
+        print("   teardown: NO REACTION - NinjaTrader is busy. Cleanup is queued, "
+              "not repeated; piling more requests on a blocked queue is what "
+              "produced the backlog on 2026-08-19.")
+    else:
+        for s in steps:
+            print(f"   teardown {s['step'].strip()[:16]:<16} "
+                  f"{'ok' if s.get('ok') else 'PROBLEM':<6} "
+                  f"{str(s.get('detail', ''))[:50]}")
+    print(f"   baseline {'clean' if ok else 'NOT clean'}")
+    return [{"step": "restore", "ok": ok, "detail": d}]
+
+
+def _iso_day(stamp: str) -> str:
+    """Day part of a NinjaTrader stamp as ISO, so it can be compared with --to.
+
+    ⚠ The two sides speak different date formats. NinjaTrader formats the stamp
+    for the machine's locale, so it can arrive as `dd.MM.yyyy HH:mm:ss`, while
+    `--to` is always ISO `yyyy-MM-dd`. The old check compared the two AS STRINGS:
+
+        '11.08.2026' < '2026-08-10'   ->   True
+
+    which is broken in both directions and was measured on 2026-08-19:
+      * it fired on days 01-20 of ANY month, so a complete run was reported as
+        "cut short" - it flagged this very comparison run, and the reference run
+        from the dialog path carries the same false MISMATCH.txt;
+      * it can never fire on days 21-31, so a genuinely truncated run there passes
+        unnoticed.
+
+    A check that both cries wolf and goes blind is worse than none, because the
+    false alarms teach everyone to ignore the true ones.
+    """
+    s = (stamp or "").strip()
+    if len(s) >= 10 and s[2] == "." and s[5] == ".":
+        return f"{s[6:10]}-{s[3:5]}-{s[0:2]}"
+    if len(s) >= 10 and s[4] == "-" and s[7] == "-":
+        return s[:10]
+    return ""
+
+
+
+def wait_for_enable_event(strategy: str, since: int, timeout: float) -> str | None:
+    """Wait for NinjaTrader's own "Enabling NinjaScript strategy" entry.
+
+    Reads the AddOn's buffer of Cbi.Log events - not the log FILE, and never the
+    Output window, which is entirely bot-written. Any Error entry in between aborts
+    immediately instead of waiting out the deadline.
+    """
+    needle = f"Enabling NinjaScript strategy '{strategy}"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        # Same cap as in nt_check: unfiltered this returns the 60 OLDEST
+        # lines, and the enable line is the newest. Filter server-side.
+        entries = nt_entries(since, contains=needle)
+        for e in entries:
+            if "|Error|" in e:
+                raise RuntimeError(f"NinjaTrader reported an error while arming: {e[:200]}")
+        hit = [e for e in entries if needle.lower() in e.lower()]
+        if hit:
+            return hit[0][:160]
+        time.sleep(1.0)
+    return None
+
+
+
+# --from/--to are checked at argument time - by the CLI parser and by this
+# driver's own parser (iso_date, date_order_error) - and by no stage afterwards.
+#
+# Measured 2026-09-01: seven archived runs (05:16 to 08:23) carried
+# "to": "2026-13-07". Nothing checked the value on the way in - the CLI
+# declared both dates as plain strings and the AddOn hands them to
+# DateTime.Parse as they arrive - so every one of them ran stage 1a, lasted
+# 45-58 s of wall clock, and died with
+#     2 connect: exception - FormatException: String was not recognized as
+#     a valid DateTime.
+# A month 13 must never reach NinjaTrader.
+#
+# The shape is pinned by the pattern and not by date.fromisoformat alone:
+# measured on Python 3.11.9, fromisoformat also accepts "20260607" and
+# "2026-W23-1", two shapes nobody documented. The pattern refuses the shape
+# (2026-7-7, 07/07/2026), fromisoformat refuses the calendar (month 13,
+# 30 February), and both refusals name the accepted form and the value sent.
+DATE_FORMAT = "YYYY-MM-DD"
+_DATE_SHAPE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def iso_date(value: str) -> str:
+    """argparse `type=` for --from and --to: exactly YYYY-MM-DD and a real
+    calendar day, returned as the SAME string - the request JSON and the
+    archive carry what was typed. Refuses with the accepted form and the
+    offending value."""
+    if not _DATE_SHAPE.match(value):
+        raise argparse.ArgumentTypeError(
+            f"'{value}' is not a date of the form {DATE_FORMAT}")
+    try:
+        date.fromisoformat(value)
+    except ValueError as ex:
+        raise argparse.ArgumentTypeError(
+            f"'{value}' is not a calendar date ({DATE_FORMAT}: {ex})") from None
+    return value
+
+
+def order_notice_counts(detail: str) -> tuple[int, int]:
+    """(this sample, this run) from the AddOn's "order notices" step text.
+
+    The `strategystate` stage answers `N dismissed this sample, M in this run`
+    for NinjaTrader's order-rejection notice ("Stop price can't be changed above
+    the market") it confirmed - see DismissOrderRejectNotices in the AddOn. An
+    absent or unreadable step (an AddOn built before the step existed) reads as
+    (0, 0): nothing was confirmed, nothing is claimed.
+    """
+    m = re.match(r"\s*(\d+) dismissed this sample, (\d+) in this run", detail or "")
+    if not m:
+        return 0, 0
+    return int(m.group(1)), int(m.group(2))
+
+
+def date_order_error(date_from: str, date_to: str) -> str | None:
+    """The check `type=` cannot make, because it sees one value at a time:
+    the range end must not lie before its start (the same day is a one-day
+    run). Returns the refusal text, or None for a usable pair."""
+    if date.fromisoformat(date_to) < date.fromisoformat(date_from):
+        return (f"--to {date_to} lies before --from {date_from}; the range "
+                f"end must be the same day as the start or later")
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--nt8-dir", dest="nt8_dir", default=None,
+                    help="NinjaTrader data directory this run talks to;"
+                         " default ~/Documents/NinjaTrader 8")
+    ap.add_argument("--archive", default=None,
+                    help="where the finished run is written;"
+                         " default <nt8-dir>/NT8Bridge/runs")
+    ap.add_argument("--bot-logs", dest="bot_logs", default=None,
+                    help="directory a strategy writes its own logs to. Any"
+                         " entry that appears there during the run is copied"
+                         " into the archive. Off unless given.")
+    ap.add_argument("--name", required=True)
+    ap.add_argument("--source", choices=["historical", "marketreplay"], required=True)
+    ap.add_argument("--tick-replay", dest="tickreplay", choices=["true", "false"], required=True)
+    # No default: a strategy name is a fact about the caller's installation,
+    # and guessing one turns "you forgot an argument" into "that strategy does
+    # not exist", which points at the wrong problem.
+    ap.add_argument("--strategy", required=True)
+    ap.add_argument("--account", default=None,
+                    help="account the strategy runs on; default is the playback"
+                         " account NinjaTrader names itself. An account that does"
+                         " not exist stops the run - it is not swapped for another.")
+    ap.add_argument("--instrument", default="MNQ 09-26")
+    # Only these three build a bar-type token below; anything else used to fall
+    # through to the Minute token, so `--bars-type Day` silently ran a Minute
+    # series. argparse rejects it now instead.
+    ap.add_argument("--bars-type", dest="barsperiod", choices=["Tick", "Minute", "Wave"], default="Wave")
+    ap.add_argument("--bars-value", dest="barvalue", default="120")
+    ap.add_argument("--trading-hours", dest="tradinghours", default=None,
+                    help="trading-hours template name to force on the strategy "
+                         "(exact installed name; the attach step lists all names "
+                         "on a miss). Default: the instrument's own template.")
+    # type=iso_date: refused at parse time, before anything below runs -
+    # see the block above iso_date for the seven runs that made it so.
+    ap.add_argument("--from", dest="date_from", required=True, type=iso_date,
+                    help=f"range start EST, {DATE_FORMAT}")
+    ap.add_argument("--to", dest="date_to", required=True, type=iso_date,
+                    help=f"range end EST, {DATE_FORMAT}, inclusive; the same day "
+                         "as --from or later")
+    ap.add_argument("--max-wait", dest="maxwait", type=int, default=40,
+                    help="play-loop budget, in units of 30 s")
+    # ⚠ SINGLE-STEP MODE. The run stops after every visible sub-step and waits for
+    # a keypress. The pause belongs HERE, in the script, not in whoever is watching
+    # it: a step that only pauses when someone remembers to pause it is not a
+    # controlled run. Requested by the user on 2026-08-20 so each sub-step can be
+    # inspected before the next one changes the state it was measured in.
+    ap.add_argument("--step", action="store_true",
+                    help="stop after every sub-step and wait for a keypress")
+    # (The interactive --attach-only hold mode - load the strategy and then
+    # pause - was removed 2026-08-21 once the enable freeze was
+    # fixed at its root: the run is headless now. The AddOn keeps the `arm`
+    # stage and attach's enable:false for hand-driven diagnosis.)
+    # ⚠ EMPTY for the Playback path, and that is not an oversight.
+    #
+    # Playback needs every other connection DOWN - when playback is switched on,
+    # every other connection MUST be closed first (2026-08-20).
+    # `keep` exists for a future Strategy Analyzer path, which needs the
+    # opposite: a LIVE connection up and no Playback at all.
+    #
+    # It doubles as a free build probe. A name that matches nothing changes no
+    # outcome - everything is disconnected either way - but only the newer AddOn
+    # reports a `kept up on request` step, so the answer says which build the
+    # running process is executing.
+    ap.add_argument("--keep", default=None,
+                    help="connection names that must NOT be disconnected, comma "
+                         "separated. Leave empty for Playback.")
+    # A transcript that does not depend on a pipe. `tee` between the console and
+    # this process would also buffer the prompts, and a prompt nobody sees is a
+    # run that looks hung - so the file is written from inside instead.
+    # The machine-readable contract for a headless caller (the nt8bridge CLI):
+    # the same result.json every run archives, written additionally to a path
+    # the caller chose, so it never has to parse human output for the verdict.
+    ap.add_argument("--result", default=None,
+                    help="also write the run's result.json to this path "
+                         "(for the headless CLI caller)")
+    ap.add_argument("--log", default=None,
+                    help="write everything printed to this file as well")
+
+    ap.add_argument("--rc-file", dest="rc_file", default=None,
+                    help="also write the exit code to this file. Behind a "
+                         "pipe a cmd chain sees the pipe's code, not ours.")
+    ap.add_argument("--stage-wait", dest="stage_wait", type=int, default=None,
+                    help="seconds a single stage may take (default 10). The "
+                         "connect budget scales with it. Raise it on a slow "
+                         "machine or a busy NinjaTrader: the round trip alone "
+                         "costs about 3 s per request, and a logical step is "
+                         "three of them.")
+    ap.add_argument("--debug-console", action="store_true",
+                    help="mirror the FULL debug transcript to the console. "
+                         "Default: the console shows only the end-user view "
+                         "(harness + bot output window); debug goes to --log.")
+    # `dialog` is gone, not deprecated: the AddOn no longer contains a single click, and
+    # the dialog path WAS the clicking (context menu, tree selection, OK button). The
+    # option is kept only so an old command line fails LOUDLY instead of silently doing
+    # something else.
+    ap.add_argument("--setup", choices=["dialog", "template"], default="template",
+                    help="template = the click-free `attach` call (the only path). "
+                         "dialog = removed on 2026-08-19, aborts with an explanation.")
+    ap.add_argument("--template", default=None,
+                    help="template name, or a full path to the .xml. The bare name is "
+                         "resolved in the folder NinjaTrader reports for THIS bot.")
+    a = ap.parse_args()
+    # The order check needs both values, which `type=` sees one at a time.
+    # Still at argument time: nothing has been written or sent yet.
+    _order = date_order_error(a.date_from, a.date_to)
+    if _order:
+        ap.error(_order)
+
+    # Before the first request: TRIG and RES are read by every helper below,
+    # so a late override would split one run across two data directories.
+    if a.nt8_dir:
+        set_nt8_dir(a.nt8_dir)
+
+    # The stage budgets, before the first stage is sent. See the block comment
+    # on STAGE_WAIT: headless, one dispatcher carries both the stages and the
+    # message pump, so the GUI's numbers are too tight there.
+    global STAGE_WAIT, SLOW_WAIT, CONNECT_WAIT, PREFLIGHT_WAIT
+    if a.stage_wait:
+        STAGE_WAIT = a.stage_wait
+    SLOW_WAIT = int(STAGE_WAIT * 2.5)     # the ratio the GUI numbers already had
+    # never below its measured floor, however small --stage-wait is; a huge
+    # --stage-wait may still raise it further (see the CONNECT_WAIT block)
+    CONNECT_WAIT = max(600, SLOW_WAIT)
+    # the same floor rule for the preflight (see the PREFLIGHT_WAIT block)
+    PREFLIGHT_WAIT = max(1800, SLOW_WAIT)
+
+    # AFTER set_nt8_dir, never before: --nt8-dir recomputes ARCHIVE, so an
+    # explicit --archive applied first would be silently overwritten.
+    global ARCHIVE, BOTLOGS
+    if a.archive:
+        ARCHIVE = Path(a.archive)
+    if a.bot_logs:
+        BOTLOGS = Path(a.bot_logs)
+
+    # Set BEFORE anything is printed, so the transcript carries the whole run and
+    # the first sub-step already pauses.
+    #
+    # Two console modes. Only three things belong in the end-user console:
+    # what the CLI itself prints, one harness line per phase, and everything
+    # the strategy wrote to the output window:
+    #   default        console = end-user view, --log file = full debug transcript
+    #   --debug-console console = everything (the old tee), for debugging only
+    if not a.log and not a.debug_console:
+        # The debug transcript must land SOMEWHERE - without it a failed run
+        # would be undiagnosable. No wall-clock stamp in the name (name + pid
+        # identify the file); the content carries data-stream times only.
+        Path("logs").mkdir(exist_ok=True)
+        a.log = str(Path("logs")
+                    / f"{a.name or 'playbackrun'}_pid{os.getpid():d}_transcript.log")
+    if a.debug_console:
+        if a.log:
+            sys.stdout = _Tee(sys.stdout, a.log)
+            sys.stderr = _Tee(sys.stderr, a.log)
+            print(f"=== transcript -> {a.log} ===")
+    else:
+        _UI["user_mode"] = True
+        sys.stdout = _FileOnly(a.log)
+        # stderr keeps reaching the console: an uncaught traceback IS the
+        # meaningful error message the caller was promised.
+        sys.stderr = _Tee(sys.__stderr__, a.log)
+        print(f"=== transcript -> {a.log} ===")
+    # ONE bot per pass. The driver accepted several until 2026-08-26, when the
+    # idea was measured: two bots on one connection took 1163.8 s for a week of
+    # Market Replay against roughly 606 s for one, so they SHARE the replay walk
+    # rather than parallelising it. The two-variant pass came to 1214.6 s against
+    # 1311.7 s sequential - 7.4 %, and that saving was the second connect it
+    # avoided, not the bots.
+    BOTS.clear()
+    BOTS.append((a.strategy, (a.account or "").strip(), (a.template or "").strip()))
+
+
+    STEP_MODE["on"] = bool(a.step)
+    if a.step:
+        print("=== SINGLE-STEP MODE: stops after every sub-step ===")
+
+    # The end-user header: a parameter table first, then one line per phase,
+    # then the progress line.
+    user(f"NT8 playback run: {a.name or a.strategy}")
+    user("-" * 62)
+    for k, v in (("Strategy", ", ".join(f"{b}{'@' + acc if acc else ''}"
+                                        f"{' [' + tm + ']' if tm else ''}"
+                                        for b, acc, tm in BOTS)),
+                 ("Instrument", a.instrument),
+                 ("Source", f"{a.source}  (TickReplay {a.tickreplay})"),
+                 ("Period", f"{a.barsperiod} {a.barvalue}"),
+                 ("Window", f"{a.date_from} .. {a.date_to}"),
+                 ("Template", a.template or "(bot defaults)"),
+                 ("Transcript", a.log or "-")):
+        user(f"| {k:12} | {v}")
+    user("-" * 62)
+
+    # ⚠ --template IS OPTIONAL, and it has to be.
+    #
+    # The goal of this remote control is to be BOT-INDEPENDENT and to work with a
+    # completely empty strategy. Demanding a hand-made template per bot is the
+    # opposite of that: a bot with no parameters has nothing to put in one.
+    #
+    # The bridge never needed it. `attach` handles the empty case itself and says
+    # so - measured in NT8BridgeServerPlayback.cs:
+    #     if (string.IsNullOrWhiteSpace(tmplD)) { ... step("template", true, "none - defaults"); }
+    # Only this script forbade it. Instrument, bar type, range and Tick Replay come
+    # from the request either way; a template only adds the bot's own parameters.
+    if a.setup == "dialog":
+        ap.error("--setup dialog no longer exists. Configuring through the Strategies "
+                 "window meant clicking (context menu, tree selection, OK button), and the "
+                 "AddOn is click-free since 2026-08-19. Use: --setup template --template <name>")
+
+    target = ARCHIVE / (f"{a.name}_{a.instrument.replace(' ', '')}_"
+                        f"{a.date_from.replace('-', '')}_{a.date_to.replace('-', '')}")
+    n = 1
+    base = target
+    while target.exists():
+        n += 1
+        target = base.with_name(base.name + f"__{n:d}")
+    target.mkdir(parents=True)
+    _shots["dir"] = target / "shots"
+    _shots["dir"].mkdir(exist_ok=True)
+    log = []
+
+    def note(d: dict) -> dict:
+        log.append(d)
+        return d
+
+    def mandatory(d: dict, *keys) -> dict:
+        """Abort on the first failed MANDATORY step.
+
+        Measured 2026-08-18/19: the chain pulled four modes through although
+        enabling failed in every one - four empty cells, 90 minutes, and
+        "archived" at the end. A run that logs failures and carries on is worse
+        than one that stops: it looks like a result.
+        """
+        bad = [s for s in d.get("steps", [])
+               if not s.get("ok") and any(k.lower() in s["step"].lower() for k in keys)]
+        if not d.get("steps"):
+            bad = [{"step": "(no answer)", "detail": "stage returned nothing"}]
+        if d.get("status") == "expired":
+            bad = [{"step": "(expired)", "detail": "server dropped the request, not executed"}]
+        if bad:
+            print("")
+            print("⚠ ABORT - mandatory step failed:")
+            for s in bad:
+                user(f"ERROR: {s['step'].strip()} - {s.get('detail', '')[:140]}")
+            for s in bad:
+                print(f"   {s['step'].strip()[:28]:28} {s.get('detail', '')[:90]}")
+            (target / "ABORT.txt").write_text(
+                json.dumps(bad, indent=2, ensure_ascii=False), encoding="utf-8")
+            FAIL.update(stage=d.get("stage") or FAIL.get("stage"),
+                        step=bad[0]["step"].strip(),
+                        detail=bad[0].get("detail", ""))
+            raise RuntimeError(f"mandatory step failed: {bad[0]['step'].strip()} - "
+                               f"{bad[0].get('detail', '')[:200]}")
+        return d
+
+    # BOTLOGS is None unless --bot-logs named a directory, so the guard tests
+    # the constant itself before touching it.
+    before = (set(p.name for p in BOTLOGS.iterdir())
+              if BOTLOGS and BOTLOGS.exists() else set())
+    # ⚠ Wall-clock duration - the one quantity a wall clock is right for.
+    # It says how long the MACHINE took; everything about the DATA is stamped
+    # from the stream. The assignment was lost in a restructure and the run
+    # crashed with NameError while reporting (2026-08-19) - after the
+    # measurement, so nothing was falsified, but the run counted as failed.
+    wall_start = time.time()
+    rc = 0
+    teardown = []
+    # For the machine-readable result the headless caller reads (result.json):
+    # how the run ended, and the message of the exception that ended it early.
+    end_reason = "aborted-before-play"
+    err_text = None
+    terminated = played = False
+    end_gap = False   # pre-set like `played`: an abort before the play loop
+                      # must not NameError in the end_reason chain
+    # Wall clock of the preflight poll (stage 0), for result.json. Pre-set so
+    # an abort before it ran still reports a number.
+    preflight_s = 0.0
+
+    try:
+        # ⚠ CONFIGURE WHILE DISCONNECTED. Measured 2026-08-19, both halves:
+        #
+        #   player running  -> the ObjectDialog VANISHES between `select strategy`
+        #                      (ok) and `data series` ("no ObjectDialog found");
+        #                      "Enable" comes back greyed; bridge calls queue for
+        #                      minutes behind the transport.
+        #   disconnected    -> the same seven fields all write and read back:
+        #                      Type=Wave, Wave Size=120, Tick Replay=False,
+        #                      Account=Playback101, Label, Instrument=MNQ 09-26.
+        #
+        # A transport at Max speed saturates NinjaTrader's single UI thread, and the
+        # dialog does not survive that. Disconnecting is also the ONLY reliable stop
+        # found: toggling btnPlay six times left the clock running, while a
+        # disconnect gave timer.Enabled=False and RealtimeTickCount delta=0.
+        # ⚠ CONNECTED **AND** PARKED before touching the dialog. Two separate
+        # requirements, and confusing them cost a NinjaTrader crash on 2026-08-19:
+        #
+        #   connection DOWN -> the account does not exist. The Account combo still
+        #       reports `wrote ComboBox.Text=Playback101 read=Playback101` - that is
+        #       the TEXT, not the bound account - and confirming the dialog raises
+        #       "Trying to add realtime strategy with no account"
+        #       (Cbi.Log.Assert <- StrategiesGrid.StrategyAdd). NinjaTrader had to be
+        #       restarted. A read-back that checks a string instead of the binding is
+        #       not a verification.
+        #
+        #   transport RUNNING -> the ObjectDialog vanishes between two bridge calls
+        #       and "Enable" comes back greyed; a Max-speed player saturates
+        #       NinjaTrader's single UI thread.
+        #
+        # Measured directly after `connect`: timer.Enabled=True, RealtimeTickCount
+        # +1/s (the idle beat), NowEst 10.08. 00:00:00 -> 00:00:02 over six seconds.
+        # Connected and quiet - which is exactly the window to configure in.
+        # ================================================================
+        # ⚠ PREFLIGHT: DOES THE BRIDGE ANSWER AT ALL? IF NOT YET: WAIT.
+        #
+        # Measured 2026-08-20: a run was started into a NinjaTrader that was still
+        # blocked from the previous attempt. Its very first request - reading the
+        # log index - got no answer in 16 s, `alloff` none in 96 s, and the whole
+        # transcript read like a fresh failure of step 1. It was not: the state was
+        # already broken before the run began, and every line after that measured
+        # the wrong thing.
+        #
+        # So the first thing a run does is ask ONE cheap question - and when it
+        # goes unanswered, ask it AGAIN, up to PREFLIGHT_WAIT (see that block
+        # for the measurements). Nothing else is sent meanwhile: piling
+        # requests onto a blocked queue is what produced the backlog on
+        # 2026-08-19, and a report built on top of it is worse than no report.
+        # Each probe carries a short TTL and is taken back when unanswered, so
+        # the queue holds at most this one question.
+        #
+        # ⚠ SILENCE IS NOT "RESTART NINJATRADER". Seven archived runs between
+        # 2026-08-29 and 2026-09-02 aborted here after one 20 s ask, with the
+        # advice to clear the trigger folder and restart. For the last of them
+        # NinjaTrader's own log shows a Playback connect in progress (388 s on
+        # 2026-09-02); the connect runs on the AddOn's single poller thread,
+        # so no trigger is read until it returns, and the run only had to
+        # wait. Holds of the same kind measured 423-453 s (2026-08-28/29)
+        # and 735 s for a cold start (2026-09-01). The poll waits out every
+        # silence but one: the process list, read after the probe, does not
+        # name NinjaTrader.exe - nothing could ever answer, so that one is
+        # refused after the first unanswered probe (see the PREFLIGHT_WAIT
+        # block). A list that could not be read is not that one.
+        # ⚠ ONLY "DID IT ANSWER" - NOT "were all steps ok".
+        #
+        # First attempt asked this visibly, and the hard stop killed the run on
+        # `timer  field 'timer' not found or null` - which is the NORMAL reading
+        # before Playback is connected. The probe was right, the verdict was mine:
+        # a stage whose steps legitimately fail in the pre-connect state cannot be
+        # used as a pass/fail gate. show=False keeps the hard stop out of it, and
+        # the only question asked here is whether an answer came back at all.
+        pre = preflight()
+        preflight_s = pre["seconds"]
+        order_notices_total = 0     # NinjaTrader order-rejection notices the AddOn confirmed in this run
+        if pre["answered"]:
+            user("Bridge connected.")
+            # Throw away output-window lines that predate this run - measured
+            # 2026-08-21: the first poll returned a Terminated census from the
+            # PREVIOUS session, which read like output of this run.
+            bot_output()
+        print("--- 0 preflight - does the bridge answer ---")
+        _n_steps = len(pre["steps"])
+        _answered = f"yes, {_n_steps:d} step(s)" if _n_steps else "NO"
+        print(f"   bridge answered               {_answered}")
+        print(f"   preflight wall clock          {preflight_s:.1f} s, "
+              f"{pre['probes']:d} probe(s), budget {PREFLIGHT_WAIT:d} s")
+        # The last reading of the process list - never None once the preflight
+        # went unanswered (the poll reads it after every unanswered probe).
+        _proc = pre["process"]
+        if not pre["answered"] and _proc["listed"] is False:
+            # The one verdict the poll passes itself - see the PREFLIGHT_WAIT
+            # block. The error string is the one a spent budget raises, so a
+            # caller sees ONE signature for "nothing answered"; the cause is
+            # here and in the user line the poll already printed - as what
+            # tasklist answered, not as a claim about the process list.
+            print("")
+            print("   " + "!" * 66)
+            print("   NinjaTrader.exe is not running. The process list was read after probe")
+            print(f"   {pre['probes']:d} ({preflight_s:.0f} s) and does not name it; measured:")
+            print(f"      {_proc['detail']}")
+            print("   NOTHING was started.")
+            print("   Nothing can answer a probe without the process, so the poll did not")
+            print(f"   wait out its budget ({PREFLIGHT_WAIT:d} s). Start NinjaTrader, sign in,")
+            print("   let the AddOn load (it writes heartbeat.json when it has), then run")
+            print("   again.")
+            print("   " + "!" * 66)
+            raise RuntimeError("preflight: the bridge did not answer")
+        if not pre["answered"]:
+            _age = heartbeat_age()
+            print("")
+            print("   " + "!" * 66)
+            print(f"   NinjaTrader answered NO request for {preflight_s:.0f} s "
+                  f"(budget {PREFLIGHT_WAIT:d} s). NOTHING was started.")
+            print("   The measured causes of this signature end by themselves and are")
+            print("   covered by the budget: a Playback connect keeping the AddOn's poller")
+            print("   thread busy (388 s on 2026-09-02, 423/437/453 s on 2026-08-28/29,")
+            print("   NinjaTrader's own log) and a cold start (735 s on 2026-09-01). This")
+            print("   silence is longer than every measured one. heartbeat.json is written")
+            print("   from the main UI thread, not from the poller thread, so its age")
+            print("   cannot tell busy from broken - it is reported, not judged:")
+            if _age >= 0:
+                print(f"   heartbeat.json age: {_age:.0f} s")
+            else:
+                print("   heartbeat.json: none - the AddOn writes it when it loads, so it")
+                print("   has not loaded for this data directory (or the file was removed)")
+            if _proc["listed"] is True:
+                print("   Its process exists - the process list was read after every probe;")
+                print(f"   the last read: {_proc['detail']}")
+            else:
+                print("   Whether its process exists is NOT known - the process list could not")
+                print("   be read after the last probe, so the silence was treated as a wait;")
+                print(f"   the last read: {_proc['detail']}")
+                print("   Check the process yourself first.")
+            print("   Look at NinjaTrader itself before running again: is it signed in, is")
+            print("   the AddOn loaded, is a modal dialog open (a modal blocks the dispatcher")
+            print("   and the bridge stops answering - measured 2026-08-20)?")
+            print("   " + "!" * 66)
+            raise RuntimeError("preflight: the bridge did not answer")
+
+        # ================================================================
+        # THE OPERATING SEQUENCE, as specified by the user on 2026-08-19 and
+        # verified step by step against the panel that same day.
+        #
+        #   1  EVERY connection off, then the baseline: no strategy rows, no
+        #      dialogs, transport parked. Step 1 has to survive any starting
+        #      situation - nothing connected, one live feed, several at once.
+        #   2  connection -> Playback
+        #   3  wait until the Playback box is no longer greyed
+        #   4  Market Replay OR Historical
+        #   5  start and end date, always end > start (otherwise NinjaTrader errors)
+        #   6  the same range into the adapter, and reset the clock
+        #   7  speed to Max, so the DISPLAY reads Max too
+        #   8  set the strategy up and enable it
+        #   9  and only NOW: start the playback
+        #
+        # ⚠ NOT ONE TICK MAY PASS BEFORE STEP 9. A transport that runs during
+        # setup costs the strategy the data it consumed, and a bot attached
+        # afterwards starts mid-stream. Measured through steps 1-8: the clock
+        # stayed on 2026-08-10 00:00:00 at every single sub-step.
+        #
+        # ⚠ Numbering changed on 2026-08-20 when switching everything off became
+        # step 1. Labels and comments were renumbered together - a step whose
+        # label says 1 while the sequence calls it 2 is a defect, not cosmetics.
+        # ================================================================
+        # Start from a state we established, with the SAME one-call cleanup the
+        # teardown uses. `baseline` used to be here and it is not a UI action but a
+        # whole cleanup routine - it cannot answer inside a ten-second budget, so
+        # every run aborted on its own opening step (measured 2026-08-19).
+        _nt = nt_index()
+
+        # ⚠ STEP 1 STARTS BY SWITCHING EVERYTHING OFF - UNCONDITIONALLY.
+        #
+        # When playback is switched on, every other connection MUST be closed
+        # first, and that may happen without asking (2026-08-20).
+        # This is not a judgement call and not an intrusion to ask
+        # about: it is a precondition of the mode. No `keep` here - `keep` exists
+        # for a future Strategy Analyzer path, where a LIVE connection must
+        # survive and Playback must be absent.
+        #
+        # The run has to survive ANY starting situation: nothing connected, one live
+        # feed, several at once. Playback refuses to connect while anything else is
+        # up and says so in a MODAL dialog, which blocks the dispatcher - the bridge
+        # then stops answering at all.
+        #
+        # Neither older stage did this: `disconnect` touches only the Playback
+        # connection, and `connect` disconnects the others but connects Playback in
+        # the same breath. So a run used to begin on whatever happened to be open.
+        # Measured 2026-08-20: a report built from the CONFIGURATION showed six rows
+        # and no "Live", while NinjaTrader had "Live" connected the whole time.
+        #
+        # `alloff` enumerates the LIVE list, disconnects every one, waits for
+        # NinjaTrader's own status entry, and then for every connection to report
+        # Disconnected - and it names them, so "nothing was connected" is a
+        # measurement rather than an assumption.
+        _req1a = {"stage": "alloff"}
+        if a.keep:
+            _req1a["keep"] = a.keep
+        mandatory(note(stage("1a all connections off", _req1a, wait=90)),
+                  "all disconnected")
+
+        # Start from a state we established, with the SAME one-call cleanup the
+        # teardown uses. `baseline` used to be here and it is not a UI action but a
+        # whole cleanup routine - it cannot answer inside a ten-second budget, so
+        # every run aborted on its own opening step (measured 2026-08-19).
+        mandatory(note(stage("1b clean start", {"stage": "restore"}, wait=30)),
+                  "strategy rows", "dialogs", "transport")
+        nt_check(_nt, what="step 1 baseline")
+        user("Baseline clean: no connections, no strategies.")
+
+        # 2 - the SOURCE goes with the connect. The panel's radio buttons cannot be
+        # written while connected: assigning IsChecked makes NinjaTrader rebuild the
+        # transport synchronously on the UI thread, and the bridge call sits in that
+        # same dispatcher (900 s on 2026-08-18; on 19.08. the stage simply stopped
+        # answering). The adapter static decides the source, and the panel follows it
+        # on connect - which is exactly why it is set here, before connecting.
+        _nt = nt_index()
+        user(f"Connecting Playback ({a.source}) ...")
+        # ⚠ THE RANGE HAS TO TRAVEL WITH THE CONNECT, not only with stage `range`.
+        #
+        # Measured 2026-08-24: without it the connect answered
+        #     playback connection   ok=false   Status=null
+        # and NinjaTrader put up a modal "String was not recognized as a valid
+        # DateTime. (Panic)" - which also blocks the dispatcher, so every later
+        # request queued behind it and four of them expired unexecuted.
+        #
+        # The step list said it plainly: `FromEst` and `ToEst` were MISSING from
+        # it entirely. The AddOn writes them only when the request carries `from`
+        # and `to`, and this call sent neither, so the adapter went into Connect
+        # with no range at all.
+        #
+        # Stage `range` still sets them afterwards, and has to: before the
+        # connection is up the adapter discards them. These two writes are for
+        # the connect itself, which reads them while connecting.
+        # The instrument travels with the connect because the coverage step needs
+        # it: it answers "is the requested window in the replay STORE", and the
+        # store is per instrument. Without it that step had to fall back to the
+        # panel's own range, which Connect restores from the saved configuration -
+        # so it compared the request against whatever the last session used.
+        # wait=CONNECT_WAIT, not SLOW_WAIT: the connect can sporadically sit
+        # for minutes inside NinjaTrader and still succeed - see the
+        # CONNECT_WAIT block at the top for the measurement.
+        _connect_t0 = time.monotonic()
+        mandatory(note(stage("2 connect", {"stage": "connect", "source": a.source,
+                                           "instrument": a.instrument,
+                                           "from": a.date_from, "to": a.date_to},
+                             wait=CONNECT_WAIT)), "playback connection")
+        _connect_s = time.monotonic() - _connect_t0
+        if _connect_s > SLOW_WAIT:
+            # loud, so a run full of slow connects reads as pathology in the
+            # transcript instead of vanishing into a green verdict
+            user("SLOW CONNECT: %.0f s (typical 16-30 s, budget %d s) - "
+                 "NinjaTrader-internal stall, the run continues."
+                 % (_connect_s, CONNECT_WAIT))
+        # The measured resource name, not the English sentence - see nt_check.
+        nt_check(_nt, expect="CbiConnectionProcessConnectionStatusUpdate",
+                 contains="Connected", what="connect")
+        user("Connected.")
+
+        # ⚠ THE SEPARATE "panel ready" STEP IS GONE - step 2 already waits for it.
+        #
+        # The panel goes GREY for about 12 s after the connect and then comes back.
+        # Measured 11 311 / 11 876 / 12 236 / 16 313 / 17 749 ms across five runs.
+        # That transition used to be watched HERE, because `connect` returned as soon
+        # as the connection was up.
+        #
+        # `connect` now waits for the transition itself and reports it:
+        #     panel usable  ok  usable after 11876 ms  [noPlaybackWindow;wl:;hooked;enabled;]
+        # so by the time this line was reached the panel had been free for seconds.
+        # Asking for the transition a SECOND time demanded an event that was over:
+        # measured 2026-08-20, "never went grey within 40000 ms - with
+        # requireTransition the connect must show". The step could not pass, and the
+        # step before it had already proven what it was there to prove.
+        #
+        # Two steps waiting for one transition is not extra safety; the later one is
+        # guaranteed to fail. The wait belongs where the action is - trigger and wait
+        # are one step - so it stays in `connect`.
+        #
+        # The `ready` stage itself is kept: it is the right tool wherever a panel
+        # transition is NOT already covered by the action that caused it.
+        # 3 - verify the source took, and report what the panel shows. Writing the
+        # radios here is what deadlocks; reading them is free.
+        # The panel has to EXIST before any stage writes it. NinjaTrader does not
+        # persist the Playback window in a workspace (measured 2026-08-29: 52 windows
+        # across 7 workspaces, none titled "Playback"), so after a NinjaTrader start
+        # the source check finds nothing and the run ends there - measured 2026-09-03,
+        # three attempts in one call, each "3 source check: panel radios - Playback
+        # window not found" after a healthy connect. The stage is idempotent: an open
+        # window is reported ("already open"), never a second one.
+        # mandatory() keys are SUBSTRINGS of the step names it must see ok (:1456-1457),
+        # and this stage answers with one of two shapes: "already open" when the window
+        # is there, or "open PlaybackControlCenter" + "window present" when it had to be
+        # created. Both failing shapes are named here; the "already open" step is only
+        # ever emitted as ok.
+        mandatory(note(stage("2b playback window", {"stage": "openwindow"})),
+                  "window present", "open PlaybackControlCenter")
+        mandatory(note(stage("3 source check", {"stage": "source", "source": a.source})),
+                  "IsSourceHistoricalData")
+        # 4 - the panel editors, with end AFTER start
+        if a.date_to < a.date_from:
+            raise RuntimeError(f"end {a.date_to} is before start {a.date_from}")
+        mandatory(note(stage("4 dates", {"stage": "uiset", "from": a.date_from,
+                                           "to": a.date_to})), "dtpStart", "dtpEnd")
+        # the adapter's own range + the clock at the start
+        mandatory(note(stage("5 range", {"stage": "range", "from": a.date_from,
+                                          "to": a.date_to}, wait=SLOW_WAIT)),
+                  "FromEst", "ToEst")
+        # 6 - panel memory only; writing the adapter static would start the run
+        mandatory(note(stage("6 speed", {"stage": "speed", "value": "max"})), "panel")
+
+        # 7 - the click-free path: ONE call, no window, configuration out of the
+        # template NinjaTrader itself reads and writes. The request's own fields are
+        # applied on top of the template inside the bridge, so instrument and range
+        # stay per-run while bar type and Tick Replay come from the template.
+        if a.setup == "template":
+            bp_token = f"77077:{a.barvalue}:1" if a.barsperiod.lower() == "wave" \
+                       else (f"0:{a.barvalue}:1") if a.barsperiod.lower() == "tick" \
+                       else (f"4:{a.barvalue}:1")
+            # Remember where the log stands, so only lines written AFTER this attach count.
+            _nt_attach = nt_index()
+            # The names the GRID path reports. "added to account" and
+            # "SetState(Realtime)" belong to the older via=account path and can
+            # never appear here - a required step that cannot occur fails every
+            # run regardless of what NinjaTrader did.
+            # Every one of these is a MEASURED effect, not a call that returned.
+            # (The interactive --attach-only hold mode was removed 2026-08-21
+            # after the enable freeze was fixed at its root - the AddOn's
+            # `arm` stage and attach's enable:false remain available for
+            # diagnosis via hand-written triggers.)
+            for _bi, (_bot, _acct, _tmpl) in enumerate(BOTS, start=1):
+                user(f"Attaching strategy {_bot}"
+                     f"{' on ' + _acct if _acct else ''}"
+                     f"{' with template ' + _tmpl if _tmpl else ''} ...")
+                _req = {"stage": "attach",
+                        "strategy": _bot,
+                        # optional trading-hours template override (coverage
+                        # experiments); empty = the instrument's own
+                        "tradingHours": a.tradinghours or "",
+                        # empty string when none was given - the stage reads
+                        # that as "use the bot's defaults" and reports it
+                        # The template, when one was named; otherwise the bot's
+                        # own defaults.
+                        "template": _tmpl or a.template or "",
+                        "instrument": a.instrument,
+                        "barsPeriod": bp_token,
+                        "tickReplay": a.tickreplay,
+                        "from": a.date_from,
+                        "to": a.date_to}
+                # Empty = the playback account NinjaTrader names itself.
+                if _acct:
+                    _req["account"] = _acct
+                mandatory(note(stage(f"7.{_bi:d} attach {_bot}", _req,
+                                     wait=ARM_WAIT)),
+                          "template", "configuration valid",
+                          "StrategyEnable", "enable requested (NOT proof)")
+                # Each bot is armed on its own; the log wait below covers the
+                # LAST one, and every earlier bot has already been confirmed by
+                # its own attach steps.
+                if _bi < len(BOTS):
+                    _ok = wait_for_enable_event(_bot, since=_nt_attach, timeout=90.0)
+                    if not _ok:
+                        raise RuntimeError(
+                            f"NinjaTrader never logged 'Enabling NinjaScript "
+                            f"strategy {_bot}' within 90 s.")
+                    user(f"Strategy armed: {_bot}")
+
+            # ⚠ WATCH NINJATRADER'S OWN LOG, NOT THE GRID.
+            #
+            # Arming is heavy: NinjaTrader loads the series and steps the state machine,
+            # and it does that ON THE UI THREAD. Every observation that goes through the
+            # dispatcher therefore queues BEHIND the very work it wants to observe - which
+            # is how a busy NinjaTrader became a frozen one three times on 2026-08-19, the
+            # last time with 13 of my own polls stacked up behind it.
+            #
+            # NinjaTrader logs `Enabling NinjaScript strategy '<Name>/<id>'` through
+            # Cbi.Log, and the AddOn buffers those entries as they arrive. The `ntlog`
+            # stage hands them out from that buffer under its own lock - still a request,
+            # but one that needs no dispatcher, so it answers while the UI thread is busy.
+            # That is the one channel that cannot make the situation worse.
+            armed = wait_for_enable_event(a.strategy, since=_nt_attach, timeout=90.0)
+            if not armed:
+                raise RuntimeError(
+                    f"NinjaTrader never logged 'Enabling NinjaScript strategy "
+                    f"{a.strategy}' within 90 s. "
+                    f"The enable was fired and did not start - do NOT poll it, that only "
+                    f"adds load. Stage 'ntlog' shows NinjaTrader's own entries since the "
+                    f"enable was fired - that is the channel this wait listens to.")
+            print(f"   armed: {armed}")
+            # Only the fact. The raw NinjaTrader log line sits in the debug
+            # transcript and carries a WALL-CLOCK stamp - those never go into
+            # the user console (data-stream times only).
+            user("Strategy armed.")
+        else:
+            # unreachable: --setup dialog is rejected in main(). Kept as a tripwire so a
+            # future edit that re-enables the flag fails here instead of clicking.
+            raise RuntimeError("the dialog setup path was removed with the clicks")
+
+        # Nothing may have moved yet. This is the whole point of the order above,
+        # so it is CHECKED rather than trusted. One call answers all three: where
+        # the clock stands, whether it is advancing, and where the range ends.
+        c0, m0, to0 = clock_vs_end()
+        print(f"   before start: clock={c0}  moving={m0}")
+        # ⚠ THE CLOCK MUST BE AT THE RANGE START - not merely standing still.
+        #
+        # Measured 2026-08-19: a run began with the clock on 10.08. 23:59:59,
+        # which is ToEst. It was not moving, so the old check passed; pressing
+        # play then changed nothing because there was nothing left to play. A
+        # standing clock at the END looks exactly like a standing clock at the
+        # START, and only one of them is a run.
+        if m0:
+            raise RuntimeError(f"the transport was already running before step 8 - "
+                               f"the strategy has lost the ticks up to {c0}")
+        # Compare against ToEst, not against the start DATE. With a one-day range
+        # start and end fall on the same date, so `c0[:10] == date_from` was true
+        # for a clock sitting on 23:59:59 - the run then pressed play with nothing
+        # left to play and failed one step later (measured 2026-08-19). What has to
+        # hold is simply: there is still range ahead of us.
+        if not c0:
+            raise RuntimeError("no clock reading before the start")
+        c0n = c0.replace("T", " ")[:19]
+        to0n = (to0 or "").strip()[:19]
+        if to0n:
+            # Both come from PlaybackAdapter rendered by the machine's locale, so
+            # either can arrive as dd.MM.yyyy HH:mm:ss - normalise both before
+            # comparing, or the string order is meaningless.
+            def _norm(s: str) -> str:
+                s = s.strip()
+                if "." in s[:10]:
+                    d, t_ = s.split(" ", 1) if " " in s else (s, "00:00:00")
+                    dd, mm, yy = d.split(".")
+                    return f"{yy}-{mm}-{dd} {t_}"
+                return s
+            if _norm(c0n) >= _norm(to0n):
+                raise RuntimeError(
+                    f"the clock is on {c0n}, at or past ToEst {to0n} - nothing would play")
+
+        # 8 - the transport is started by WRITING THE SPEED, not by pressing play.
+        # The stage samples the clock before and after and reports movement, so the
+        # verdict rests on the clock and not on the write having resolved.
+        mandatory(note(stage("8 start", {"stage": "play", "value": "max"},
+                             wait=SLOW_WAIT)), "PlaybackSpeed", "after")
+        user(f"Playing {a.date_from} .. {a.date_to} ...")
+        # Baseline for the console's percent figure: the first sampled data
+        # time. Percent is DATA progress (NowEst between first sample and
+        # ToEst), never wall clock.
+        _pb = {"base": None}
+
+        # ⚠ END OF RUN: the strategy reaches State.Terminated.
+        #
+        # Every NinjaScript passes through OnStateChange and ends at Terminated. No
+        # strategy has to cooperate, nothing is written to disk, no GUI element is
+        # read - which matters, because this goes back upstream.
+        #
+        # NowEst >= ToEst is kept as a second witness: it says the RANGE was played,
+        # while Terminated says the STRATEGY finished. Both together separate "played
+        # to the end" from "stopped early", and the run reports which one it was.
+        #
+        # Four candidates were rejected, each for a measured reason:
+        #   clock standing still ......... a guess about stillness; a minute wasted
+        #                                  at the end of every run
+        #   IsAvailableChanged ........... subscribed 2026-08-19, never fired
+        #   the progress slider .......... falls short of its maximum when data is
+        #                                  missing (user, 2026-08-19) - waiting hangs
+        #   a strategy's own counter file  only some strategies write one
+        print("--- playing ---")
+        terminated = played = False
+        end_gap = False          # NowEst jumped over a tick-store gap - a failure
+        prev_now = None          # previous sample's data time, the gap witness
+        SAMPLE_S = 10
+        for i in range(int(a.maxwait * 30 / SAMPLE_S)):
+            time.sleep(SAMPLE_S)
+            c, m, to = clock_vs_end()
+            st = stage("state", {"stage": "strategystate"}, wait=STAGE_WAIT, show=False)
+            sv = {str(s.get("step", "")).strip(): str(s.get("detail", "")) for s in st.get("steps", [])}
+            # NinjaTrader's order-rejection notice ("Stop price can't be changed above
+            # the market") is confirmed by the AddOn once per sample and counted in
+            # the "order notices" step (DismissOrderRejectNotices). It is said on the
+            # console when one was confirmed, and the run total lands in result.json,
+            # so an unattended run's notices are visible afterwards - the box itself
+            # is gone.
+            _now_n, _total_n = order_notice_counts(sv.get("order notices", ""))
+            order_notices_total = max(order_notices_total, _total_n)
+            if _now_n:
+                user(f"NinjaTrader order-rejection notice confirmed by the bridge "
+                     f"({_now_n:d} this sample, {_total_n:d} in this run)")
+            # ⚠ startswith, not equality - and that is a repair of my own regression.
+            # The stage used to answer a bare "yes"/"no"; on 2026-08-20 the text was
+            # changed to "yes - the strategy has terminated" so that `ok` could stop
+            # being a data field. This comparison was not carried along, so it never
+            # matched again and every run ended with "NowEst reached ToEst (strategy
+            # not yet Terminated)" - a report that was wrong about why it stopped.
+            terminated = sv.get("terminated", "no").strip().lower().startswith("yes")
+            # ⚠ PARSE, NEVER STRING-COMPARE, DD.MM.YYYY TIMES.
+            #
+            # Measured 2026-08-21, twice in one afternoon: `c >= to` on the raw
+            # strings ended "14.01.2026 ..." >= "13.03.2026 ..." (day field
+            # compares first) - two runs reported ok=true at 5.7 % and 13.2 %
+            # coverage. Every one-day run before was accidentally correct: with
+            # an identical date prefix the string order equals the time order.
+            _c = _to = None
+            try:
+                _c = datetime.strptime(c, "%d.%m.%Y %H:%M:%S")
+                _to = datetime.strptime(to, "%d.%m.%Y %H:%M:%S")
+            except (ValueError, TypeError):
+                # Unparsable sample -> no end verdict this round. Say it loudly
+                # in the transcript; a format change must not end runs silently.
+                if c or to:
+                    print(f"   ⚠ unparsable data time in end check: c={c!r} to={to!r}")
+            played = bool(_c and _to and _c >= _to)
+            # ⚠ A RUNNING CLOCK IS NOT A DATA STREAM.
+            #
+            # Until now this loop watched NowEst and the grid row, and a run that
+            # reached ToEst was called finished. Neither says the strategy was ever
+            # FED anything. Measured 2026-08-20: the empty bot "played" a full tick
+            # day in 3:00 min while CallbackSonde needed 107 min on the same day -
+            # and nothing in the transcript could tell whether one bar had arrived.
+            #
+            # These counters are NinjaTrader's own, on the strategy instance, not
+            # the bot's: a bot that prints nothing still has them. They are gone the
+            # moment the strategy is removed, so they have to be read WHILE it runs.
+            lv = stage("live", {"stage": "stratlive"}, wait=STAGE_WAIT, show=False)
+            lvv = {str(s.get("step", "")).strip(): str(s.get("detail", ""))
+                   for s in lv.get("steps", [])}
+            bars = ", ".join(f"{k}={v.split(' bars')[0]}"
+                             for k, v in lvv.items() if k.startswith("bars["))
+            print(f"   +{(i + 1) * SAMPLE_S:5d}s  {c}  moving={m:<5}  ToEst={to}  "
+                  f"State={lvv.get('strategy', '?').split('State=')[-1][:12]}  "
+                  f"CurrentBar={lvv.get('CurrentBar', '?')[:9]}  {bars[:44]}", flush=True)
+            try:
+                _now = datetime.strptime(c, "%d.%m.%Y %H:%M:%S")
+                _to = datetime.strptime(to, "%d.%m.%Y %H:%M:%S")
+                if _pb["base"] is None:
+                    _pb["base"] = _now
+                _span = (_to - _pb["base"]).total_seconds()
+                _pct = (100.0 * (_now - _pb["base"]).total_seconds() / _span
+                        if _span > 0 else 100.0)
+                user_progress(
+                    f"{c} | {min(_pct, 100.0):5.1f} % | "
+                    f"State={lvv.get('strategy', '?').split('State=')[-1][:12].strip()} | "
+                    f"Bar={lvv.get('CurrentBar', '?').strip()}")
+            except (ValueError, TypeError):
+                # No parsable data time -> no progress line. Never a wall clock.
+                pass
+            # What the bot printed since the last round - shown right after the
+            # harness line, so [BOT] lines and phase lines interleave in order.
+            print_bot_output()
+            # ⚠ CAUSE AND EFFECT - not to be swapped (user, 2026-08-21):
+            # State.Terminated is the EFFECT of the enable checkbox being taken
+            # away (our teardown, a hand, or NT8's own error handling) - never a
+            # sign that the data ran out. The grid row count reaching 0 is the
+            # EFFECT of our own Remove. Both are success checks of the CLEANUP.
+            # The only END-of-run signal is the data-side one: NowEst at the
+            # right edge (>= ToEst).
+            if terminated:
+                user("ABORT: strategy left the account (State.Terminated) before the data end.")
+                print("   strategy hit State.Terminated - it was DISABLED (externally "
+                      "or by NT8's error handling). That is an ABORT, not the data end.")
+                break
+            if played:
+                # ⚠ ARRIVING IS NOT THE SAME AS PLAYING THROUGH.
+                #
+                # Measured 2026-08-21 (MNQ ##-##): the
+                # tick store had 123 missing weekdays; the player streamed to
+                # the first gap (18.01.) and then JUMPED to the right edge
+                # (17.08.) between two samples. NowEst >= ToEst was true, the
+                # run reported ok=true - at 5.7 % actual coverage. A jump this
+                # size is a DATA GAP, and a gap must fail loudly, not pass as
+                # the data end. The previous sample's data time is the witness:
+                # if the clock crossed more than 3 days between two samples,
+                # the store did not carry the run to the edge.
+                gap_days = None
+                try:
+                    _prev = datetime.strptime(prev_now, "%d.%m.%Y %H:%M:%S")
+                    _here = datetime.strptime(c, "%d.%m.%Y %H:%M:%S")
+                    gap_days = (_here - _prev).total_seconds() / 86400.0
+                except (ValueError, TypeError):
+                    pass
+                if gap_days is not None and gap_days > 3.0:
+                    user(f"ERROR: data gap - the player jumped {gap_days:.1f} days "
+                         f"(from {prev_now} to {c}) instead of streaming there. The tick "
+                         f"store does not cover the window.")
+                    print(f"   ⚠ DATA GAP: NowEst jumped {gap_days:.1f} days "
+                          f"({prev_now} -> {c}). NowEst >= ToEst is the effect of the "
+                          f"jump, not of playing through. This is a FAILED run.")
+                    FAIL.update({"stage": "play", "step": "coverage",
+                                 "detail": f"player jumped {gap_days:.1f} days "
+                                           f"({prev_now} -> {c}): tick store gap"})
+                    end_gap = True
+                    break
+                user("End of data reached (player at the right edge).")
+                print("   NowEst reached ToEst - the data end. (Strategy still enabled, "
+                      "as expected: Terminated only follows a disable.)")
+                break
+            prev_now = c
+        # ⚠ EVERY end that is not the DATA end is a failure for the caller.
+        # `played` is the only good exit (NowEst at ToEst); a Terminated
+        # strategy was DISABLED (NT8 error handling or a hand) and a loop
+        # that ran out of budget saw neither - both used to leave rc at 0,
+        # which is exactly the "looks like a result" trap mandatory() names.
+        if end_gap:
+            end_reason = "data-gap"
+            rc = rc or 2
+        elif played:
+            end_reason = "data-end"
+        elif terminated:
+            end_reason = "strategy-stopped"
+            rc = rc or 2
+        else:
+            end_reason = "did-not-finish"
+            rc = rc or 2
+            print("   ⚠ neither the data end nor an abort was seen - the run did not finish")
+    except KeyboardInterrupt as ex:
+        print("")
+        print(f"   stopped by the user: {ex}")
+        end_reason = "interrupted"
+        err_text = str(ex) or "KeyboardInterrupt"
+        rc = 2
+    except RuntimeError as ex:
+        # ⚠ A CONTROLLED STOP IS NOT A CRASH - do not print a stack trace for it.
+        #
+        # The hard stop and the mandatory check raise on purpose, and Python 3.13
+        # renders the trace with ~~~^^^ markers under the call. A reader takes that
+        # for a syntax error, which is exactly what it looks like (2026-08-20).
+        # The reason for stopping was already
+        # printed, in full, right above it - the trace adds nothing but noise and
+        # sends the reader looking for a defect in the script.
+        print("")
+        print(f"   === RUN ABORTED ===  {ex}")
+        print("   The reason is the FAIL block above. This is a controlled stop,")
+        print("   not a crash: nothing was built on the step that failed.")
+        end_reason = "aborted"
+        err_text = str(ex)
+        rc = 2
+    except Exception as ex:                          # noqa: BLE001
+        # Anything unforeseen still gets its full trace - that one IS a defect.
+        traceback.print_exc()
+        end_reason = "crashed"
+        err_text = f"{type(ex).__name__}: {ex}"
+        rc = 2
+    finally:
+        # Guarantee 1: the baseline is restored no matter how we got here.
+        teardown = restore_baseline(a.strategy)
+        # The strategy's Terminated pass prints its last lines DURING the
+        # teardown - fetch them so the console shows the complete output window.
+        # lease=0 again: this is the run's LAST request, and a 120 would re-arm
+        # the lease the restore stage has just released.
+        try:
+            print_bot_output(lease=0)
+        except Exception:
+            pass
+        user("Baseline restored." if all(bool(s.get("ok")) for s in teardown)
+             else "WARNING: baseline NOT clean - see teardown.json in the archive.")
+
+
+    new = ((set(p.name for p in BOTLOGS.iterdir()) - before)
+           if BOTLOGS and BOTLOGS.exists() else set())
+    (target / "run.json").write_text(json.dumps(log, indent=2, ensure_ascii=False),
+                                     encoding="utf-8")
+    (target / "teardown.json").write_text(json.dumps(teardown, indent=2, ensure_ascii=False,
+                                                     default=str), encoding="utf-8")
+    (target / "requested.json").write_text(json.dumps(vars(a), indent=2), encoding="utf-8")
+    for o in sorted(new):
+        q = BOTLOGS / o
+        if q.is_dir():
+            shutil.copytree(q, target / ("botlog_" + o), dirs_exist_ok=True)
+    wall_s = time.time() - wall_start
+    print("")
+    print(f"Wall-clock duration: {int(wall_s // 60)}:{int(wall_s % 60):02} min:s")
+    (target / "duration.json").write_text(
+        json.dumps({"wallClockSeconds": round(wall_s, 1),
+                    "note": "wall clock, not data time - how long this mode took"},
+                   indent=2), encoding="utf-8")
+    print(f"\nArchived in {target}")
+
+    best = None
+    for f in sorted(target.glob("botlog_*/DEBUG_callbacks.json")):
+        j = json.loads(f.read_text(encoding="utf-8"))
+        if best is None or j.get("OnBarUpdate_bip0", 0) > best.get("OnBarUpdate_bip0", 0):
+            best = j
+    problems = []
+    if best is None:
+        # NOT an error. The census is a MEASUREMENT, never a control: a strategy
+        # that writes no counter file is a perfectly good run, and an empty test
+        # strategy never writes one. An earlier `return rc or 3` here turned every
+        # clean run of such a strategy into exit 2.
+        print("   no counter file - the strategy wrote no census (an empty bot "
+              "never does; the census is a measurement, not a control)")
+    else:
+        # ⚠ The bot reports what it ACTUALLY got. Compare it with what was asked
+        # for. Measured 2026-08-19: a run requested Tick Replay on and the counter
+        # file says IsTickReplay=False - a result that would have been filed under
+        # the wrong heading. A run whose settings do not match the request is not a
+        # measurement of what was requested.
+        got_tr = str(best.get("IsTickReplay", "")).lower()
+        if got_tr != a.tickreplay.lower():
+            problems.append(f"Tick Replay requested {a.tickreplay}, bot reports {got_tr}")
+        if str(best.get("Instrument", "")).strip() != a.instrument:
+            problems.append(f"instrument requested {a.instrument!r}, "
+                            f"bot reports {best.get('Instrument')!r}")
+        # "no market data at all" and "market data stops early" are different answers
+        # and must not share a message. Measured 2026-08-19: Market Replay without Tick
+        # Replay delivers ZERO OnMarketData events over the whole range - the run is
+        # complete, the count is the finding. Reporting that as "cut short" hid it.
+        # The one census key this check needs by name: the timestamp of the LAST
+        # market-data event. A strategy names its own counters, so when the key is
+        # absent the check says so instead of passing quietly - a "cut short" test
+        # that silently does not run reads exactly like one that found nothing
+        # wrong.
+        LAST_DATA_KEY = "MarketData_LastDataTime"
+        if LAST_DATA_KEY not in best:
+            span_to = ""
+            print(f"   note: census has no {LAST_DATA_KEY!r} - the 'run was cut "
+                  f"short' check cannot run for this strategy")
+        else:
+            span_to = str(best[LAST_DATA_KEY]).strip()
+        if LAST_DATA_KEY in best and span_to in ("", "-"):
+            print(f"   note: no market data events at all "
+                  f"(OnMarketData={best.get('OnMarketData')}) - that is the measurement, "
+                  f"not a truncated run")
+        elif _iso_day(span_to) and _iso_day(span_to) < a.date_to:
+            problems.append(f"market data ends {span_to[:10]}, range ends "
+                            f"{a.date_to} - run was cut short")
+        if problems:
+            print("   ⚠ RUN DOES NOT MATCH THE REQUEST:")
+            for x in problems:
+                print(f"      {x}")
+            (target / "MISMATCH.txt").write_text(chr(10).join(problems), encoding="utf-8")
+            rc = rc or 2
+        # Print the keys the census ACTUALLY carries, not a fixed list. A fixed
+        # list is a contract with one particular strategy: it prints None for
+        # every counter that strategy does not write, and silently drops every
+        # counter it writes that nobody thought of. The ones below lead because
+        # they answer "did the run get data at all"; everything else follows in
+        # the order the file has it.
+        LEAD = ("IsTickReplay", "Instrument", "OnBarUpdate_bip0", "CurrentBar",
+                "OnMarketData", "MarketData_Last", "MarketData_Bid", "MarketData_Ask")
+        for k in LEAD:
+            if k in best:
+                print(f"   {k:30} {best[k]}")
+        for k in best:
+            if k not in LEAD:
+                print(f"   {k:30} {best[k]}")
+
+    # ── The machine-readable contract for the headless caller. ─────────────────
+    #
+    # One JSON object that says whether the run is a RESULT: it is `ok` only if
+    # the DATA END was reached (NowEst at ToEst - the sole good exit per the
+    # cause-vs-effect rule of 2026-08-21), the teardown restored the baseline,
+    # and nothing mismatched the request. Every failure carries the stage, the
+    # sub-step and NinjaTrader's own detail line, so the caller of the CLI
+    # bridge gets a message worth reading instead of an exit code alone.
+    baseline_clean = bool(teardown) and all(bool(s.get("ok")) for s in teardown)
+    ok = (rc == 0 and end_reason == "data-end" and baseline_clean and not problems)
+    if not ok and rc == 0:
+        rc = 2                       # e.g. data end reached but baseline NOT clean
+    result = {
+        "command": "playbackrun",
+        "ok": ok,
+        "rc": rc,
+        "endReason": end_reason,
+        "failed": dict(FAIL) if FAIL.get("step") else None,
+        "error": err_text,
+        "mismatch": problems or None,
+        "baselineClean": baseline_clean,
+        "archive": str(target),
+        "name": a.name,
+        "strategy": a.strategy,
+        "strategies": [{"strategy": b, "account": acc or None,
+                        "template": tm or a.template or None} for b, acc, tm in BOTS],
+        "instrument": a.instrument,
+        "source": a.source,
+        "tickReplay": a.tickreplay,
+        "barsPeriod": a.barsperiod,
+        "barValue": a.barvalue,
+        "from": a.date_from,
+        "to": a.date_to,
+        "wallClockSeconds": round(wall_s, 1),
+        # Wall clock the preflight spent waiting for the bridge (stage 0). A
+        # slow preflight is a busy NinjaTrader; here it stays visible in the
+        # archive instead of hiding inside wallClockSeconds.
+        "preflightSeconds": round(preflight_s, 1),
+        # NinjaTrader order-rejection notices the AddOn confirmed during the play
+        # loop (see the "order notices" step). 0 when none appeared.
+        "orderNoticesDismissed": order_notices_total,
+        "censusFound": best is not None,
+        "census": best,
+    }
+    payload = json.dumps(result, indent=2, ensure_ascii=False, default=str)
+    (target / "result.json").write_text(payload, encoding="utf-8")
+    if a.result:
+        Path(a.result).write_text(payload, encoding="utf-8")
+    # The closing block of the end-user console: the result as JSON, then the
+    # duration line.
+    user("")
+    user(payload)
+    user(f"=== Backtest duration (min:s): {int(wall_s // 60)}:{int(wall_s % 60):02} ===")
+    return rc
+
+
+if __name__ == "__main__":
+    # The exit code can go into a file too: behind `python ... | tee` a cmd batch
+    # sees the pipe's code, not ours, and a chain meant to stop on the first
+    # failure would run to the end regardless.
+    #
+    # Only when --rc-file asks for it. This used to write into the package
+    # directory next to this module, which is read-only in a normal install and
+    # is not the caller's choice of location either.
+    _rc = 1
+    try:
+        _rc = main()
+    finally:
+        _target = None
+        for _i, _arg in enumerate(sys.argv):
+            if _arg == "--rc-file" and _i + 1 < len(sys.argv):
+                _target = sys.argv[_i + 1]
+            elif _arg.startswith("--rc-file="):
+                _target = _arg.split("=", 1)[1]
+        if _target:
+            try:
+                _p = Path(_target)
+                _p.parent.mkdir(parents=True, exist_ok=True)
+                _p.write_text(str(_rc), encoding="ascii")
+            except OSError:
+                pass
+    raise SystemExit(_rc)

--- a/nt8bridge/precheck.py
+++ b/nt8bridge/precheck.py
@@ -80,6 +80,7 @@ def run_precheck(strategy_path) -> list[CompileError]:
         ["powershell", "-NoProfile", "-File", str(compiler), str(path)],
         capture_output=True,
         text=True,
+        errors="replace",
         env=env,
     )
     return parse_errors(proc.stdout + "\n" + proc.stderr)

--- a/nt8bridge/restart.py
+++ b/nt8bridge/restart.py
@@ -44,13 +44,49 @@ DEFAULT_TASK = ""
 DEFAULT_EXE = ""
 
 
-def is_running() -> bool:
+def process_listed() -> tuple[bool | None, str]:
+    """Read the process list once. Returns (listed, detail).
+
+    `listed` has THREE values, and the third is why this exists next to is_running():
+        True   tasklist lists NinjaTrader.exe
+        False  tasklist was read and does not list it
+        None   the list could NOT be read - tasklist is missing, timed out (30 s), exited non-zero
+               or printed nothing - so nothing is known about the process
+    Any NinjaTrader.exe counts: the list does not tell instances apart, so a second NinjaTrader
+    next to a dead target keeps a caller waiting instead of stopping it.
+    `detail` is what was measured, for the caller's message: the row(s) naming the process, the
+    line tasklist printed instead (locale text - "INFO: No tasks are running which match the
+    specified criteria." on an English Windows), or the failure.
+
+    Measured 2026-09-02: an unlisted name answers exit 0 plus that one line; an unknown filter
+    answers exit 1 with the error on stderr and nothing on stdout; a missing executable raises
+    FileNotFoundError and a hung one TimeoutExpired. A caller that reads every one of those as
+    "not running" passes a verdict it never measured - the preflight poll of playback_run did,
+    and ended a run after one probe with a message asserting an empty process list nobody had seen.
+    """
     try:
-        out = subprocess.run(["tasklist", "/FI", "IMAGENAME eq NinjaTrader.exe"],
-                             capture_output=True, text=True, timeout=30).stdout
-        return "NinjaTrader.exe" in out
-    except Exception:
-        return False
+        r = subprocess.run(["tasklist", "/FI", "IMAGENAME eq NinjaTrader.exe"],
+                           capture_output=True, text=True, errors="replace", timeout=30)
+    except Exception as e:  # noqa: BLE001 - reported, not swallowed
+        return None, f"tasklist could not be run: {type(e).__name__}: {e}"
+    rows = [" ".join(ln.split()) for ln in r.stdout.splitlines() if "NinjaTrader.exe" in ln]
+    if rows:
+        return True, "tasklist lists " + "; ".join(rows)
+    text = " ".join(r.stdout.split())
+    if r.returncode == 0 and text:
+        return False, f"tasklist answered: {text}"
+    err = " ".join(r.stderr.split())
+    return None, (f"tasklist exited {r.returncode}"
+                  + (f", stdout: {text}" if text else ", printed nothing on stdout")
+                  + (f", stderr: {err}" if err else ""))
+
+
+def is_running() -> bool:
+    """True when the process list was read and lists NinjaTrader.exe; False otherwise - a list
+    that could not be read included. The callers of this bool (stop, wait_for, the restart
+    command) act the same on "not seen" and "not there"; a caller that must keep them apart
+    reads process_listed() itself (the preflight poll of playback_run does)."""
+    return process_listed()[0] is True
 
 
 def run_task(task: str) -> tuple[bool, str]:
@@ -61,7 +97,7 @@ def run_task(task: str) -> tuple[bool, str]:
         return False, "schtasks not available"
     try:
         r = subprocess.run(["schtasks", "/run", "/tn", task],
-                           capture_output=True, text=True, timeout=60)
+                           capture_output=True, text=True, errors="replace", timeout=60)
         ok = r.returncode == 0
         return ok, (r.stdout or r.stderr or "").strip()
     except Exception as e:  # noqa: BLE001 - reported, not swallowed
@@ -96,14 +132,14 @@ def stop(timeout: float = 60.0, force_after: float = 25.0) -> tuple[bool, str]:
         return True, "not running"
     try:
         subprocess.run(["taskkill", "/IM", "NinjaTrader.exe"],
-                       capture_output=True, text=True, timeout=30)
+                       capture_output=True, text=True, errors="replace", timeout=30)
     except Exception as e:  # noqa: BLE001 - reported, not swallowed
         return False, f"graceful close failed to dispatch: {e}"
     if wait_for(False, force_after):
         return True, "closed gracefully"
     try:
         subprocess.run(["taskkill", "/F", "/IM", "NinjaTrader.exe"],
-                       capture_output=True, text=True, timeout=30)
+                       capture_output=True, text=True, errors="replace", timeout=30)
     except Exception as e:  # noqa: BLE001
         return False, f"terminate failed to dispatch: {e}"
     remaining = max(1.0, timeout - force_after)

--- a/nt8bridge/satemplate.py
+++ b/nt8bridge/satemplate.py
@@ -1,0 +1,82 @@
+# MIT License
+# Copyright (c) 2026 Quantrosoft Pty. Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Satemplate: put one of NinjaTrader's own strategy templates on the SA tab.
+
+`configure` sets individual properties from a config.json. That is the right
+shape for a handful of parameters and the wrong one for the files NinjaTrader
+writes itself under templates\\Strategy: those carry the COMPLETE parameter set,
+and a test suite is usually one strategy class against many of them, identical
+in everything else. Naming the file beats restating hundreds of properties, and
+it cannot drift from what the GUI runs, because it IS what the GUI runs.
+
+    python -m nt8bridge satemplate --template "C:\\...\\VariantA.xml"
+    python -m nt8bridge backtest   --config run.json     # then fire Run
+
+A bare name is looked up in the strategy's own template folder, which
+NinjaTrader is asked for rather than assembled from a naming rule; a full path
+is taken as given.
+
+THE STRATEGY IS SELECTED FIRST WHEN IT HAS TO CHANGE
+
+Writing the tab's `Strategy` makes NinjaTrader install a fresh StrategyTemplate
+and silently drop whatever was on the old one (see configure.py and issue #6).
+So when the template belongs to a different class than the tab holds, the AddOn
+selects the class BEFORE assigning - the other order loses the whole template
+without an error. `switchedFrom` in the response names the class that was
+replaced, and is empty when nothing was switched.
+
+THE INSTRUMENT TRAVELS WITH THE TEMPLATE
+
+NinjaTrader does not hand it over by itself. Measured on a running instance:
+after assigning a template naming NQ 06-26, the strategy read NQ 06-26 and the
+tab still read ES 09-26 - and it is the TAB's instrument that the Analyzer runs.
+Left alone, that applies one template's parameters to another instrument and
+reports nothing. So when the template names an instrument, the AddOn writes it
+to the tab as well.
+
+Response:
+  {id, status, template, strategy, tabStrategy, instrument, from, to,
+   switchedFrom, applied}, plus `params` when applied is true and `error`
+  when it is false
+
+`instrument`, `from` and `to` are the three values the run will actually be
+carried out with, read back after the writes - the instrument off the TAB, the
+dates off the template. `applied` is a reference comparison: the instance read
+back off the tab has to be the very one that was assigned. A property that
+accepts a write and quietly keeps its own object would otherwise pass as
+success, and the run afterwards would use the wrong parameters while every step
+reported ok.
+"""
+from __future__ import annotations
+
+from nt8bridge import ntio
+from nt8bridge.compile import new_request_id
+
+
+def run_satemplate(template: str, timeout: float = 30.0) -> dict:
+    trigger, result = ntio.ensure_bridge_dirs()
+    rid = new_request_id()
+    ntio.atomic_write_json(
+        trigger / f"satemplate_{rid}.json",
+        {"id": rid, "kind": "satemplate", "template": template},
+    )
+    return ntio.poll_for_json(result / f"satemplate_{rid}.json", timeout=timeout)

--- a/nt8bridge/watchdog.py
+++ b/nt8bridge/watchdog.py
@@ -33,6 +33,7 @@ def nt8_running(process_name: str = PROCESS_NAME) -> bool:
             ["tasklist", "/FI", "IMAGENAME eq " + process_name],
             capture_output=True,
             text=True,
+            errors="replace",
         ).stdout
         return process_name.lower() in (out or "").lower()
     except OSError:
@@ -58,7 +59,8 @@ def is_hung(threshold_sec: float, now=None) -> bool:
 
 def kill_nt8(process_name: str = PROCESS_NAME) -> None:
     try:
-        subprocess.run(["taskkill", "/F", "/IM", process_name], capture_output=True, text=True)
+        subprocess.run(["taskkill", "/F", "/IM", process_name],
+                       capture_output=True, text=True, errors="replace")
     except OSError:
         pass
 

--- a/tests/test_analyzerrun.py
+++ b/tests/test_analyzerrun.py
@@ -1,0 +1,148 @@
+# MIT License
+# Copyright (c) 2026 Quantrosoft Pty. Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nt8bridge import analyzerrun, cli
+
+
+def test_parse_opt_spec_accepts_the_headless_runner_syntax():
+    entries = analyzerrun.parse_opt_spec("DeltaVolume1:150:250:50,Fast:20:30:5")
+    assert [e["name"] for e in entries] == ["DeltaVolume1", "Fast"]
+    assert entries[0] == {"name": "DeltaVolume1", "min": "150", "max": "250", "step": "50"}
+
+
+@pytest.mark.parametrize("spec, fragment", [
+    ("Fast:20:30", "needs 4 fields"),
+    ("Fast:20:30:0", "must be > 0"),
+    ("Fast:20:30:x", "is not a number"),
+    ("", "needs --opt"),
+    ("2Fast:1:2:1", "not a property name"),
+])
+def test_parse_opt_spec_refuses_the_same_mistakes_as_nt8cli(spec, fragment):
+    with pytest.raises(ValueError) as e:
+        analyzerrun.parse_opt_spec(spec)
+    assert fragment in str(e.value)
+
+
+def test_property_overrides_take_name_equals_value_only():
+    assert analyzerrun.property_overrides(["--OptimizationPeriod=10", "--TestPeriod=5"]) == {
+        "OptimizationPeriod": "10", "TestPeriod": "5"}
+    with pytest.raises(ValueError):
+        analyzerrun.property_overrides(["--TestPeriod", "5"])
+
+
+def test_build_request_carries_mode_template_and_ranges():
+    r = analyzerrun.build_request("rid1", "walkforward", r"C:\t\WFO.xml", "Fast:20:30:5",
+                                  params={"TestPeriod": "5"}, timeout=900.0)
+    assert r["kind"] == "analyzerrun"
+    assert r["mode"] == "WalkForward"
+    assert r["template"] == r"C:\t\WFO.xml"
+    assert r["opt"] == "Fast:20:30:5"
+    assert r["optimizer"] == "default"
+    assert r["params"] == {"TestPeriod": "5"}
+    assert r["timeoutSec"] == 900.0
+
+
+def test_build_request_anchored_is_a_walk_forward_mode_of_its_own():
+    r = analyzerrun.build_request("rid2", "walkforward", "WFO", "Fast:20:30:5", anchored=True)
+    assert r["mode"] == "WalkForwardAnchored"
+    with pytest.raises(ValueError):
+        analyzerrun.build_request("rid3", "optimize", "WFO", "Fast:20:30:5", anchored=True)
+    with pytest.raises(ValueError):
+        analyzerrun.build_request("rid4", "optimize", "WFO", "Fast:20:30:5", optimizer="random")
+
+
+def test_run_analyzer_writes_its_request_and_reads_its_own_result_file(monkeypatch):
+    captured, polled = {}, {}
+    monkeypatch.setattr(analyzerrun.ntio, "ensure_bridge_dirs", lambda: (Path("trig"), Path("res")))
+    monkeypatch.setattr(analyzerrun, "new_request_id", lambda: "rid7")
+    monkeypatch.setattr(analyzerrun.ntio, "atomic_write_json",
+                        lambda p, o: captured.update(path=p, obj=o))
+    monkeypatch.setattr(analyzerrun.ntio, "poll_for_json",
+                        lambda p, timeout=30.0: polled.update(path=p, timeout=timeout)
+                        or {"status": "ok"})
+    out = analyzerrun.run_analyzer("optimize", "WFO", "Fast:20:30:5", timeout=600.0)
+    assert captured["path"] == Path("trig") / "analyzerrun_rid7.json"
+    assert captured["obj"]["mode"] == "Optimize"
+    assert polled["path"] == Path("res") / "analyzerrun_rid7.json"
+    # the client waits the run's budget plus the AddOn's margin to write the file
+    assert polled["timeout"] == 630.0
+    assert out["status"] == "ok"
+
+
+def test_deliver_csvs_numbers_several_files_in_the_order_given(tmp_path):
+    srcs = []
+    for k in range(3):
+        f = tmp_path / ("run_%d.csv" % k)
+        f.write_text("row%d" % k)
+        srcs.append(str(f))
+    out = tmp_path / "out" / "wfo.csv"
+    dests = analyzerrun.deliver_csvs(srcs, str(out))
+    assert [Path(d).name for d in dests] == ["wfo_0.csv", "wfo_1.csv", "wfo_2.csv"]
+    assert (tmp_path / "out" / "wfo_1.csv").read_text() == "row1"
+    single = analyzerrun.deliver_csvs(srcs[:1], str(tmp_path / "one.csv"))
+    assert single == [str(tmp_path / "one.csv")]
+    assert analyzerrun.deliver_csvs(srcs, None) == srcs
+
+
+def test_cli_walkforward_passes_overrides_and_anchored_through(monkeypatch, capsys):
+    seen = {}
+
+    def fake_run(mode, template, opt, **kw):
+        seen.update(mode=mode, template=template, opt=opt, **kw)
+        return {"status": "ok", "csvFiles": []}
+
+    monkeypatch.setattr(cli.ntanalyzerrun, "run_analyzer", fake_run)
+    rc = cli.main(["walkforward", "--template=WFO.xml", "--opt=Fast:20:30:5", "--anchored",
+                   "--OptimizationPeriod=10", "--TestPeriod=5", "--timeout", "60"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["command"] == "walkforward"
+    assert seen["mode"] == "walkforward"
+    assert seen["template"] == "WFO.xml"
+    assert seen["opt"] == "Fast:20:30:5"
+    assert seen["anchored"] is True
+    assert seen["params"] == {"OptimizationPeriod": "10", "TestPeriod": "5"}
+    assert seen["timeout"] == 60.0
+
+
+def test_cli_optimize_refuses_a_malformed_range_before_writing_a_request(monkeypatch, capsys):
+    called = []
+    monkeypatch.setattr(cli.ntanalyzerrun, "run_analyzer",
+                        lambda *a, **k: called.append(1) or {"status": "ok"})
+    rc = cli.main(["optimize", "--template=WFO.xml", "--opt=Fast:20:30"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert payload["ok"] is False
+    assert "needs 4 fields" in payload["error"]
+    assert called == []
+
+
+def test_cli_optimize_refuses_an_override_of_the_wrong_shape(monkeypatch, capsys):
+    monkeypatch.setattr(cli.ntanalyzerrun, "run_analyzer", lambda *a, **k: {"status": "ok"})
+    rc = cli.main(["optimize", "--template=WFO.xml", "--opt=Fast:20:30:5", "--TestPeriod", "5"])
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 2
+    assert "--Name=value" in payload["error"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -312,3 +312,218 @@ def test_histdump_cli_dispatch(monkeypatch, capsys):
     assert called["instrument_glob"] == "MNQ*" and called["mode"] == "depth"
     out = json.loads(capsys.readouterr().out)
     assert out["command"] == "histdump" and out["count"] == 1
+
+
+def test_backtest_without_config_runs_the_tab_as_it_stands(monkeypatch, capsys):
+    """No --config is a plain Run, not a missing argument.
+
+    A template put on the tab by `satemplate` already carries instrument, window
+    and every parameter, so demanding them again here would reintroduce exactly
+    the restatement that naming a file removes. The AddOn injects params only
+    when the request carries some, which makes an empty config a Run and nothing
+    else.
+    """
+    seen = {}
+    monkeypatch.setattr(cli.ntbacktest, "run_backtest",
+                        lambda cfg, timeout=120.0: seen.update(cfg=cfg) or {"status": "ok"})
+    rc = cli.main(["backtest"])
+    out = json.loads(capsys.readouterr().out)
+    assert seen["cfg"] == {}
+    assert out["command"] == "backtest" and rc == 0
+
+
+def test_backtest_with_a_bad_config_still_refuses(monkeypatch, capsys):
+    """Optional is not ignored: a config that IS given is still validated."""
+    def boom(_path):
+        raise cli.ntconfig.ConfigError("Config not found: nope.json")
+
+    monkeypatch.setattr(cli.ntconfig, "load_config", boom)
+    rc = cli.main(["backtest", "--config", "nope.json"])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1 and out["ok"] is False and "nope.json" in out["error"]
+
+
+def test_satemplate_forwards_the_template_and_timeout(monkeypatch, capsys):
+    seen = {}
+    monkeypatch.setattr(cli.ntsatemplate, "run_satemplate",
+                        lambda template, timeout=30.0:
+                        seen.update(template=template, timeout=timeout)
+                        or {"status": "ok", "applied": True})
+    rc = cli.main(["satemplate", "--template", r"C:\t\A.xml", "--timeout", "45"])
+    out = json.loads(capsys.readouterr().out)
+    assert seen["template"] == r"C:\t\A.xml" and seen["timeout"] == 45.0
+    assert out["command"] == "satemplate" and out["applied"] is True and rc == 0
+
+
+def test_satemplate_that_did_not_apply_is_a_failure(monkeypatch, capsys):
+    """A template the tab did not take must not exit 0.
+
+    The run afterwards would use whatever was there before, and every step would
+    report ok while the numbers belonged to another variant.
+    """
+    monkeypatch.setattr(cli.ntsatemplate, "run_satemplate",
+                        lambda template, timeout=30.0:
+                        {"status": "error", "applied": False,
+                         "error": "the tab kept its previous StrategyTemplate instance"})
+    rc = cli.main(["satemplate", "--template", "A.xml"])
+    capsys.readouterr()
+    assert rc == 1
+
+
+def _fake_playbackrun_driver(result):
+    """Stand in for the driver process, writing the result file it would write."""
+    import subprocess
+
+    seen = {}
+
+    def fake_run(cmd, **kw):
+        seen["cmd"] = cmd
+        path = cmd[cmd.index("--result") + 1]
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(result, fh)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    return seen, fake_run
+
+
+def test_playbackrun_cli_dispatch(monkeypatch, capsys):
+    """The wrapper's job is the argument list and the verdict, not the run itself."""
+    import subprocess
+
+    from nt8bridge import cli
+
+    seen, fake_run = _fake_playbackrun_driver({"command": "playbackrun", "ok": True, "rc": 0})
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc = cli.main(["playbackrun", "--strategy", "MyBot", "--instrument", "NQ 06-26",
+                   "--source", "marketreplay", "--tick-replay", "false",
+                   "--bars-type", "Minute", "--bars-value", "1",
+                   "--from", "2026-08-10", "--to", "2026-08-10"])
+    capsys.readouterr()
+    assert rc == 0
+    cmd = seen["cmd"]
+    for flag, value in (("--strategy", "MyBot"), ("--instrument", "NQ 06-26"),
+                        ("--source", "marketreplay"), ("--tick-replay", "false"),
+                        ("--bars-type", "Minute"), ("--bars-value", "1"),
+                        ("--from", "2026-08-10"), ("--to", "2026-08-10")):
+        assert cmd[cmd.index(flag) + 1] == value
+    assert cmd[cmd.index("--setup") + 1] == "template"
+
+
+def test_playbackrun_that_did_not_reach_the_data_end_is_a_failure(monkeypatch, capsys):
+    """`ok: false` must not exit 0 - a run that stopped early is not a measurement."""
+    import subprocess
+
+    from nt8bridge import cli
+
+    _, fake_run = _fake_playbackrun_driver(
+        {"command": "playbackrun", "ok": False, "rc": 2, "endReason": "did-not-finish"})
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc = cli.main(["playbackrun", "--strategy", "MyBot", "--instrument", "NQ 06-26",
+                   "--source", "historical", "--tick-replay", "true",
+                   "--bars-type", "Tick", "--bars-value", "1",
+                   "--from", "2026-08-10", "--to", "2026-08-10"])
+    capsys.readouterr()
+    assert rc == 2
+
+
+def test_playbackrun_rejects_an_unsupported_bar_type(capsys):
+    """`--bars-type Day` used to fall through to the Minute token and run silently."""
+    import pytest
+
+    with pytest.raises(SystemExit):
+        cli.main(["playbackrun", "--strategy", "MyBot", "--instrument", "NQ 06-26",
+                  "--source", "marketreplay", "--tick-replay", "false",
+                  "--bars-type", "Day", "--bars-value", "1",
+                  "--from", "2026-08-10", "--to", "2026-08-10"])
+    assert "invalid choice" in capsys.readouterr().err
+
+
+def test_playbackrun_refuses_a_malformed_date_before_starting_the_driver(monkeypatch, capsys):
+    """Measured 2026-09-01: seven runs carried --to 2026-13-07 into NinjaTrader and
+    each ended 45-58 s of wall clock later with "FormatException: String was not recognized as a
+    valid DateTime." The parser refuses it here, and the driver never starts."""
+    import subprocess
+
+    import pytest
+
+    seen, fake_run = _fake_playbackrun_driver({"command": "playbackrun", "ok": True, "rc": 0})
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    for bad in ("2026-13-07", "07/07/2026", "2026-7-7"):
+        with pytest.raises(SystemExit) as ex:
+            cli.main(["playbackrun", "--strategy", "MyBot", "--instrument", "NQ 06-26",
+                      "--from", "2026-06-07", "--to", bad])
+        err = capsys.readouterr().err
+        assert ex.value.code == 2
+        assert bad in err and "YYYY-MM-DD" in err
+    assert "cmd" not in seen            # no driver process, hence no request
+
+
+def test_playbackrun_refuses_an_end_before_the_start(monkeypatch, capsys):
+    """Both dates well-formed, the pair unusable: the same refusal, the same silence."""
+    import subprocess
+
+    import pytest
+
+    seen, fake_run = _fake_playbackrun_driver({"command": "playbackrun", "ok": True, "rc": 0})
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    with pytest.raises(SystemExit) as ex:
+        cli.main(["playbackrun", "--strategy", "MyBot", "--instrument", "NQ 06-26",
+                  "--from", "2026-06-07", "--to", "2026-06-01"])
+    err = capsys.readouterr().err
+    assert ex.value.code == 2
+    assert "--to 2026-06-01" in err and "--from 2026-06-07" in err
+    assert "cmd" not in seen
+
+
+def test_playbackrun_forwards_a_valid_pair_unchanged(monkeypatch, capsys):
+    """type= returns the string it was given, so the driver sees what was typed;
+    the same day at both ends is a one-day run, not a refusal."""
+    import subprocess
+
+    seen, fake_run = _fake_playbackrun_driver({"command": "playbackrun", "ok": True, "rc": 0})
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc = cli.main(["playbackrun", "--strategy", "MyBot", "--instrument", "NQ 06-26",
+                   "--from", "2026-06-07", "--to", "2026-06-07"])
+    capsys.readouterr()
+    assert rc == 0
+    cmd = seen["cmd"]
+    assert cmd[cmd.index("--from") + 1] == "2026-06-07"
+    assert cmd[cmd.index("--to") + 1] == "2026-06-07"
+
+
+def test_playbackrun_passes_account_and_stage_wait_to_the_driver(monkeypatch, capsys):
+    """--account and --stage-wait are the driver's; the wrapper only has to hand them over."""
+    import subprocess
+
+    from nt8bridge import cli
+
+    seen, fake_run = _fake_playbackrun_driver({"command": "playbackrun", "ok": True, "rc": 0})
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc = cli.main(["playbackrun", "--strategy", "MyBot", "--instrument", "NQ 06-26",
+                   "--source", "marketreplay", "--tick-replay", "false",
+                   "--bars-type", "Minute", "--bars-value", "1",
+                   "--from", "2026-08-10", "--to", "2026-08-10",
+                   "--account", "Playback101", "--stage-wait", "20"])
+    capsys.readouterr()
+    assert rc == 0
+    cmd = seen["cmd"]
+    assert cmd[cmd.index("--account") + 1] == "Playback101"
+    assert cmd[cmd.index("--stage-wait") + 1] == "20"
+
+
+def test_playbackrun_without_account_and_stage_wait_sends_neither(monkeypatch, capsys):
+    """Absent switches must stay absent: the driver's own defaults decide, not a wrapper value."""
+    import subprocess
+
+    from nt8bridge import cli
+
+    seen, fake_run = _fake_playbackrun_driver({"command": "playbackrun", "ok": True, "rc": 0})
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc = cli.main(["playbackrun", "--strategy", "MyBot", "--instrument", "NQ 06-26",
+                   "--source", "marketreplay", "--tick-replay", "false",
+                   "--bars-type", "Minute", "--bars-value", "1",
+                   "--from", "2026-08-10", "--to", "2026-08-10"])
+    capsys.readouterr()
+    assert rc == 0
+    assert "--account" not in seen["cmd"]
+    assert "--stage-wait" not in seen["cmd"]

--- a/tests/test_playback_run_dates.py
+++ b/tests/test_playback_run_dates.py
@@ -1,0 +1,152 @@
+"""--from/--to of playback_run are refused at argument time, before any request.
+
+Measured 2026-09-01: seven archived runs carried "to": "2026-13-07" and every
+one of them died in stage 2 with "FormatException: String was not recognized
+as a valid DateTime." after 45-58 s of wall clock - nothing had checked the
+value on the way in. These tests drive the validator directly, and main() end
+to end against trigger and result folders under tmp_path, so "no request was
+written" is a reading of the folder and not a belief.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import pytest
+
+from nt8bridge import playback_run as pr
+
+# What the AddOn's `transport` stage answers before Playback is connected: a
+# step that reports FAIL is still an ANSWER, so the preflight is satisfied.
+ANSWER = {"id": "a1", "status": "ok", "stage": "transport",
+          "steps": [{"step": "timer", "ok": False,
+                     "detail": "field 'timer' not found or null"}]}
+# What stage() returns when no result file appeared within its wait.
+NOREACTION = {"status": "noreaction", "steps": [], "id": "0" * 32}
+
+
+@pytest.mark.parametrize("value", ["2026-06-07", "2026-08-10", "2024-02-29"])
+def test_iso_date_returns_a_valid_day_unchanged(value):
+    """The same string comes back: the request JSON and the archive carry
+    what was typed, exactly as before the check existed."""
+    assert pr.iso_date(value) == value
+
+
+@pytest.mark.parametrize("value, reason", [
+    ("2026-13-07", "month must be in 1..12"),          # the seven archived runs
+    ("2026-02-30", "day is out of range for month"),
+    ("2026-7-7", "not a date of the form"),
+    ("07/07/2026", "not a date of the form"),
+    ("20260607", "not a date of the form"),            # fromisoformat alone takes this on 3.11
+    ("2026-W23-1", "not a date of the form"),          # and this one
+    ("2026-06-07T00:00", "not a date of the form"),
+    (" 2026-06-07", "not a date of the form"),
+])
+def test_iso_date_refuses_with_the_accepted_form_and_the_value(value, reason):
+    with pytest.raises(argparse.ArgumentTypeError) as ex:
+        pr.iso_date(value)
+    text = str(ex.value)
+    assert value in text
+    assert pr.DATE_FORMAT in text
+    assert reason in text
+
+
+def test_date_order_allows_the_same_day_and_refuses_an_earlier_end():
+    assert pr.date_order_error("2026-06-07", "2026-06-07") is None
+    assert pr.date_order_error("2026-06-07", "2026-06-08") is None
+    text = pr.date_order_error("2026-06-07", "2026-06-01")
+    assert "--to 2026-06-01" in text and "--from 2026-06-07" in text
+    assert "before" in text
+
+
+# ---------------------------------------------------------------- main() end to end
+
+def _argv(tmp_path, date_from: str, date_to: str) -> list:
+    nt8 = tmp_path / "nt8"
+    nt8.mkdir(exist_ok=True)
+    return ["playback_run.py", "--name", "DATES", "--source", "historical",
+            "--tick-replay", "false", "--strategy", "EmptyStrategy",
+            "--instrument", "NQ 06-26", "--bars-type", "Minute",
+            "--bars-value", "1", "--from", date_from, "--to", date_to,
+            "--nt8-dir", str(nt8), "--archive", str(tmp_path / "runs"),
+            "--log", str(tmp_path / "transcript.log"), "--debug-console",
+            "--result", str(tmp_path / "result.json")]
+
+
+@pytest.fixture
+def driver(tmp_path, monkeypatch):
+    """Trigger and result folders under tmp_path, and every module global
+    main() rewrites put back afterwards."""
+    trig = tmp_path / "trigger"
+    res = tmp_path / "result"
+    trig.mkdir()
+    res.mkdir()
+    for name in ("NT8", "TRIG", "RES", "ARCHIVE", "BOTLOGS",
+                 "STAGE_WAIT", "SLOW_WAIT", "CONNECT_WAIT", "PREFLIGHT_WAIT"):
+        monkeypatch.setattr(pr, name, getattr(pr, name))
+    monkeypatch.setattr(pr, "TRIG", trig)
+    monkeypatch.setattr(pr, "RES", res)
+    monkeypatch.setattr(pr, "BOTS", [])
+    monkeypatch.setattr(pr, "FAIL", {"stage": None, "step": None, "detail": None})
+    monkeypatch.setitem(pr.STEP_MODE, "on", False)
+    monkeypatch.setitem(pr._UI, "user_mode", False)
+    monkeypatch.setitem(pr._shots, "dir", None)
+    return tmp_path, trig, res
+
+
+@pytest.mark.parametrize("date_from, date_to, expect", [
+    ("2026-06-07", "2026-13-07", ["2026-13-07", "YYYY-MM-DD", "month must be in 1..12"]),
+    ("2026-06-07", "07/07/2026", ["07/07/2026", "YYYY-MM-DD"]),
+    ("2026-06-07", "2026-06-01", ["--to 2026-06-01", "--from 2026-06-07", "before"]),
+])
+def test_main_refuses_before_any_request_is_written(
+        driver, monkeypatch, capsys, date_from, date_to, expect):
+    """Exit 2 with the accepted form and the offending value on stderr, and
+    nothing else happened: no request asked, no trigger file, no result file,
+    no archive, no transcript."""
+    tmp_path, trig, res = driver
+    monkeypatch.setattr(sys, "argv", _argv(tmp_path, date_from, date_to))
+    sent = []
+
+    def must_not_be_called(title, req, wait=None, show=True, report_miss=True):
+        sent.append(dict(req))
+        raise AssertionError("a request was sent: " + title)
+
+    monkeypatch.setattr(pr, "stage", must_not_be_called)
+    with pytest.raises(SystemExit) as ex:
+        pr.main()
+    err = capsys.readouterr().err
+    assert ex.value.code == 2
+    for piece in expect:
+        assert piece in err
+    assert sent == []
+    assert list(trig.iterdir()) == []
+    assert list(res.iterdir()) == []
+    assert not (tmp_path / "runs").exists()
+    assert not (tmp_path / "result.json").exists()
+    assert not (tmp_path / "transcript.log").exists()
+
+
+def test_main_accepts_a_valid_pair_and_carries_it_unchanged(driver, monkeypatch, capsys):
+    """A usable pair passes the parser, the bridge is asked, and result.json
+    carries the strings as typed. The scripted bridge answers the preflight
+    probe only, so the run stops at step 1a with rc 2, as it always did."""
+    tmp_path, trig, res = driver
+    monkeypatch.setattr(sys, "argv", _argv(tmp_path, "2026-06-07", "2026-06-08"))
+    sent, script = [], [dict(ANSWER)]
+
+    def scripted(title, req, wait=None, show=True, report_miss=True, lease=120):
+        # `lease` mirrors stage()'s signature - the teardown passes lease=0
+        # (test_playback_run_lease.py); a stand-in without it fails there.
+        sent.append(dict(req))
+        return script.pop(0) if script else dict(NOREACTION)
+
+    monkeypatch.setattr(pr, "stage", scripted)
+    rc = pr.main()
+    capsys.readouterr()
+    assert rc == 2
+    assert sent and sent[0]["stage"] == "transport"
+    result = json.loads((tmp_path / "result.json").read_text(encoding="utf-8"))
+    assert result["from"] == "2026-06-07"
+    assert result["to"] == "2026-06-08"

--- a/tests/test_playback_run_lease.py
+++ b/tests/test_playback_run_lease.py
@@ -1,0 +1,97 @@
+"""The driver lease travels in every request, and the run's last requests release it.
+
+Measured 2026-09-07 08:23 on NinjaTrader 8.1.8.2 (bridge.log against NinjaTrader's own
+trace): the AddOn started the 120 s lease at the RECEIPT of the connect request, the
+connect took 282 s, and on its next poll tick the AddOn found the lease expired and
+tore down the connection it had just built. The AddOn now counts from the moment it
+answered; this file pins the driver's half of the contract - what it sends.
+"""
+import json
+import threading
+import time
+
+import pytest
+
+from nt8bridge import playback_run as pr
+
+
+@pytest.fixture
+def bridge(tmp_path, monkeypatch):
+    trig = tmp_path / "trigger"
+    res = tmp_path / "result"
+    trig.mkdir()
+    res.mkdir()
+    monkeypatch.setattr(pr, "TRIG", trig)
+    monkeypatch.setattr(pr, "RES", res)
+    monkeypatch.setitem(pr._UI, "user_mode", False)
+    monkeypatch.setitem(pr._shots, "dir", None)
+    return trig, res
+
+
+def answer_first_trigger(trig, res, seen: list) -> threading.Thread:
+    """A stand-in AddOn: reads the first trigger file, records it, answers it."""
+
+    def run():
+        for _ in range(500):
+            files = list(trig.iterdir())
+            if files:
+                f = files[0]
+                req = json.loads(f.read_text(encoding="utf-8"))
+                seen.append(req)
+                f.unlink()
+                (res / f.name).write_text(json.dumps(
+                    {"id": req["id"], "status": "ok", "stage": req.get("stage"),
+                     "steps": [{"step": "answered", "ok": True, "detail": ""}]}),
+                    encoding="utf-8")
+                return
+            time.sleep(0.01)
+
+    t = threading.Thread(target=run, daemon=True)
+    t.start()
+    return t
+
+
+def test_stage_sends_the_default_lease(bridge):
+    trig, res = bridge
+    seen = []
+    t = answer_first_trigger(trig, res, seen)
+    d = pr.stage("x", {"stage": "transport"}, wait=2, show=False)
+    t.join(2)
+    assert d.get("status") == "ok"
+    assert seen and seen[0]["leaseSec"] == 120
+    assert seen[0]["ttlSec"] == 2
+    assert seen[0]["kind"] == "playbackrun"
+
+
+def test_stage_lease_zero_is_the_clean_exit(bridge):
+    """lease=0 is the AddOn's release (NoteLease: v <= 0 -> nothing to guard).
+    The restore stage and the bot-output fetch after it send it."""
+    trig, res = bridge
+    seen = []
+    t = answer_first_trigger(trig, res, seen)
+    d = pr.stage("x", {"stage": "restore"}, wait=2, show=False, lease=0)
+    t.join(2)
+    assert d.get("status") == "ok"
+    assert seen and seen[0]["leaseSec"] == 0
+
+
+def test_teardown_requests_release_the_lease(bridge, monkeypatch):
+    """restore_baseline() and the bot-output fetch after it both pass lease=0 -
+    the run's last two requests. Anything else sending 120 after them would
+    re-arm the lease and the AddOn would restore the baseline a second time
+    two minutes later (bridge.log 2026-09-07 06:26:06Z, 06:24:01Z)."""
+    calls = []
+
+    def fake_stage(title, req, wait=None, show=True, report_miss=True, lease=120):
+        calls.append({"title": title, "stage": req.get("stage"), "lease": lease})
+        return {"status": "ok", "steps": [{"step": "ok", "ok": True, "detail": ""}]}
+
+    monkeypatch.setattr(pr, "stage", fake_stage)
+    pr.restore_baseline("Bot")
+    pr.print_bot_output(lease=0)
+    assert [c["stage"] for c in calls] == ["restore", "botout"]
+    assert [c["lease"] for c in calls] == [0, 0]
+    # and the same fetch OUTSIDE a teardown keeps the guard armed
+    calls.clear()
+    pr.print_bot_output()
+    assert calls == [{"title": "botout", "stage": "botout", "lease": 120}]

--- a/tests/test_playback_run_order_notices.py
+++ b/tests/test_playback_run_order_notices.py
@@ -1,0 +1,13 @@
+"""The "order notices" step of the play loop: what the driver reads out of it."""
+from nt8bridge.playback_run import order_notice_counts
+
+
+def test_counts_are_read_from_the_step_text():
+    assert order_notice_counts("1 dismissed this sample, 3 in this run") == (1, 3)
+    assert order_notice_counts("0 dismissed this sample, 0 in this run") == (0, 0)
+
+
+def test_absent_or_foreign_step_text_claims_nothing():
+    assert order_notice_counts("") == (0, 0)
+    assert order_notice_counts(None) == (0, 0)
+    assert order_notice_counts("yes - the strategy has terminated") == (0, 0)

--- a/tests/test_playback_run_preflight.py
+++ b/tests/test_playback_run_preflight.py
@@ -1,0 +1,561 @@
+"""Stage 0 of playback_run - the preflight - waits for a busy NinjaTrader.
+
+Runs without NinjaTrader: the request/response function the module uses for
+every stage (`stage`) is replaced by a scripted one, and the poll's clock,
+sleep and process-list reading (`process`) are injected, so a poll that
+would take half an hour of wall clock finishes in milliseconds and never
+reads the process list. Two tests drive the REAL stage() against an empty
+trigger folder - to prove the cleanup, and to prove what the transcript of an
+unanswered poll holds - and four drive main() end to end so the contract a
+caller sees (rc, the error string, result.json, the console explanation) is
+what is tested.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import time
+import types
+
+import pytest
+
+from nt8bridge import playback_run as pr
+
+# What the AddOn's `transport` stage answers before Playback is connected - a
+# step that reports FAIL is still an ANSWER (stage 0 asks show=False for that).
+ANSWER = {"id": "a1", "status": "ok", "stage": "transport",
+          "steps": [{"step": "timer", "ok": False,
+                     "detail": "field 'timer' not found or null"}]}
+# What stage() returns when no result file appeared within wait + grace.
+NOREACTION = {"status": "noreaction", "steps": [], "id": "0123456789abcdef"}
+# What HandleTrigger writes for a trigger older than its ttlSec: a reaction
+# without steps.
+EXPIRED = {"id": "e1", "status": "expired", "executed": False,
+           "errors": [{"code": "EXPIRED",
+                       "message": "request waited 40s in the queue, past its "
+                                  "20s TTL; not executed"}]}
+# stage() listens wait + GRACE = 20 + 6 s for a probe that gets no answer, and
+# returns within a round trip (about 3 s measured) for one that does.
+UNANSWERED_S = 26.0
+ANSWERED_S = 3.0
+# What restart.process_listed returns - the three states, with the text it
+# quotes (measured 2026-09-02; the INFO line is the console's locale text).
+LISTED = (True, "tasklist lists NinjaTrader.exe 4711 Console 1 1,234,567 K")
+UNLISTED = (False, "tasklist answered: INFO: No tasks are running which match "
+                   "the specified criteria.")
+UNREADABLE = (None, "tasklist could not be run: FileNotFoundError: [WinError 2] "
+                    "The system cannot find the file specified")
+UNREADABLE_2 = (None, "tasklist exited 1, printed nothing on stdout, stderr: "
+                      "ERROR: The search filter cannot be recognized.")
+
+
+def unreadable_lines(out: str) -> list:
+    return [ln for ln in out.splitlines()
+            if ln.startswith("The process list could not be read after probe")]
+
+
+class FakeClock:
+    """A clock that advances only when told."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.fixture
+def bridge(tmp_path, monkeypatch):
+    """Trigger and result folders under tmp_path; debug console mode, so user()
+    lines are plain print()s that capsys sees; module state restored after."""
+    trig = tmp_path / "trigger"
+    res = tmp_path / "result"
+    trig.mkdir()
+    res.mkdir()
+    monkeypatch.setattr(pr, "TRIG", trig)
+    monkeypatch.setattr(pr, "RES", res)
+    monkeypatch.setitem(pr._UI, "user_mode", False)
+    monkeypatch.setitem(pr._shots, "dir", None)
+    return tmp_path
+
+
+def scripted_stage(clock: FakeClock, script: list, calls: list):
+    """A stand-in for stage(): answers from `script` in order, NOREACTION once
+    the script is used up, and moves the clock by what the real one would
+    have spent listening."""
+
+    def fake_stage(title, req, wait=None, show=True, report_miss=True, lease=120):
+        # `lease` mirrors stage()'s signature: the run's teardown passes lease=0
+        # (test_playback_run_lease.py), so a stand-in without it would turn every
+        # main() test into a TypeError inside the teardown. Not recorded here -
+        # the lease contract has its own file.
+        calls.append({"title": title, "req": dict(req), "wait": wait, "show": show,
+                      "report_miss": report_miss})
+        d = script.pop(0) if script else dict(NOREACTION)
+        clock.advance(ANSWERED_S if d.get("steps") else UNANSWERED_S)
+        return d
+
+    return fake_stage
+
+
+def busy_lines(out: str) -> list:
+    return [ln for ln in out.splitlines()
+            if ln.startswith("NinjaTrader is busy - no answer for")]
+
+
+def test_answered_first_probe_does_not_wait(bridge, monkeypatch, capsys):
+    """(a) One answer, one probe, no waiting line - the fast path stays fast."""
+    clock, calls, sleeps = FakeClock(), [], []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [dict(ANSWER)], calls))
+    pre = pr.preflight(budget=1800, clock=clock, sleep=sleeps.append,
+                       process=lambda: pytest.fail("process list read on the fast path"))
+    assert pre["answered"] is True
+    assert pre["process"] is None                  # no reading was made
+    assert pre["probes"] == 1
+    assert pre["steps"] == ANSWER["steps"]
+    assert pre["seconds"] == pytest.approx(ANSWERED_S)
+    assert sleeps == []
+    out = capsys.readouterr().out
+    assert busy_lines(out) == []
+    assert "Bridge answered after" not in out
+    # The probe is the cheap transport read with the short TTL, and never
+    # visible: a FAIL step before connect must not trip the hard stop. Its
+    # miss is the poll's to record - the stage's own NO REACTION verdict
+    # ("not waiting longer") stays out of a transcript that asks again.
+    assert calls == [{"title": "0 preflight",
+                      "req": {"stage": "transport", "sampleMs": "200"},
+                      "wait": pr.PREFLIGHT_PROBE_WAIT, "show": False,
+                      "report_miss": False}]
+
+
+def test_unanswered_probes_are_waited_out_and_reported_at_most_every_30_s(
+        bridge, monkeypatch, capsys):
+    """(b) Five silent probes with the process PRESENT, then an answer: the
+    poll continues exactly as it did before the process check existed, the
+    process list is asked once per unanswered probe and never for the answered
+    one, and the console line came no more often than every PREFLIGHT_REPORT_S."""
+    clock, calls, sleeps, checks = FakeClock(), [], [], []
+    script = [dict(NOREACTION) for _ in range(5)] + [dict(ANSWER)]
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, script, calls))
+
+    def present() -> tuple:
+        checks.append(clock.now)
+        return LISTED
+
+    pre = pr.preflight(budget=1800, clock=clock, sleep=sleeps.append, process=present)
+    assert pre["answered"] is True
+    assert pre["process"] == {"listed": True, "detail": LISTED[1]}
+    assert pre["probes"] == 6
+    assert pre["seconds"] == pytest.approx(5 * UNANSWERED_S + ANSWERED_S)
+    # one check per unanswered probe, each AFTER that probe's 26 s of
+    # listening - and none for the sixth probe, which was answered
+    assert checks == [1000.0 + UNANSWERED_S * n for n in range(1, 6)]
+    out = capsys.readouterr().out
+    assert "NinjaTrader.exe is not running" not in out
+    assert unreadable_lines(out) == []
+    reported = [int(re.search(r"no answer for (\d+) s", ln).group(1))
+                for ln in busy_lines(out)]
+    # the first miss at 26 s, then never closer than PREFLIGHT_REPORT_S
+    assert reported == [26, 78, 130]
+    assert all(b - a >= pr.PREFLIGHT_REPORT_S
+               for a, b in zip(reported, reported[1:]))
+    assert all("waiting up to 1800 s" in ln for ln in busy_lines(out))
+    assert "Bridge answered after 133 s (6 probes)" in out
+    # every probe carried the short TTL, so none can be executed late
+    assert [c["wait"] for c in calls] == [pr.PREFLIGHT_PROBE_WAIT] * 6
+    # a silent probe is re-asked at once - stage() already listened 26 s
+    assert sleeps == []
+
+
+def test_reaction_without_steps_is_re_asked_after_one_poller_tick(
+        bridge, monkeypatch, capsys):
+    """An `expired` file is the AddOn reading triggers again, not an answer:
+    the next probe follows after one poller tick, not in a hot loop."""
+    clock, calls, sleeps = FakeClock(), [], []
+    monkeypatch.setattr(pr, "stage",
+                        scripted_stage(clock, [dict(EXPIRED), dict(ANSWER)], calls))
+    pre = pr.preflight(budget=1800, clock=clock, sleep=sleeps.append,
+                       process=lambda: LISTED)
+    assert pre["answered"] is True
+    assert pre["probes"] == 2
+    assert sleeps == [1.0]
+
+
+def test_budget_exhausted_is_not_answered(bridge, monkeypatch, capsys):
+    """(c) at the function: the poll gives up only once the budget is spent,
+    and reports how long it listened."""
+    clock, calls, sleeps = FakeClock(), [], []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [], calls))
+    pre = pr.preflight(budget=100, clock=clock, sleep=sleeps.append,
+                       process=lambda: LISTED)
+    assert pre["answered"] is False
+    assert pre["process"] == {"listed": True, "detail": LISTED[1]}
+    assert pre["steps"] == []
+    assert pre["probes"] == 4                     # 4 x 26 s = 104 s >= 100 s
+    assert pre["seconds"] == pytest.approx(4 * UNANSWERED_S)
+    assert pre["seconds"] >= 100
+
+
+def test_no_trigger_file_is_left_behind_by_the_poll(bridge, monkeypatch):
+    """(d) With the REAL stage() and no AddOn: the trigger it wrote is taken
+    back once the probe went unanswered, and nothing stays in either folder."""
+    # the real stage() sleeps 0.1 s per sample for wait + 6 s: make that free
+    monkeypatch.setattr(pr, "time", types.SimpleNamespace(
+        time=time.time, monotonic=time.monotonic, sleep=lambda s: None))
+    real_stage = pr.stage
+    after_stage = []
+
+    def spy(title, req, wait=None, show=True, report_miss=True):
+        d = real_stage(title, req, wait=wait, show=show, report_miss=report_miss)
+        after_stage.append(sorted(p.name for p in pr.TRIG.iterdir()))
+        return d
+
+    monkeypatch.setattr(pr, "stage", spy)
+    clock = FakeClock()
+
+    def ticking() -> float:
+        # 30 s per reading against a 1 s budget: one probe, then the poll ends
+        clock.advance(30.0)
+        return clock.now
+
+    pre = pr.preflight(budget=1, clock=ticking, sleep=lambda s: None,
+                       process=lambda: LISTED)
+    assert pre["answered"] is False
+    assert pre["probes"] == 1
+    # the trigger existed while the probe was pending ...
+    assert len(after_stage) == 1 and len(after_stage[0]) == 1
+    assert after_stage[0][0].startswith("playbackrun_")
+    assert after_stage[0][0].endswith(".json")
+    # ... and is gone once the poll ended - and no result file appeared
+    assert list(pr.TRIG.iterdir()) == []
+    assert list(pr.RES.iterdir()) == []
+
+
+def test_unanswered_probes_leave_only_the_polls_own_lines_in_the_transcript(
+        bridge, monkeypatch, capsys):
+    """(h) With the REAL stage() and no AddOn, budget 100 s: four probes go
+    unanswered and the transcript holds the poll's record of them - one
+    "asking again" line per probe that was asked again, the user line every
+    PREFLIGHT_REPORT_S - and nothing from the stage itself. Measured
+    2026-09-02 before the fix: the stage's NO REACTION verdict ("not waiting
+    longer, that IS the finding") stood in the transcript four times, each
+    directly above the poll's "asking again" - 25 lines contradicting each
+    other once per probe. The default is unchanged: a stage nobody asks again
+    keeps reporting its miss, visible or not."""
+    monkeypatch.setattr(pr, "time", types.SimpleNamespace(
+        time=time.time, monotonic=time.monotonic, sleep=lambda s: None))
+    clock = FakeClock()
+
+    def ticking() -> float:
+        clock.advance(UNANSWERED_S)      # what one real probe costs
+        return clock.now
+
+    pre = pr.preflight(budget=100, clock=ticking, sleep=lambda s: None,
+                       process=lambda: LISTED)
+    assert pre["answered"] is False
+    assert pre["probes"] == 4                     # 4 x 26 s = 104 s >= 100 s
+    out = capsys.readouterr().out
+    assert "NO REACTION" not in out
+    assert "not waiting longer" not in out
+    assert "progress file: never written" not in out
+    assert "--- 0 preflight ---" not in out
+    asked_again = [ln for ln in out.splitlines() if "no answer to probe" in ln]
+    assert [int(re.search(r"probe (\d+)", ln).group(1)) for ln in asked_again] == [1, 2, 3]
+    assert all(ln.endswith("- asking again") for ln in asked_again)
+    reported = [int(re.search(r"no answer for (\d+) s", ln).group(1))
+                for ln in busy_lines(out)]
+    assert reported == [26, 78]
+    # the last miss is the caller's verdict, not a line here; nothing else
+    assert len(out.splitlines()) == len(asked_again) + len(reported)
+    assert list(pr.TRIG.iterdir()) == []
+    assert list(pr.RES.iterdir()) == []
+    # the default: the same unanswered request, not part of a poll, reports
+    # its miss - the hidden probe of a caller that stops there included
+    pr.stage("lone probe", {"stage": "transport"}, wait=1, show=False)
+    out = capsys.readouterr().out
+    assert "--- lone probe ---" in out
+    assert "NO REACTION in 7 s (server budget 1 s + 6 s grace)" in out
+    assert "not waiting longer, that IS the finding" in out
+    assert "progress file: never written" in out
+    pr.stage("lone probe", {"stage": "transport"}, wait=1, show=False,
+             report_miss=False)
+    assert capsys.readouterr().out == ""
+
+
+def test_process_absent_stops_the_poll_after_the_first_probe(
+        bridge, monkeypatch, capsys):
+    """(e) No NinjaTrader.exe: the poll stops after ONE unanswered probe - the
+    26 s the single ask cost - not after the budget, and says why. The process
+    list is asked once, AFTER the probe, never before it."""
+    clock, calls, sleeps, checks = FakeClock(), [], [], []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [], calls))
+
+    def absent() -> tuple:
+        checks.append(clock.now)
+        return UNLISTED
+
+    pre = pr.preflight(budget=1800, clock=clock, sleep=sleeps.append, process=absent)
+    assert pre["answered"] is False
+    assert pre["process"] == {"listed": False, "detail": UNLISTED[1]}
+    assert pre["steps"] == []
+    assert pre["probes"] == 1
+    assert pre["seconds"] == pytest.approx(UNANSWERED_S)
+    assert checks == [1000.0 + UNANSWERED_S]      # after the probe, not before
+    assert len(calls) == 1
+    assert sleeps == []
+    out = capsys.readouterr().out
+    assert "NinjaTrader.exe is not running" in out
+    assert UNLISTED[1] in out                     # what was measured, quoted
+    assert "the poll stops after probe 1 (26 s of 1800 s)" in out
+    assert busy_lines(out) == []                  # a dead process is not "busy"
+
+
+def test_process_that_disappears_mid_poll_ends_it_on_that_round(
+        bridge, monkeypatch, capsys):
+    """The check is made every round, not once: a process that goes away
+    during the wait ends the poll on the first round that misses it, and the
+    rounds before it polled as usual."""
+    clock, calls, checks = FakeClock(), [], []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [], calls))
+    answers = [LISTED, LISTED, UNLISTED]
+
+    def process() -> tuple:
+        checks.append(clock.now)
+        return answers.pop(0)
+
+    pre = pr.preflight(budget=1800, clock=clock, sleep=lambda s: None, process=process)
+    assert pre["answered"] is False
+    assert pre["process"]["listed"] is False
+    assert pre["probes"] == 3
+    assert pre["seconds"] == pytest.approx(3 * UNANSWERED_S)
+    assert len(checks) == 3
+    out = capsys.readouterr().out
+    reported = [int(re.search(r"no answer for (\d+) s", ln).group(1))
+                for ln in busy_lines(out)]
+    assert reported == [26]                       # round 2 at 52 s is < 30 s later
+    assert "the poll stops after probe 3 (78 s of 1800 s)" in out
+
+
+def test_unreadable_process_list_is_no_verdict_and_is_said_once_per_failure(
+        bridge, monkeypatch, capsys):
+    """(f) tasklist that cannot be run, then one that exits 1, then a listing,
+    then an answer: a read that failed says nothing about the process, so the
+    poll goes on exactly as with the process present - and the console names
+    each distinct failure ONCE, not once per probe."""
+    clock, calls, checks = FakeClock(), [], []
+    script = [dict(NOREACTION) for _ in range(4)] + [dict(ANSWER)]
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, script, calls))
+    answers = [UNREADABLE, UNREADABLE, UNREADABLE_2, LISTED]
+
+    def process() -> tuple:
+        checks.append(clock.now)
+        return answers.pop(0)
+
+    pre = pr.preflight(budget=1800, clock=clock, sleep=lambda s: None, process=process)
+    assert pre["answered"] is True
+    assert pre["probes"] == 5
+    assert pre["process"] == {"listed": True, "detail": LISTED[1]}
+    assert len(checks) == 4
+    out = capsys.readouterr().out
+    assert "NinjaTrader.exe is not running" not in out
+    said = unreadable_lines(out)
+    assert len(said) == 2                         # two distinct failures, two lines
+    assert "after probe 1 (" in said[0] and UNREADABLE[1] in said[0]
+    assert "after probe 3 (" in said[1] and UNREADABLE_2[1] in said[1]
+    assert all("whether NinjaTrader.exe is running is not known" in ln for ln in said)
+    reported = [int(re.search(r"no answer for (\d+) s", ln).group(1))
+                for ln in busy_lines(out)]
+    assert reported == [26, 78]                   # the wait is reported as before
+    assert "Bridge answered after 107 s (5 probes)" in out
+
+
+def test_unreadable_process_list_for_the_whole_budget_is_not_a_verdict(
+        bridge, monkeypatch, capsys):
+    """(g) Never readable: the budget is spent as with the process present -
+    the poll never claims the process is absent - and the last reading says
+    so for the caller's report."""
+    clock, calls = FakeClock(), []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [], calls))
+    pre = pr.preflight(budget=100, clock=clock, sleep=lambda s: None,
+                       process=lambda: UNREADABLE)
+    assert pre["answered"] is False
+    assert pre["process"] == {"listed": None, "detail": UNREADABLE[1]}
+    assert pre["probes"] == 4                     # 4 x 26 s = 104 s >= 100 s
+    assert pre["seconds"] == pytest.approx(4 * UNANSWERED_S)
+    out = capsys.readouterr().out
+    assert "NinjaTrader.exe is not running" not in out
+    assert len(unreadable_lines(out)) == 1        # one failure, said once
+
+
+def test_default_process_check_is_the_restart_commands_own(bridge, monkeypatch):
+    """One implementation of "is NinjaTrader.exe running": the poll's default
+    is restart.process_listed itself - and it is resolved at call time, so a
+    hook set on the module is honoured by a call that names no `process`."""
+    from nt8bridge import restart
+    assert pr.ninjatrader_process_listed is restart.process_listed
+    clock, calls = FakeClock(), []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [], calls))
+    monkeypatch.setattr(pr, "ninjatrader_process_listed", lambda: UNLISTED)
+    pre = pr.preflight(budget=1800, clock=clock, sleep=lambda s: None)
+    assert pre["process"] == {"listed": False, "detail": UNLISTED[1]}
+    assert pre["probes"] == 1
+
+
+def _main_args(tmp_path) -> list:
+    nt8 = tmp_path / "nt8"
+    nt8.mkdir()
+    return ["playback_run.py", "--name", "PRE", "--source", "historical",
+            "--tick-replay", "false", "--strategy", "EmptyStrategy",
+            "--instrument", "NQ 06-26", "--bars-type", "Minute",
+            "--bars-value", "1", "--from", "2026-08-10", "--to", "2026-08-10",
+            "--nt8-dir", str(nt8), "--archive", str(tmp_path / "runs"),
+            "--log", str(tmp_path / "transcript.log"), "--debug-console",
+            "--result", str(tmp_path / "result.json")]
+
+
+@pytest.fixture
+def main_env(bridge, monkeypatch):
+    """main() rewrites module paths, budgets and run state from its arguments;
+    monkeypatch puts every one of them back afterwards."""
+    for name in ("NT8", "TRIG", "RES", "ARCHIVE", "BOTLOGS",
+                 "STAGE_WAIT", "SLOW_WAIT", "CONNECT_WAIT", "PREFLIGHT_WAIT"):
+        monkeypatch.setattr(pr, name, getattr(pr, name))
+    monkeypatch.setattr(pr, "BOTS", [])
+    monkeypatch.setattr(pr, "FAIL", {"stage": None, "step": None, "detail": None})
+    monkeypatch.setitem(pr.STEP_MODE, "on", False)
+    monkeypatch.setattr(sys, "argv", _main_args(bridge))
+    return bridge
+
+
+def test_main_exhausted_budget_aborts_with_the_exact_error_and_records_the_wait(
+        main_env, monkeypatch, capsys):
+    """(c) end to end: rc 2, the error string callers match on, the measured
+    cause and the budget in the explanation, `preflightSeconds` in the archive
+    - and nothing but the teardown was sent after the probes."""
+    clock, calls = FakeClock(), []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [], calls))
+    real_preflight = pr.preflight
+
+    def injected(budget=None, **_):
+        return real_preflight(budget, clock=clock, sleep=lambda s: None,
+                              process=lambda: LISTED)
+
+    monkeypatch.setattr(pr, "preflight", injected)
+    rc = pr.main()
+    out = capsys.readouterr().out
+    assert rc == 2
+    result = json.loads((main_env / "result.json").read_text(encoding="utf-8"))
+    assert result["error"] == "preflight: the bridge did not answer"
+    assert result["rc"] == 2
+    assert result["ok"] is False
+    assert result["endReason"] == "aborted"
+    assert result["preflightSeconds"] >= 1800
+    assert "NinjaTrader.exe is not running" not in out
+    assert "Its process exists" in out
+    assert "the last read: " + LISTED[1] in out   # the evidence, not a claim
+    assert "NOT known" not in out
+    assert result["preflightSeconds"] == pytest.approx(70 * UNANSWERED_S, abs=0.1)
+    probes = [c for c in calls if c["title"] == "0 preflight"]
+    assert len(probes) == 70                      # 70 x 26 s = 1820 s >= 1800 s
+    assert "budget 1800 s" in out
+    assert "388 s on 2026-09-02" in out
+    assert "735 s on 2026-09-01" in out
+    assert "Clear the trigger folder" not in out
+    # after the probes only the teardown's own two calls went out
+    assert [c["req"]["stage"] for c in calls[len(probes):]] == ["restore", "botout"]
+    # the archived copy carries the same number
+    archived = json.loads(
+        next((main_env / "runs").glob("PRE_*/result.json")).read_text(encoding="utf-8"))
+    assert archived["preflightSeconds"] == result["preflightSeconds"]
+
+
+def test_main_process_absent_aborts_at_once_with_the_exact_error(
+        main_env, monkeypatch, capsys):
+    """(e) end to end: no NinjaTrader.exe - rc 2 and the SAME error string
+    callers match on, after ONE probe (26 s) instead of the 1800 s budget; the
+    explanation names the missing process, not the busy-NinjaTrader causes;
+    `preflightSeconds` records the 26 s; and only the teardown followed."""
+    clock, calls = FakeClock(), []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [], calls))
+    real_preflight = pr.preflight
+
+    def injected(budget=None, **_):
+        return real_preflight(budget, clock=clock, sleep=lambda s: None,
+                              process=lambda: UNLISTED)
+
+    monkeypatch.setattr(pr, "preflight", injected)
+    rc = pr.main()
+    out = capsys.readouterr().out
+    assert rc == 2
+    result = json.loads((main_env / "result.json").read_text(encoding="utf-8"))
+    assert result["error"] == "preflight: the bridge did not answer"
+    assert result["rc"] == 2
+    assert result["ok"] is False
+    assert result["endReason"] == "aborted"
+    assert result["preflightSeconds"] == pytest.approx(UNANSWERED_S, abs=0.1)
+    probes = [c for c in calls if c["title"] == "0 preflight"]
+    assert len(probes) == 1
+    assert "NinjaTrader.exe is not running" in out
+    assert "The process list was read after probe" in out
+    assert "1 (26 s) and does not name it; measured:" in out
+    assert UNLISTED[1] in out                     # what tasklist answered, quoted
+    assert "has no such" not in out               # no claim beyond the reading
+    assert "388 s on 2026-09-02" not in out
+    assert "Clear the trigger folder" not in out
+    # after the one probe only the teardown's own two calls went out
+    assert [c["req"]["stage"] for c in calls[len(probes):]] == ["restore", "botout"]
+
+
+def test_main_unreadable_process_list_waits_out_the_budget_and_says_unknown(
+        main_env, monkeypatch, capsys):
+    """(g) end to end: tasklist never readable - the run waits out the budget
+    like a busy NinjaTrader (rc 2, the same error string, 70 probes), and the
+    explanation says the process is UNKNOWN with the failed read quoted - it
+    neither claims the process exists nor that it is absent."""
+    clock, calls = FakeClock(), []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [], calls))
+    real_preflight = pr.preflight
+
+    def injected(budget=None, **_):
+        return real_preflight(budget, clock=clock, sleep=lambda s: None,
+                              process=lambda: UNREADABLE)
+
+    monkeypatch.setattr(pr, "preflight", injected)
+    rc = pr.main()
+    out = capsys.readouterr().out
+    assert rc == 2
+    result = json.loads((main_env / "result.json").read_text(encoding="utf-8"))
+    assert result["error"] == "preflight: the bridge did not answer"
+    assert result["preflightSeconds"] == pytest.approx(70 * UNANSWERED_S, abs=0.1)
+    probes = [c for c in calls if c["title"] == "0 preflight"]
+    assert len(probes) == 70
+    assert "NinjaTrader.exe is not running" not in out
+    assert "Its process exists" not in out
+    assert "Whether its process exists is NOT known" in out
+    assert "the last read: " + UNREADABLE[1] in out
+    assert len(unreadable_lines(out)) == 1        # one failure, said once
+    assert [c["req"]["stage"] for c in calls[len(probes):]] == ["restore", "botout"]
+
+
+def test_main_answered_preflight_keeps_the_fast_path_and_its_contract(
+        main_env, monkeypatch, capsys):
+    """The answered path is unchanged: "Bridge connected.", the output-window
+    discard right after the answer, and `preflightSeconds` near zero."""
+    clock, calls = FakeClock(), []
+    monkeypatch.setattr(pr, "stage", scripted_stage(clock, [dict(ANSWER)], calls))
+    rc = pr.main()                # the real clock: the scripted stage answers at once
+    out = capsys.readouterr().out
+    result = json.loads((main_env / "result.json").read_text(encoding="utf-8"))
+    # the run stops at step 1a - nothing answers after the probe
+    assert rc == 2
+    assert result["error"].startswith("mandatory step failed")
+    assert 0.0 <= result["preflightSeconds"] < 1.0
+    assert "Bridge connected." in out
+    assert busy_lines(out) == []
+    stages = [c["req"]["stage"] for c in calls]
+    assert stages[:2] == ["transport", "botout"]
+    assert stages[-2:] == ["restore", "botout"]

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -8,6 +8,7 @@ NinjaTrader, and `_restart`'s ordering is asserted here against a fake module.
 from __future__ import annotations
 
 import json
+import subprocess
 
 import pytest
 
@@ -140,6 +141,75 @@ def test_failed_start_says_nt_is_now_down(monkeypatch, capsys):
     out = json.loads(capsys.readouterr().out)
     assert rc == 1 and out["stage"] == "start"
     assert "STOPPED" in out["hint"]
+
+
+# ── process_listed: three states, and is_running() as the bool view of them ────────────────────────
+
+class _Completed:
+    """What subprocess.run returns, reduced to the three fields process_listed reads."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
+
+
+def _tasklist_gives(monkeypatch, outcome) -> None:
+    """subprocess.run replaced for the tasklist call: `outcome` is returned, or raised."""
+
+    def fake_run(args, **kw):
+        assert args[:2] == ["tasklist", "/FI"]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+# tasklist's own shapes, measured 2026-09-02: a listing has a header, a rule and
+# one row per process; an unlisted name answers exit 0 plus one INFO line (the
+# console's locale text); an unknown filter answers exit 1, nothing on stdout.
+ROW = ("\nImage Name                     PID Session Name        Session#    Mem Usage\n"
+       "========================= ======== ================ =========== ============\n"
+       "NinjaTrader.exe               4711 Console                    1  1,234,567 K\n")
+INFO = "INFO: No tasks are running which match the specified criteria.\n"
+
+
+def test_process_listed_true_quotes_the_row(monkeypatch):
+    _tasklist_gives(monkeypatch, _Completed(0, ROW))
+    listed, detail = restart.process_listed()
+    assert listed is True
+    assert detail == "tasklist lists NinjaTrader.exe 4711 Console 1 1,234,567 K"
+    assert restart.is_running() is True
+
+
+def test_process_listed_false_quotes_what_tasklist_answered(monkeypatch):
+    _tasklist_gives(monkeypatch, _Completed(0, INFO))
+    listed, detail = restart.process_listed()
+    assert listed is False
+    assert detail == "tasklist answered: " + INFO.strip()
+    assert restart.is_running() is False
+
+
+@pytest.mark.parametrize("outcome, said", [
+    (FileNotFoundError(2, "The system cannot find the file specified"),
+     "tasklist could not be run: FileNotFoundError: [Errno 2] The system cannot find the file "
+     "specified"),
+    (subprocess.TimeoutExpired(["tasklist"], 30),
+     "tasklist could not be run: TimeoutExpired: Command '['tasklist']' timed out after 30 seconds"),
+    (_Completed(1, "", "ERROR: The search filter cannot be recognized.\n\n"),
+     "tasklist exited 1, printed nothing on stdout, stderr: ERROR: The search filter cannot be "
+     "recognized."),
+    (_Completed(0, ""), "tasklist exited 0, printed nothing on stdout"),
+])
+def test_process_listed_none_when_the_list_could_not_be_read(monkeypatch, outcome, said):
+    """None, not False: a read that failed says nothing about the process. Before this existed,
+    every one of these read as "not running" - and the preflight poll of playbackrun ended a run
+    on it after one probe. is_running() folds None into False for the callers that act the same
+    on "not seen" and "not there"."""
+    _tasklist_gives(monkeypatch, outcome)
+    listed, detail = restart.process_listed()
+    assert listed is None
+    assert detail == said
+    assert restart.is_running() is False
 
 
 # ── deploy: a missing flag is an argparse error, not a TypeError ────────────────────────────────────

--- a/tests/test_satemplate.py
+++ b/tests/test_satemplate.py
@@ -1,0 +1,74 @@
+# MIT License
+# Copyright (c) 2026 Quantrosoft Pty. Ltd.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from pathlib import Path
+
+from nt8bridge import satemplate
+
+
+def test_run_satemplate_writes_the_template_request(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(satemplate.ntio, "ensure_bridge_dirs", lambda: (Path("trig"), Path("res")))
+    monkeypatch.setattr(satemplate, "new_request_id", lambda: "rid7")
+    monkeypatch.setattr(satemplate.ntio, "atomic_write_json",
+                        lambda p, o: captured.update(path=p, obj=o))
+    monkeypatch.setattr(satemplate.ntio, "poll_for_json",
+                        lambda p, timeout=30.0: {"status": "ok", "applied": True})
+    out = satemplate.run_satemplate(r"C:\t\VariantA.xml")
+    assert captured["obj"]["kind"] == "satemplate"
+    assert captured["obj"]["template"] == r"C:\t\VariantA.xml"
+    assert captured["path"] == Path("trig") / "satemplate_rid7.json"
+    assert out["status"] == "ok"
+
+
+def test_run_satemplate_reads_its_own_result_file(monkeypatch):
+    """The reply is picked up under the request's OWN prefix.
+
+    A stage whose answer is filed under another kind's prefix polls a name that
+    never appears, and the caller waits out its timeout while the work is long
+    done - which is how a guard turns into the hang it exists to prevent.
+    """
+    polled = {}
+    monkeypatch.setattr(satemplate.ntio, "ensure_bridge_dirs", lambda: (Path("t"), Path("r")))
+    monkeypatch.setattr(satemplate, "new_request_id", lambda: "rid8")
+    monkeypatch.setattr(satemplate.ntio, "atomic_write_json", lambda p, o: None)
+    monkeypatch.setattr(satemplate.ntio, "poll_for_json",
+                        lambda p, timeout=30.0: polled.update(path=p, timeout=timeout) or {})
+    satemplate.run_satemplate("VariantB", timeout=12.5)
+    assert polled["path"] == Path("r") / "satemplate_rid8.json"
+    assert polled["timeout"] == 12.5
+
+
+def test_run_satemplate_passes_a_bare_name_through_unchanged(monkeypatch):
+    """Resolving a bare name is the AddOn's job, not this side's.
+
+    It asks NinjaTrader for the strategy's template folder, which differs per bot
+    (flat "Strategy\\Foo" vs nested "Strategy\\Foo.Foo"). Assembling that path
+    here from a naming rule would be a second answer to the same question.
+    """
+    captured = {}
+    monkeypatch.setattr(satemplate.ntio, "ensure_bridge_dirs", lambda: (Path("t"), Path("r")))
+    monkeypatch.setattr(satemplate, "new_request_id", lambda: "rid9")
+    monkeypatch.setattr(satemplate.ntio, "atomic_write_json",
+                        lambda p, o: captured.update(obj=o))
+    monkeypatch.setattr(satemplate.ntio, "poll_for_json", lambda p, timeout=30.0: {"status": "ok"})
+    satemplate.run_satemplate("VariantC")
+    assert captured["obj"]["template"] == "VariantC"

--- a/tests/test_state_commands.py
+++ b/tests/test_state_commands.py
@@ -17,6 +17,18 @@ def test_playback_build_request():
     assert req["instrument"] == "NQ 06-26"
 
 
+def test_playback_request_carries_the_coverage_opt_in_only_when_asked():
+    """The wide .nrd scan is opt-in (measured 2026-08-19: 3-7 min for 35 instruments, and the
+    AddOn's poller is held for that long). The flag travels as the STRING "true" because that is
+    what the AddOn compares it to; a request without the flag must not carry the key at all."""
+    assert ntplayback.build_playback_request("id3", coverage=True) == {
+        "id": "id3", "kind": "playback", "coverage": "true"}
+    assert "coverage" not in ntplayback.build_playback_request("id4")
+    assert "coverage" not in ntplayback.build_playback_request("id5", "NQ 06-26")
+    both = ntplayback.build_playback_request("id6", "NQ 06-26", coverage=True)
+    assert both["instrument"] == "NQ 06-26" and both["coverage"] == "true"
+
+
 def _pb(**over):
     payload = {
         "status": "ok",
@@ -69,6 +81,34 @@ def test_no_readable_nrd_is_refused():
     assert "no readable" in why
 
 
+def test_unscanned_coverage_is_not_read_as_an_empty_store():
+    """A request naming neither an instrument nor the coverage opt-in comes back with
+    coverageScanned false and coverage []. Nobody looked at the store, so the verdict must say so
+    instead of "no readable .nrd" — a claim about data that was never read."""
+    st = _pb(coverageScanned=False, coverage=[])
+    assert st.coverage_scanned is False
+    ok, why = st.ready_to_seek()
+    assert ok is False
+    assert "coverage not scanned" in why
+    assert "no readable" not in why
+
+
+def test_scanned_coverage_with_data_is_ready():
+    ok, why = _pb(coverageScanned=True).ready_to_seek()
+    assert ok is True
+    assert "parked" in why
+
+
+def test_absent_coverage_scanned_key_keeps_the_old_meaning():
+    """An AddOn without the opt-in never writes coverageScanned and always scans, so its empty
+    coverage list still means 'nothing readable'."""
+    st = _pb(coverage=[])
+    assert st.coverage_scanned is True
+    ok, why = st.ready_to_seek()
+    assert ok is False
+    assert "no readable" in why
+
+
 def test_span_lookup():
     st = _pb()
     assert st.span("NQ 06-26") == ("2026-04-19T23:00:00", "2026-04-23T22:59:00")
@@ -96,6 +136,53 @@ def test_not_stale_when_the_process_started_after_the_build():
     })
     assert st.stale is False
     assert "running current code" in st.reason
+
+
+def test_not_stale_when_the_running_code_is_newer_than_every_source():
+    """Measured 2026-09-02/03: compile + reload in one process started at 16:02; the DLL on disk
+    is newer than the process every time, NinjaTrader executes a temp assembly compiled from the
+    sources, and that is what runs. Sources vs running code decides, not clocks of the process."""
+    st = ntntstatus.assess({
+        "status": "ok",
+        "processStartUtc": "2026-09-02T14:02:37Z",
+        "dllOnDisk": {"builtUtc": "2026-09-03T03:15:04Z"},
+        "runningAssembly": {"name": "0d46200ae29d4fc2b124b520081cbd4f",
+                            "location": r"C:\Users\x\Documents\NinjaTrader 8\tmp\0d46200ae29d4fc2b124b520081cbd4f.dll",
+                            "builtUtc": "2026-09-03T03:15:03Z"},
+        "newestSource": {"path": r"C:\Users\x\Documents\NinjaTrader 8\bin\Custom\AddOns\NT8BridgeServer.cs",
+                         "modifiedUtc": "2026-09-03T03:14:40Z"},
+        "sourcesNewerThanRunningCode": False,
+    })
+    assert st.stale is False
+    assert "running current code" in st.reason
+    assert st.sources_newer is False and st.running_built == "2026-09-03T03:15:03Z"
+
+
+def test_stale_when_a_source_is_newer_than_the_running_code():
+    """The 33-minute wasted cell: a source deployed after the running code was compiled."""
+    st = ntntstatus.assess({
+        "status": "ok",
+        "processStartUtc": "2026-09-02T14:02:37Z",
+        "dllOnDisk": {"builtUtc": "2026-09-03T03:15:04Z"},
+        "runningAssembly": {"builtUtc": "2026-09-03T03:15:03Z"},
+        "newestSource": {"path": r"C:\x\bin\Custom\Strategies\MyBot.cs", "modifiedUtc": "2026-09-03T03:40:00Z"},
+        "sourcesNewerThanRunningCode": True,
+    })
+    assert st.stale is True
+    assert "MyBot.cs" in st.reason and "reload or restart" in st.reason
+
+
+def test_without_a_source_comparison_the_time_rule_applies_and_says_so():
+    """An AddOn that could not read one side (or an older AddOn) reports no comparison; the
+    verdict then falls back to the clocks and names that."""
+    st = ntntstatus.assess({
+        "status": "ok",
+        "processStartUtc": "2026-09-02T14:02:37Z",
+        "dllOnDisk": {"builtUtc": "2026-09-02T18:17:37Z"},
+        "sourcesNewerThanRunningCode": None,
+    })
+    assert st.stale is True
+    assert "time rule" in st.reason
 
 
 def test_missing_timestamps_do_not_silently_pass_as_fresh():


### PR DESCRIPTION
I have extended your bridge with NinjaTrader's **Playback** engine, in both of its run modes — **Market Replay** and **Historical** — plus a way to run the Strategy Analyzer from one of NinjaTrader's own strategy templates. Everything stays in the style of the project: in-process, JSON in and out, no UI automation.

## What this adds

- **`playbackrun`** — one Playback measurement, end to end, with no click anywhere: every connection off, clean start, connect, source (`--source marketreplay|historical`), dates, range, speed, attach the strategy, play to the data end, restore the baseline. Every value it writes is read back, and it exits **0** only when the data end was reached **and** the teardown restored the baseline, so a run that stopped for any other reason cannot be mistaken for a result. Each run is archived (request, result, transcript, screenshots).
- **Both Playback sources, kept apart because they do not read the same store.** Market Replay is served from `db\replay` (`.nrd`), Historical from `db\tick` (`.ncd`), and the coverage pre-flight scans the one the run will read. The source itself is settled on `PlaybackAdapter.IsSourceHistoricalData`; the panel's radio buttons are display only, because writing them while connected makes NinjaTrader re-parse the panel's date fields and throw.
- **`satemplate`** — put one of NinjaTrader's own strategy template files on the Strategy Analyzer tab (the complete parameter set plus instrument and window). `backtest --config` becomes optional, and the run cannot drift from what the GUI would run.
- A second AddOn file, `addon/NT8BridgeServerPlayback.cs`, carrying the Playback stages.

## What the existing commands gained on the way

All of it is what a long unattended run turned out to need; every entry in `CHANGELOG.md` carries the measurement behind it.

- Every request carries a TTL; `connections` says whether a row came from the configuration or only from the live list.
- `playbackrun`: a connect budget of its own (`CONNECT_WAIT`, min. 600 s), a preflight that waits out a busy NinjaTrader (`PREFLIGHT_WAIT`, min. 1800 s) but refuses at once when no `NinjaTrader.exe` is running, and `--from`/`--to` validated as `YYYY-MM-DD` before anything is sent.
- During a run the bridge confirms NinjaTrader's order-rejection boxes for the playback account (the ones carrying `affected Order:`) and counts them; every other modal still stands and is still the finding.
- `playback`: the `.nrd` coverage scan is opt-in (`--coverage` / `--instrument`), responses carry `coverageScanned`.
- `ntstatus` decides "stale" by comparing the newest `.cs` under `bin\Custom` with the build time of the assembly NinjaTrader actually executes — after a `reload` that is a temp assembly, so the old rule (DLL newer than the process) called reloaded code stale.
- Subprocess output decoded with `errors="replace"`, for a non-English Windows.

## Verification

- `pytest`: **307 passed, 8 skipped** (the skips need matplotlib, an offline compiler, or `.nrd` fixtures that are not in the repository).
- Both AddOn files compile against NinjaTrader 8.1's own reference set with 0 errors, and the same code compiles and hot-reloads inside NinjaTrader (`compile` + `reload`).
- Measured on NinjaTrader 8.1.8.2 between 2026-08-19 and 2026-09-03; the dates and numbers in `CHANGELOG.md` are those measurements. Live runs on the final build: Strategy Analyzer 298/298 runs byte-identical to their stored references, Playback/Market Replay 8/8 byte-identical, Playback/Historical 3 runs to the data end (2 byte-identical, 1 differing in fill prices of a stop race inside the strategy under test, not in the bridge).

Happy to split this up or adjust anything to your taste.